### PR TITLE
Fixing panic when parsing invalid relative date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Updating tparse library when parsing relative dates. Using a relative date/timestamp of "30" no longer causes a panic.
+
 ## Released
 
 ### v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-jsonnet v0.14.0
 	github.com/gorilla/websocket v1.4.0
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
-	github.com/karrick/tparse/v2 v2.7.1
+	github.com/karrick/tparse/v2 v2.8.2
 	github.com/manifoldco/promptui v0.3.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karrick/tparse/v2 v2.7.1 h1:SSfwxsbxZS3yai0V8EcCyYjpsiYIOvQj/kvzTLu/zS4=
 github.com/karrick/tparse/v2 v2.7.1/go.mod h1:OzmKMqNal7LYYHaO/Ie1f/wXmLWAaGKwJmxUFNQCVxg=
+github.com/karrick/tparse/v2 v2.8.2 h1:NhvrrB7nXYa0VLn0JKn9L3oG/GZN+LB/+g5QfWE30rU=
+github.com/karrick/tparse/v2 v2.8.2/go.mod h1:OzmKMqNal7LYYHaO/Ie1f/wXmLWAaGKwJmxUFNQCVxg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/cmd/timestampHelper.go
+++ b/pkg/cmd/timestampHelper.go
@@ -16,7 +16,6 @@ func parseDurationRelativeToNow(offsetDuration string) (*time.Time, error) {
 
 // getTimestampUsingOffset returns a timestamp relative to a base timestamp
 // example: +1d3w4mo-7y6h4m
-// TODO: an offsetDuration of "30" throws a panic!
 func getTimestampUsingOffset(now time.Time, offsetDuration string) (*time.Time, error) {
 	another, err := tparse.AddDuration(now, offsetDuration)
 	if err != nil {

--- a/pkg/cmd/timestampHelper_test.go
+++ b/pkg/cmd/timestampHelper_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestInvalidDates(t *testing.T) {
+
+	timestamp, err := parseDurationRelativeToNow("2020010101")
+
+	if err == nil {
+		t.Errorf("Timestamp should throw an error. got %s, expected nil", err)
+	}
+
+	if timestamp != nil {
+		t.Errorf("Timestamp should be nil. got=%v", timestamp)
+	}
+}


### PR DESCRIPTION
* Parsing "30" in a --dateFrom or --dateTo field no longer causes a panic