### PR TITLE
Feat/user templates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -108,6 +108,7 @@ RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod
     && rm -rf /var/lib/apt/lists/* /tmp/gotools
 
 # Install powershell dependencies
+USER $USERNAME
 RUN pwsh -Command "Install-Module -Name platyPS -Scope CurrentUser -Force" \
     && pwsh -Command "Install-Module -Name Pester -Scope CurrentUser -MinimumVersion '5.0.0' -Force"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@
     }
     ```
 
+    To help with the development of templates, there is a command which evaluates a template and prints the output to the console.
+
+    **Bash/zsh**
+
+    ```sh
+    c8y template execute --template ./mytemplate.jsonnet
+    ```
+
+    **PowerShell**
+
+    ```powershell
+    Invoke-Template -Template ./template.jsonnet
+    ```
+
 * Added support for setting additional properties when uploading a binary file
 
     **PowerShell**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+* Added command to read the current configuration settings as json
+
+    **PowerShell**
+
+    ```powershell
+    Get-ClientSetting
+    ```
+
+    **Bash/zsh**
+
+    ```sh
+    c8y settings list
+    ```
+
 * Added support for templates and template variables for all POST and PUT commands. See the [templates concept documentation](https://reubenmiller.github.io/go-c8y-cli/docs/concepts/templates/) for full details.
 
     `jsonnet` templates can be used to create json data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+* Added support for setting additional properties when uploading a binary file
+
+    **PowerShell**
+
+    ```powershell
+    New-Binary -File "myfile.json" -Data @{ c8y_Global = @{}; type = "c8y_upload" }
+    ```
+
+    **Bash/zsh**
+
+    ```sh
+    c8y binaries create --file "myfile.json" --data "c8y_Global={},type=c8y_upload"
+    ```
+
+
 * The `Data` parameter now supports a json file path to make it easier to upload complex json structures.
 
     **Example: Create a new managed object from a json file**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+* Added support for templates and template variables for all POST and PUT commands. See the [templates concept documentation](https://reubenmiller.github.io/go-c8y-cli/docs/concepts/templates/) for full details.
+
+    `jsonnet` templates can be used to create json data
+
+    *File: custom.device.jsonnet*
+
+    ```jsonnet
+    {
+        name: "my device",
+        type: vars("type", "defaultType"),
+        cpuThreshold: rand.int,
+        c8y_IsDevice: {},
+    }
+    ```
+
+    **Usage: Bash/zsh**
+
+    ```sh
+    c8y inventory create \
+        --template ./examples/templates/device.jsonnet \
+        --templateVars "type=myCustomType1" \
+        --dry
+    ```
+
+    **Usage: PowerShell**
+
+    ```sh
+    New-ManagedObject `
+        -Template ./examples/templates/measurement.jsonnet `
+        -TemplateVars "type=myCustomType1" `
+        -WhatIf
+    ```
+
+    **Output**
+
+    These command would produce the following body which would be sent to Cumulocity.
+
+    ```json
+    {
+        "name": "my device",
+        "type": "myCustomType1",
+        "c8y_IsDevice": {},
+        "cpuThreshold": 88,
+    }
+    ```
+
 * Added support for setting additional properties when uploading a binary file
 
     **PowerShell**
@@ -46,6 +92,25 @@
     ```sh
     c8y inventory create --data ./myfile.json
     ```
+
+#### PSc8y (PowerShell)
+
+* Fixed logic when removing username information from the current session path when using the hide sensitive information option. Affects MacOS and Linux
+
+* Added Pipeline support to following cmdlets
+    * New-TestAlarm
+    * New-TestEvent
+    * New-TestMeasurement (Confirm impact now set to High)
+    * New-TestOperation
+    * New-TestUser
+    * New-TestGroup
+    * New-TestDevice
+    * New-TestAgent
+    * New-ExternalID
+
+* `New-Microservice`
+    * Added `-Key` parameter to allow the user to set a custom value
+    * Changed the default value of the `key` property from `{name}-microservice-key` to `{name}` so it matched the default name used by the Cumulocity Java SDK for microservices
 
 ## Released
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GOCMD=go
 BUILD_DIR = build
 C8Y_PKGS = $$(go list ./... | grep -v /vendor/)
 GOMOD=$(GOCMD) mod
+TEST_THROTTLE_LIMIT=10
 
 # Set VERSION from git describe
 VERSION := $(shell git describe | sed "s/^v\?\.\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/")
@@ -151,7 +152,7 @@ build_powershell:
 	pwsh -File scripts/build-powershell/build.ps1;
 
 test_powershell:
-	pwsh -NonInteractive -File tools/PSc8y/test.parallel.ps1 -TestFileExclude "Set-Session|Get-SessionHomePath"
+	pwsh -NonInteractive -File tools/PSc8y/test.parallel.ps1 -ThrottleLimit $(TEST_THROTTLE_LIMIT) -TestFileExclude "Set-Session|Get-SessionHomePath"
 	# pwsh -NonInteractive -File tools/PSc8y/tests.ps1
 
 test_powershell_sessions:		## Run tests which interfere with the session variable

--- a/Proposals.md
+++ b/Proposals.md
@@ -3,7 +3,8 @@
 
 ## current todo
 
-* [ ] Add device commands. New-Device, Update-Device, Remove-Device, Get-DeviceCollection (already exists)
+[x] Use default values for time (i.e. createNewMeasurement --time "0s")
+[ ] Add tab completion for template files?
 
 ## Bugs
 
@@ -124,6 +125,7 @@ Manual commands
 * [x] Figure how to best package the c8y binary file/s with the powershell module
 * [x] Adding encoding tests
 * [x] Add aliases for all the commands, i.e. Get-ApplicationCollection -> apps, Get-DeviceCollection -> devices
+* [x] Add device commands. New-Device, Update-Device, Remove-Device, Get-DeviceCollection (already exists)
 
 * [ ] Client side filtering of results for those that don't support server side filters
   * [ ] Application
@@ -133,8 +135,8 @@ Manual commands
 ## Packaging
 
 * [x] Package c8y binary with the powershell app
-* [ ] Publish c8y binaries to github
-* [ ] Publish powershell module to PSGallery
+* [x] Publish c8y binaries to github
+* [x] Publish powershell module to PSGallery
 
 * Installation problem with Windows 10. Requires PowerShellGet minimum version 2.2.3! Which is not installed by default on Windows 10 PS 5.1
     Maybe add recommendation that powershell 6 (core) should be used, also with an updated PowerShellGet
@@ -148,8 +150,8 @@ Manual commands
 ## Docs
 
 * [x] Write github pages with a tutorial
-* [ ] General concepts
-    * [ ] Dates
+* [x] General concepts
+    * [x] Dates
     * [x] Lookups
 * [x] Setup
     * [x] Install binary
@@ -167,7 +169,7 @@ Manual commands
 
 ### Phase 2
 
-* [ ] Implement --all switch for collections to iterate through all results (max results)
+* [x] Implement --all switch for collections to iterate through all results (max results)
 * [ ] Make options case insensitive
 * [ ] Look over devices where []device type is used (parallel tasks?) Probably need a new template
 

--- a/Proposals.md
+++ b/Proposals.md
@@ -3,9 +3,6 @@
 
 ## current todo
 
-[x] Use default values for time (i.e. createNewMeasurement --time "0s")
-[ ] Add tab completion for template files?
-
 ## Bugs
 
 * Subscription tests are flakey
@@ -72,7 +69,10 @@
 * [x] Get microservice, delete microservice, update microservice? get credentials?
 * [x] Handle proxy/no proxy support for realtime notifications (websockets)
 
-* [ ] Allow file upload to include additional "type" property
+* [x] Allow file upload to include additional "type" property
+* [x] Add tab completion for template files?
+* [x] Add automatic path resolver in golang to find the template by just the file name
+* [x] Use default values for time (i.e. createNewMeasurement --time "0s")
 * [ ] Microservice aliases using my-app://health
 
 
@@ -159,11 +159,10 @@ Manual commands
 * [ ] Add/Remove child devices
 * [ ] users (add, skip send email, or static password)
 * [ ] managed objects
-* [ ] aliases
-* [ ] custom requests
-* [ ] Extending modules
+* [x] aliases
+* [x] custom requests
+* [x] Extending modules
 * [ ] notifications
-* [ ]
 
 # Future
 

--- a/api/spec/json/alarms.json
+++ b/api/spec/json/alarms.json
@@ -178,7 +178,7 @@
         {
           "name": "type",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "Identifies the type of this alarm, e.g. 'com_cumulocity_events_TamperEvent'."
         },
         {
@@ -186,18 +186,18 @@
           "type": "datetime",
           "required": false,
           "default": "0s",
-          "description": "Time of the alarm."
+          "description": "Time of the alarm. Defaults to current timestamp."
         },
         {
           "name": "text",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "Text description of the alarm."
         },
         {
           "name": "severity",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case.",
           "validationSet": [
             "CRITICAL",
@@ -221,6 +221,12 @@
           "type": "json",
           "description": "Additional properties of the alarm."
         }
+      ],
+      "bodyRequiredKeys": [
+        "type",
+        "text",
+        "time",
+        "severity"
       ]
     },
     {

--- a/api/spec/json/auditRecords.json
+++ b/api/spec/json/auditRecords.json
@@ -49,7 +49,7 @@
           "type": "datetime",
           "required": false,
           "default": "0s",
-          "description": "Time of the audit record."
+          "description": "Time of the audit record. Defaults to current timestamp."
         },
         {
           "name": "text",

--- a/api/spec/json/binaries.json
+++ b/api/spec/json/binaries.json
@@ -124,12 +124,28 @@
               "Remove-Item $File",
               "Find-ManagedObjectCollection -Query \"has(c8y_IsBinary) and (name eq '$FileName')\" | Remove-Binary"
             ]
+          },
+          {
+            "description": "Upload a config file and make it globally accessible for all users",
+            "beforeEach": [
+              "$File = New-TestFile",
+              "$FileName = (Get-Item $File).Name"
+            ],
+            "command": "New-Binary -File $File -Data @{ c8y_Global = @{}; type = \"c8y_upload\" }",
+            "afterEach": [
+              "Remove-Item $File",
+              "Find-ManagedObjectCollection -Query \"has(c8y_IsBinary) and (name eq '$FileName')\" | Remove-Binary"
+            ]
           }
         ],
         "go": [
           {
             "description": "Upload a log file",
             "command": "c8y binaries create --file ./output.log"
+          },
+          {
+            "description": "Upload a config file and make it globally accessible for all users",
+            "command": "c8y binaries create --file \"myConfig.json\" --data \"c8y_Global={},type=c8y_upload\""
           }
         ]
       },
@@ -139,6 +155,11 @@
           "type": "file",
           "required": true,
           "description": "File to be uploaded as a binary"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties to be added to the binary."
         }
       ]
     },

--- a/api/spec/json/events.json
+++ b/api/spec/json/events.json
@@ -257,18 +257,18 @@
           "type": "datetime",
           "required": false,
           "default": "0s",
-          "description": "Time of the event."
+          "description": "Time of the event. Defaults to current timestamp."
         },
         {
           "name": "type",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "Identifies the type of this event."
         },
         {
           "name": "text",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "Text description of the event."
         },
         {
@@ -276,6 +276,11 @@
           "type": "json",
           "description": "Additional properties of the event."
         }
+      ],
+      "bodyRequiredKeys": [
+        "type",
+        "text",
+        "time"
       ]
     },
     {

--- a/api/spec/json/identity.json
+++ b/api/spec/json/identity.json
@@ -159,11 +159,26 @@
       "examples": {
         "powershell": [
           {
-            "description": "Get external identity",
+            "description": "Create external identity",
             "beforeEach": [
-              "$my_SerialNumber = New-RandomString -Prefix \"my_SerialNumber\""
+              "$my_SerialNumber = New-RandomString -Prefix \"my_SerialNumber\"",
+              "$Device = New-TestDevice"
             ],
-            "command": "New-ExternalId -Device {{ randomdevice }} -Type \"$my_SerialNumber\" -Name \"myserialnumber\""
+            "command": "New-ExternalId -Device $Device.id -Type \"$my_SerialNumber\" -Name \"myserialnumber\"",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $Device.id"
+            ]
+          },
+          {
+            "description": "Create external identity (using pipeline)",
+            "beforeEach": [
+              "$my_SerialNumber = New-RandomString -Prefix \"my_SerialNumber\"",
+              "$Device = New-TestDevice"
+            ],
+            "command": "Get-Device $Device.id | New-ExternalId -Type \"$my_SerialNumber\" -Name \"myserialnumber\"",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $Device.id"
+            ]
           }
         ],
         "go": [
@@ -178,6 +193,7 @@
           "name": "device",
           "type": "[]device",
           "required": true,
+          "pipeline": true,
           "description": "The ManagedObject linked to the external ID."
         }
       ],

--- a/api/spec/json/inventoryReferences.json
+++ b/api/spec/json/inventoryReferences.json
@@ -124,6 +124,7 @@
         {
           "name": "group",
           "type": "[]devicegroup",
+          "pipeline": true,
           "property": "id",
           "description": "Group."
         }

--- a/api/spec/json/measurements.json
+++ b/api/spec/json/measurements.json
@@ -361,13 +361,14 @@
         {
           "name": "time",
           "type": "datetime",
-          "required": true,
-          "description": "Time of the measurement."
+          "required": false,
+          "default": "0s",
+          "description": "Time of the measurement. Defaults to current timestamp."
         },
         {
           "name": "type",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "The most specific type of this entire measurement."
         },
         {
@@ -375,6 +376,10 @@
           "type": "json",
           "description": "List of measurement fragments."
         }
+      ],
+      "bodyRequiredKeys": [
+        "type",
+        "time"
       ]
     },
     {

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -375,6 +375,32 @@
               "template"
             ]
           },
+          "bodyRequiredKeys": {
+            "type": "array",
+            "description": "List of the required body keys. The keys will be checked after any templating logic",
+            "items": {
+              "type": "string"
+            }
+          },
+          "bodyValidation": {
+            "type": "object",
+            "description": "Use a template when validating the json body",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Templating engine. Current only supports jsonnet",
+                "enum": ["jsonnet"]
+              },
+              "template": {
+                "type": "string",
+                "description": "Template in the given template engine language"
+              }
+            },
+            "required": [
+              "type",
+              "template"
+            ]
+          },
           "body": {
             "type": "array",
             "minItems": 1,

--- a/api/spec/yaml/alarms.yml
+++ b/api/spec/yaml/alarms.yml
@@ -127,23 +127,23 @@ endpoints:
 
       - name: type
         type: string
-        required: true
+        required: false
         description: Identifies the type of this alarm, e.g. 'com_cumulocity_events_TamperEvent'.
 
       - name: time
         type: datetime
         required: false
         default: "0s"
-        description: Time of the alarm.
+        description: Time of the alarm. Defaults to current timestamp.
 
       - name: text
         type: string
-        required: true
+        required: false
         description: Text description of the alarm.
 
       - name: severity
         type: string
-        required: true
+        required: false
         description: 'The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case.'
         validationSet: [CRITICAL, MAJOR, MINOR, WARNING]
 
@@ -155,6 +155,12 @@ endpoints:
       - name: data
         type: json
         description: Additional properties of the alarm.
+      
+    bodyRequiredKeys:
+      - "type"
+      - "text"
+      - "time"
+      - "severity"
 
   - name: updateAlarmCollection
     method: PUT

--- a/api/spec/yaml/auditRecords.yml
+++ b/api/spec/yaml/auditRecords.yml
@@ -39,7 +39,7 @@ endpoints:
         type: datetime
         required: false
         default: "0s"
-        description: Time of the audit record.
+        description: Time of the audit record. Defaults to current timestamp.
 
       - name: text
         type: string

--- a/api/spec/yaml/binaries.yml
+++ b/api/spec/yaml/binaries.yml
@@ -99,16 +99,32 @@ endpoints:
           afterEach:
             - Remove-Item $File
             - Find-ManagedObjectCollection -Query "has(c8y_IsBinary) and (name eq '$FileName')" | Remove-Binary
+        
+        - description: Upload a config file and make it globally accessible for all users
+          beforeEach:
+            - $File = New-TestFile
+            - $FileName = (Get-Item $File).Name
+          command: New-Binary -File $File -Data @{ c8y_Global = @{}; type = "c8y_upload" }
+          afterEach:
+            - Remove-Item $File
+            - Find-ManagedObjectCollection -Query "has(c8y_IsBinary) and (name eq '$FileName')" | Remove-Binary
 
       go:
         - description: Upload a log file
           command: c8y binaries create --file ./output.log
+        
+        - description: Upload a config file and make it globally accessible for all users
+          command: c8y binaries create --file "myConfig.json" --data "c8y_Global={},type=c8y_upload"
 
     body:
       - name: file
         type: file
         required: true
         description: File to be uploaded as a binary
+      
+      - name: data
+        type: json
+        description: Additional properties to be added to the binary.
 
   - name: updateBinary
     description: 'Update inventory binary'

--- a/api/spec/yaml/events.yml
+++ b/api/spec/yaml/events.yml
@@ -190,21 +190,26 @@ endpoints:
         type: datetime
         required: false
         default: "0s"
-        description: Time of the event.
+        description: Time of the event. Defaults to current timestamp.
 
       - name: type
         type: string
-        required: true
+        required: false
         description: Identifies the type of this event.
 
       - name: text
         type: string
-        required: true
+        required: false
         description: Text description of the event.
 
       - name: data
         type: json
         description: Additional properties of the event.
+
+    bodyRequiredKeys:
+      - "type"
+      - "text"
+      - "time"
 
   - name: updateEvent
     method: PUT

--- a/api/spec/yaml/identity.yml
+++ b/api/spec/yaml/identity.yml
@@ -119,10 +119,21 @@ endpoints:
         powershell: New-ExternalId
     examples:
       powershell:
-        - description: Get external identity
+        - description: Create external identity
           beforeEach:
               - $my_SerialNumber = New-RandomString -Prefix "my_SerialNumber"
-          command: New-ExternalId -Device {{ randomdevice }} -Type "$my_SerialNumber" -Name "myserialnumber"
+              - $Device = New-TestDevice
+          command: New-ExternalId -Device $Device.id -Type "$my_SerialNumber" -Name "myserialnumber"
+          afterEach:
+              - PSc8y\Remove-ManagedObject -Id $Device.id
+        
+        - description: Create external identity (using pipeline)
+          beforeEach:
+              - $my_SerialNumber = New-RandomString -Prefix "my_SerialNumber"
+              - $Device = New-TestDevice
+          command: Get-Device $Device.id | New-ExternalId -Type "$my_SerialNumber" -Name "myserialnumber"
+          afterEach:
+              - PSc8y\Remove-ManagedObject -Id $Device.id
 
       go:
         - description: Create external identity
@@ -131,6 +142,7 @@ endpoints:
       - name: device
         type: '[]device'
         required: true
+        pipeline: true
         description: The ManagedObject linked to the external ID.
     body:
       - name: type

--- a/api/spec/yaml/inventoryReferences.yml
+++ b/api/spec/yaml/inventoryReferences.yml
@@ -96,6 +96,7 @@ endpoints:
       # Lookup via group
       - name: group
         type: '[]devicegroup'
+        pipeline: true
         property: id
         description: Group.
 

--- a/api/spec/yaml/measurements.yml
+++ b/api/spec/yaml/measurements.yml
@@ -267,17 +267,22 @@ endpoints:
 
       - name: time
         type: datetime
-        required: true
-        description: Time of the measurement.
+        required: false
+        default: "0s"
+        description: Time of the measurement. Defaults to current timestamp.
 
       - name: type
         type: string
-        required: true
+        required: false
         description: The most specific type of this entire measurement.
 
       - name: data
         type: json
         description: List of measurement fragments.
+
+    bodyRequiredKeys:
+      - "type"
+      - "time"
 
   - name: deleteMeasurement
     description: 'Delete measurement/s'

--- a/docs/_docs/concepts/templates.md
+++ b/docs/_docs/concepts/templates.md
@@ -1,0 +1,147 @@
+---
+layout: default
+category: Concepts
+title: Templating
+---
+
+### Data Templates
+
+
+### Exercise
+
+Assume that you want to simulate create some mock some measurements in Cumulocity to assist with prototyping. Let's say that you are building a weather application and you want to create a measurement which has two different series.
+
+    * `c8y_Weather.temperature`
+    * `c8y_Weather.barometricPressure`
+
+You can create a simple jsonnet template file.
+
+```jsonnet
+{
+    c8y_Weather: {
+        temperature: {
+            value: rand.int,
+            unit: "°C",
+        },
+        barometricPressure: {
+            value: rand.float * 100 + 1000,
+            unit: "Pa",
+        },
+    },
+}
+```
+
+The template should mostly look familar to you as jsonnet uses a json-like structure. The interesting parts which might not be 100% clear are the two references to variables; `rand.int` and `rand.float`.
+
+`rand` is an object which is injected by the c8y cli tool, which has a few properties which contain randomized data. `rand.int` returns a random integer between 0 and 10, and a `rand.float` returns a 32 bit float between 0 and 1.
+
+The random values can be used to build up mock measurement, and you can control the range by using simple muliplication, divition and addition:
+
+For example if you wanted to use a value that ranges between -50 and 50, then you have subtract 50:
+
+```jsonnet
+{
+    // Integer between -50 and 50
+    value: rand.int - 50,
+}
+```
+
+And if that is still not enough, you can use an if/else statement where it uses the value of `rand.bool` to switch between two different sets of expressions.
+
+```jsonnet
+{
+    value: if rand.bool then -20 else rand.int * 10,
+}
+```
+
+#### Template Variables (TODO)
+
+Variables can also be injected into your script, and the values can be passed at runtime, 
+
+**input.vars.json**
+
+{
+    "type": "myCustom1",
+    "softwareCount": 2
+}
+
+
+
+### Usage with cli
+
+Once you have created a template you use it by passing the path to the template to the `template` parameter:
+
+```sh
+c8y measurements create \
+    --device 12345 \
+    --time "0s" \
+    --type "c8y_Measurement" \
+    --dry \
+    --template ./examples/templates/measurement.jsonnet
+```
+
+```powershell
+New-Measurement `
+    -Device 12345 `
+    -Time "0s" `
+    -Type "c8y_Measurement" `
+    -WhatIf `
+    -Template ./examples/templates/measurement.jsonnet
+```
+
+### Available (automatic) variables
+
+Below shows all of the variables which are available for use in the jsonnet template files. There are multi
+
+| Variable | Description |
+|-------|---------|
+| rand.bool | Random boolean value, either true or false |
+| rand.int | Random integer between 0 and 100 (inclusive) |
+| rand.int2 | Random integer between 0 and 100 (inclusive) |
+| rand.float | Random float32 between 0 and 1 |
+| rand.float2 | Random float32 between 0 and 1 |
+| rand.float3 | Random float32 between 0 and 1 |
+| rand.float4 | Random float32 between 0 and 1 |
+
+
+More information about jsonnet and it's synatax can be found [here](https://jsonnet.org/)
+
+
+
+### Complex Example
+
+Add a complex device managed object where the number of installed software applications in the c8y_SoftwareList fragment can be set via a variable
+
+*device.template.jsonnet*
+
+```jsonnet
+// Helper: Create software entry
+local newSoftware(i) = {
+    name: "app" + i,
+    version: "1.0." + i,
+    url: "",
+};
+
+// Settings: Default values:
+local defaults = {
+    name: "test",
+    type: "defaultType",
+    softwareCount: 2,
+} + vars;
+
+// Output: Device Managed Object
+{
+    name: "name1",
+    value: defaults.name,
+    type: defaults.type,
+    ["c8y_" + defaults.type]: {},
+    c8y_SoftwareList: [ newSoftware(i) for i in std.range(1, defaults.softwareCount)],
+}
+```
+
+**Bash/zsh**
+
+```sh
+c8y inventory create --dry --template ./examples/templates/device.template.jsonnet --templateVars "softwareCount=2"
+```
+

--- a/docs/_docs/concepts/templates.md
+++ b/docs/_docs/concepts/templates.md
@@ -199,3 +199,63 @@ The following output shows the body that will be uploaded to Cumulocity when cre
    "value": "test"
 }
 ```
+
+### Template development
+
+To help with the development of templates, there is a command which evaluates a template and prints the output to the console.
+
+**Bash/zsh**
+
+```sh
+c8y template execute --template ./mytemplate.jsonnet
+```
+
+**PowerShell**
+
+```powershell
+Invoke-Template -Template ./template.jsonnet
+```
+
+#### Input data (PowerShell)
+
+`Invoke-Template` also supports piping of input data which can be referenced 
+
+```powershell
+$Template = @"
+{
+    type: base.name + '_' + rand.int,
+    value: 1 + 2,
+}
+"@
+
+$InputData = @(
+    @{ name = "device1" },
+    @{ name = "device2" }
+)
+$templateOutput = $InputData |
+    Invoke-Template -Template $Template -Compress
+```
+
+**Output**
+
+```json
+{"name":"device1","type":"device1_70","value":3}
+{"name":"device2","type":"device2_25","value":3}
+```
+
+Or the output can be piped to `ConvertFrom-Json`:
+
+```powershell
+$templateOutput = $InputData | Invoke-Template -Template $Template -Compress | ConvertFrom-Json
+```
+
+```sh
+name  type     value
+----  ----     -----
+name  name_97      3
+name2 name2_54     3
+```
+
+**Note**
+
+When piping the output to `ConvertFrom-Json`, the `-Compress` option needs to be used otherwise it will return an error due to invalid JSON. This is because the output is a stream of json text and not a json array of results.

--- a/docs/_docs/concepts/templates.md
+++ b/docs/_docs/concepts/templates.md
@@ -133,6 +133,40 @@ The random values are assigned as variables and not functions. This means if you
 Additional information about jsonnet and it's synatax can be found [here](https://jsonnet.org/)
 
 
+### Template settings
+
+Template (jsonnet) files can be stored in a folder and this folder can be added to the `settings.template.path` settings within the global or session configuration.
+
+```json
+{
+    "settings": {
+        "template.path": "/workspaces/go-c8y-cli/.cumulocity/templates"
+    }
+}
+```
+
+The template path will be used when looking up template filenames if the user does not specify a relative or full path to it.
+
+i.e.
+
+```sh
+c8y template execute --template event.jsonnet
+```
+
+c8y will look for a file called "event.jsonnet" inside the `template.path` folder.
+
+PSc8y also supports argument completion for template files if the path is set.
+
+```powershell
+PS /workspaces/go-c8y-cli> Invoke-Template -Template <tab>
+
+alarm.jsonnet                 device.template.jsonnet       event.jsonnet                 measurement.advanced.jsonnet
+```
+
+**Note**
+
+Argument completion for template filenames is not yet supporte for bash or zsh.
+
 ### Complex Example
 
 Add a complex device managed object where the number of installed software applications in the `c8y_SoftwareList` fragment can be set via the command line.

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -81,6 +81,7 @@ The following is a list of available environment variables which control how c8y
 | C8Y_SESSION_HOME | Path where the session files and settings are located. Defaults to `~/.cumulocity` if it is not set. |
 | C8Y_USE_ENVIRONMENT | When set to `on`, the Cumulocity session settings will be loaded from environment variables. This will override the `C8Y_SESSION` variable. Useful when using in a CI/CD pipeline. |
 | C8Y_LOGGER_HIDE_SENSITIVE | Control whether sensitive session information is logged to the console or not. |
+| C8Y_JSONNET_DEBUG | Display debugging information for jsonnet templates (if used) |
 
 
 ### Environment variable details and examples   

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -26,6 +26,7 @@ The following table lists the available settings, the environment variable equiv
 | default.pageSize | `C8Y_SETTINGS_DEFAULT_PAGESIZE` | Default page size |
 | includeAll.pageSize | `C8Y_SETTINGS_INCLUDEALL_PAGESIZE` | Default page size when using the includeAll parameter |
 | includeAll.delayMS | `C8Y_SETTINGS_INCLUDEALL_DELAYMS` | Delay between fetching the next page when using the includeAll parameter |
+| template.path | `C8Y_SETTINGS_TEMPLATE_PATH` | Path / Folder where the templates are located. If the user gives a template name (without path), then a matching filename will be search for in this folder |
 
 ### Example: Set global defaults to use in each c8y session
 

--- a/docs/_pwsh/cmdlets/Add-AssetToGroup.md
+++ b/docs/_pwsh/cmdlets/Add-AssetToGroup.md
@@ -20,6 +20,8 @@ Add-AssetToGroup
 	[-Group] <Object[]>
 	[[-NewChildDevice] <Object[]>]
 	[[-NewChildGroup] <Object[]>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -90,6 +92,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -114,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -159,7 +193,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Add-ChildDeviceToDevice.md
+++ b/docs/_pwsh/cmdlets/Add-ChildDeviceToDevice.md
@@ -19,6 +19,8 @@ Create a child device reference
 Add-ChildDeviceToDevice
 	[-Device] <Object[]>
 	[-NewChild] <Object[]>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -82,6 +84,38 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -106,7 +140,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -136,7 +170,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,7 +185,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Add-ChildGroupToGroup.md
+++ b/docs/_pwsh/cmdlets/Add-ChildGroupToGroup.md
@@ -19,6 +19,8 @@ Add a device group to an existing group
 Add-ChildGroupToGroup
 	[-Group] <Object[]>
 	[-NewChildGroup] <Object[]>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -84,6 +86,38 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -108,7 +142,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -138,7 +172,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -153,7 +187,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Add-DeviceToGroup.md
+++ b/docs/_pwsh/cmdlets/Add-DeviceToGroup.md
@@ -19,6 +19,8 @@ Add a device to an existing group
 Add-DeviceToGroup
 	[-Group] <Object[]>
 	[-NewChildDevice] <Object[]>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -84,6 +86,38 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -108,7 +142,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -138,7 +172,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -153,7 +187,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Add-RoleToGroup.md
+++ b/docs/_pwsh/cmdlets/Add-RoleToGroup.md
@@ -20,6 +20,8 @@ Add-RoleToGroup
 	[-Group] <Object[]>
 	[-Role] <Object[]>
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -97,6 +99,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -121,7 +155,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,7 +185,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -166,7 +200,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Add-RoleToUser.md
+++ b/docs/_pwsh/cmdlets/Add-RoleToUser.md
@@ -20,6 +20,8 @@ Add-RoleToUser
 	[-User] <Object[]>
 	[[-Role] <Object[]>]
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -104,6 +106,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -158,7 +192,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,7 +207,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Add-UserToGroup.md
+++ b/docs/_pwsh/cmdlets/Add-UserToGroup.md
@@ -20,6 +20,8 @@ Add-UserToGroup
 	[-Group] <Object[]>
 	[-User] <Object[]>
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -90,6 +92,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -114,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -159,7 +193,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Approve-DeviceRequest.md
+++ b/docs/_pwsh/cmdlets/Approve-DeviceRequest.md
@@ -19,6 +19,8 @@ Approve a new device request
 Approve-DeviceRequest
 	[-Id] <String>
 	[[-Status] <String>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -75,6 +77,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -99,7 +133,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -129,7 +163,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/ConvertTo-JsonArgument.md
+++ b/docs/_pwsh/cmdlets/ConvertTo-JsonArgument.md
@@ -28,6 +28,8 @@ Before the c8y cli binary can accept it, it must be converted to json.
 
 The necessary character escaping of literal backslashed `\\` will be done automatically.
 
+If Data parameter is a file path then it is returned as is.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/_pwsh/cmdlets/Copy-Application.md
+++ b/docs/_pwsh/cmdlets/Copy-Application.md
@@ -18,6 +18,8 @@ Copy application
 ```
 Copy-Application
 	[-Id] <Object[]>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -63,6 +65,38 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -87,7 +121,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -117,7 +151,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -132,7 +166,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Enable-Application.md
+++ b/docs/_pwsh/cmdlets/Enable-Application.md
@@ -19,6 +19,8 @@ Enable application on tenant
 Enable-Application
 	[-Application] <Object[]>
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -75,6 +77,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -99,7 +133,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -129,7 +163,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Enable-Microservice.md
+++ b/docs/_pwsh/cmdlets/Enable-Microservice.md
@@ -19,6 +19,8 @@ Enable/subscribe a microservice
 Enable-Microservice
 	[-Id] <Object[]>
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,6 +76,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -98,7 +132,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,7 +177,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Get-ChildAssetCollection.md
+++ b/docs/_pwsh/cmdlets/Get-ChildAssetCollection.md
@@ -81,7 +81,7 @@ Aliases:
 Required: False
 Position: 2
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 

--- a/docs/_pwsh/cmdlets/Get-ClientSetting.md
+++ b/docs/_pwsh/cmdlets/Get-ClientSetting.md
@@ -1,0 +1,46 @@
+---
+category: Client Helpers
+external help file: PSc8y-help.xml
+layout: powershell
+Module Name: PSc8y
+online version:
+schema: 2.0.0
+title: Get-ClientSetting
+---
+
+# Get-ClientSetting
+
+## SYNOPSIS
+Get the Cumulocity binary settings
+
+## SYNTAX
+
+```
+Get-ClientSetting
+	[<CommonParameters>]
+```
+
+## DESCRIPTION
+Get the Cumulocity binary settings which used by the cli tool
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-ClientSetting
+```
+
+Show the current c8y cli tool settings
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/_pwsh/cmdlets/Invoke-Template.md
+++ b/docs/_pwsh/cmdlets/Invoke-Template.md
@@ -1,0 +1,121 @@
+---
+category: Misc.
+external help file: PSc8y-help.xml
+layout: powershell
+Module Name: PSc8y
+online version:
+schema: 2.0.0
+title: Invoke-Template
+---
+
+# Invoke-Template
+
+## SYNOPSIS
+Execute a jsonnet data template
+
+## SYNTAX
+
+```
+Invoke-Template
+	[-Template] <String>
+	[-TemplateVars <String>]
+	[-Data <Object[]>]
+	[-Compress]
+	[<CommonParameters>]
+```
+
+## DESCRIPTION
+Execute a jsonnet data template and show the output of the template.
+Useful when developing new templates
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Invoke-Template -Template ./template.jsonnet
+```
+
+Execute a jsonnet template
+
+### EXAMPLE 2
+```
+Invoke-Template -Template ./template.jsonnet -TemplateVars "name=input"
+```
+
+Execute a jsonnet template
+
+## PARAMETERS
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Data
+Template input data
+
+```yaml
+Type: Object[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Compress
+Output compressed/minified json
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### String
+## NOTES
+
+## RELATED LINKS

--- a/docs/_pwsh/cmdlets/New-Agent.md
+++ b/docs/_pwsh/cmdlets/New-Agent.md
@@ -20,6 +20,8 @@ New-Agent
 	[-Name] <String>
 	[[-Type] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -99,6 +101,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -123,7 +157,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -153,7 +187,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -168,7 +202,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Alarm.md
+++ b/docs/_pwsh/cmdlets/New-Alarm.md
@@ -18,12 +18,14 @@ Create a new alarm
 ```
 New-Alarm
 	[-Device] <Object[]>
-	[-Type] <String>
+	[[-Type] <String>]
 	[[-Time] <String>]
-	[-Text] <String>
-	[-Severity] <String>
+	[[-Text] <String>]
+	[[-Severity] <String>]
 	[[-Status] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,14 +76,13 @@ Accept wildcard characters: False
 ### -Type
 Identifies the type of this alarm, e.g.
 'com_cumulocity_events_TamperEvent'.
-(required)
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False
@@ -90,6 +91,7 @@ Accept wildcard characters: False
 
 ### -Time
 Time of the alarm.
+Defaults to current timestamp.
 
 ```yaml
 Type: String
@@ -105,14 +107,13 @@ Accept wildcard characters: False
 
 ### -Text
 Text description of the alarm.
-(required)
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False
@@ -122,14 +123,13 @@ Accept wildcard characters: False
 ### -Severity
 The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING.
 Must be upper-case.
-(required)
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 5
 Default value: None
 Accept pipeline input: False
@@ -168,6 +168,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -192,7 +224,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -222,7 +254,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -237,7 +269,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Application.md
+++ b/docs/_pwsh/cmdlets/New-Application.md
@@ -27,6 +27,8 @@ New-Application
 	[[-ResourcesUsername] <String>]
 	[[-ResourcesPassword] <String>]
 	[[-ExternalUrl] <String>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -207,6 +209,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 12
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -231,7 +265,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -261,7 +295,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 12
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -276,7 +310,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 13
+Position: 15
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-ApplicationBinary.md
+++ b/docs/_pwsh/cmdlets/New-ApplicationBinary.md
@@ -19,6 +19,8 @@ New application binary
 New-ApplicationBinary
 	[-Id] <Object[]>
 	[-File] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -78,6 +80,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -102,7 +136,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -132,7 +166,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -147,7 +181,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-AuditRecord.md
+++ b/docs/_pwsh/cmdlets/New-AuditRecord.md
@@ -26,6 +26,8 @@ New-AuditRecord
 	[[-User] <String>]
 	[[-Application] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -69,6 +71,7 @@ Accept wildcard characters: False
 
 ### -Time
 Time of the audit record.
+Defaults to current timestamp.
 
 ```yaml
 Type: String
@@ -190,6 +193,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -214,7 +249,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -244,7 +279,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -259,7 +294,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 12
+Position: 14
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Binary.md
+++ b/docs/_pwsh/cmdlets/New-Binary.md
@@ -18,6 +18,9 @@ New inventory binary
 ```
 New-Binary
 	[-File] <String>
+	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -41,6 +44,13 @@ New-Binary -File $File
 
 Upload a log file
 
+### EXAMPLE 2
+```
+New-Binary -File $File -Data @{ c8y_Global = @{}; type = "c8y_upload" }
+```
+
+Upload a config file and make it globally accessible for all users
+
 ## PARAMETERS
 
 ### -File
@@ -53,6 +63,53 @@ Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Data
+Additional properties to be added to the binary.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -82,7 +139,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -112,7 +169,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -127,7 +184,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Device.md
+++ b/docs/_pwsh/cmdlets/New-Device.md
@@ -20,6 +20,8 @@ New-Device
 	[-Name] <String[]>
 	[[-Type] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -97,6 +99,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -121,7 +155,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,7 +185,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -166,7 +200,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-DeviceGroup.md
+++ b/docs/_pwsh/cmdlets/New-DeviceGroup.md
@@ -20,6 +20,8 @@ New-DeviceGroup
 	[-Name] <String>
 	[[-Type] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -98,6 +100,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -122,7 +156,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -152,7 +186,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -167,7 +201,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Event.md
+++ b/docs/_pwsh/cmdlets/New-Event.md
@@ -19,9 +19,11 @@ Create event
 New-Event
 	[-Device] <Object[]>
 	[[-Time] <String>]
-	[-Type] <String>
-	[-Text] <String>
+	[[-Type] <String>]
+	[[-Text] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -72,6 +74,7 @@ Accept wildcard characters: False
 
 ### -Time
 Time of the event.
+Defaults to current timestamp.
 
 ```yaml
 Type: String
@@ -87,14 +90,13 @@ Accept wildcard characters: False
 
 ### -Type
 Identifies the type of this event.
-(required)
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -103,14 +105,13 @@ Accept wildcard characters: False
 
 ### -Text
 Text description of the event.
-(required)
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 4
 Default value: None
 Accept pipeline input: False
@@ -127,6 +128,38 @@ Aliases:
 
 Required: False
 Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -156,7 +189,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -186,7 +219,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -201,7 +234,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-EventBinary.md
+++ b/docs/_pwsh/cmdlets/New-EventBinary.md
@@ -19,6 +19,8 @@ New event binary
 New-EventBinary
 	[-Id] <String>
 	[-File] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,6 +76,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -98,7 +132,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,7 +177,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-ExternalId.md
+++ b/docs/_pwsh/cmdlets/New-ExternalId.md
@@ -20,6 +20,8 @@ New-ExternalId
 	[-Device] <Object[]>
 	[-Type] <String>
 	[-Name] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -38,10 +40,17 @@ Create a new external id
 
 ### EXAMPLE 1
 ```
-New-ExternalId -Device {{ randomdevice }} -Type "$my_SerialNumber" -Name "myserialnumber"
+New-ExternalId -Device $Device.id -Type "$my_SerialNumber" -Name "myserialnumber"
 ```
 
-Get external identity
+Create external identity
+
+### EXAMPLE 2
+```
+Get-Device $Device.id | New-ExternalId -Type "$my_SerialNumber" -Name "myserialnumber"
+```
+
+Create external identity (using pipeline)
 
 ## PARAMETERS
 
@@ -57,7 +66,7 @@ Aliases:
 Required: True
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -94,6 +103,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -118,7 +159,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -148,7 +189,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -163,7 +204,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Group.md
+++ b/docs/_pwsh/cmdlets/New-Group.md
@@ -19,6 +19,8 @@ Create a new group
 New-Group
 	[[-Name] <String>]
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,6 +76,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -98,7 +132,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,7 +177,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-HostedApplication.md
+++ b/docs/_pwsh/cmdlets/New-HostedApplication.md
@@ -25,6 +25,8 @@ New-HostedApplication
 	[[-Availability] <String>]
 	[-SkipUpload]
 	[-SkipActivation]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -176,6 +178,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Include raw response including pagination information
 
@@ -200,7 +234,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -230,7 +264,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -245,7 +279,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-ManagedObject.md
+++ b/docs/_pwsh/cmdlets/New-ManagedObject.md
@@ -20,6 +20,8 @@ New-ManagedObject
 	[[-Name] <String>]
 	[[-Type] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -90,6 +92,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -114,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -159,7 +193,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Measurement.md
+++ b/docs/_pwsh/cmdlets/New-Measurement.md
@@ -18,9 +18,11 @@ Create a new measurement
 ```
 New-Measurement
 	[-Device] <Object[]>
-	[-Time] <String>
-	[-Type] <String>
+	[[-Time] <String>]
+	[[-Type] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -64,14 +66,14 @@ Accept wildcard characters: False
 
 ### -Time
 Time of the measurement.
-(required)
+Defaults to current timestamp.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 2
 Default value: None
 Accept pipeline input: False
@@ -80,14 +82,13 @@ Accept wildcard characters: False
 
 ### -Type
 The most specific type of this entire measurement.
-(required)
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 3
 Default value: None
 Accept pipeline input: False
@@ -104,6 +105,38 @@ Aliases:
 
 Required: False
 Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -133,7 +166,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -163,7 +196,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -178,7 +211,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Microservice.md
+++ b/docs/_pwsh/cmdlets/New-Microservice.md
@@ -19,6 +19,7 @@ New microservice
 New-Microservice
 	[-File] <String>
 	[[-Name] <String>]
+	[[-Key] <String>]
 	[[-Availability] <String>]
 	[[-ContextPath] <String>]
 	[[-ResourcesUrl] <String>]
@@ -111,6 +112,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Key
+Shared secret of application.
+Defaults to application name if not provided.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Availability
 Access level for other tenants. 
 Possible values are : MARKET, PRIVATE (default)
@@ -121,7 +138,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -137,7 +154,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -153,7 +170,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -215,7 +232,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -245,7 +262,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -260,7 +277,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -321,5 +338,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ### System.Object
 ## NOTES
+This cmdlet does not support template variables
 
 ## RELATED LINKS

--- a/docs/_pwsh/cmdlets/New-MicroserviceBinary.md
+++ b/docs/_pwsh/cmdlets/New-MicroserviceBinary.md
@@ -19,6 +19,8 @@ Create/upload a new microservice binary
 New-MicroserviceBinary
 	[-Id] <Object[]>
 	[-File] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -78,6 +80,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -102,7 +136,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -132,7 +166,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -147,7 +181,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Operation.md
+++ b/docs/_pwsh/cmdlets/New-Operation.md
@@ -20,6 +20,8 @@ New-Operation
 	[-Device] <Object[]>
 	[[-Description] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -98,6 +100,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -122,7 +156,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -152,7 +186,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -167,7 +201,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-RetentionRule.md
+++ b/docs/_pwsh/cmdlets/New-RetentionRule.md
@@ -23,6 +23,8 @@ New-RetentionRule
 	[[-Source] <String>]
 	[-MaximumAge] <Int64>
 	[-Editable]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -141,6 +143,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -165,7 +199,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -195,7 +229,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -210,7 +244,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-Tenant.md
+++ b/docs/_pwsh/cmdlets/New-Tenant.md
@@ -25,6 +25,8 @@ New-Tenant
 	[[-ContactPhone] <String>]
 	[[-TenantId] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -174,6 +176,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -198,7 +232,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -228,7 +262,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -243,7 +277,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-TenantOption.md
+++ b/docs/_pwsh/cmdlets/New-TenantOption.md
@@ -20,6 +20,8 @@ New-TenantOption
 	[-Category] <String>
 	[-Key] <String>
 	[-Value] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -90,6 +92,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -114,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -159,7 +193,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-TestAgent.md
+++ b/docs/_pwsh/cmdlets/New-TestAgent.md
@@ -18,6 +18,8 @@ Create a new test agent representation in Cumulocity
 ```
 New-TestAgent
 	[[-Name] <String>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -59,6 +61,38 @@ Aliases:
 Required: False
 Position: 1
 Default value: Testagent
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-TestAlarm.md
+++ b/docs/_pwsh/cmdlets/New-TestAlarm.md
@@ -18,6 +18,8 @@ Create a new test alarm
 ```
 New-TestAlarm
 	[[-Device] <Object>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -60,6 +62,38 @@ Required: False
 Position: 1
 Default value: None
 Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 

--- a/docs/_pwsh/cmdlets/New-TestDevice.md
+++ b/docs/_pwsh/cmdlets/New-TestDevice.md
@@ -19,6 +19,8 @@ Create a new test device representation in Cumulocity
 New-TestDevice
 	[[-Name] <String>]
 	[-AsAgent]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -67,7 +69,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: Testdevice
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -82,6 +84,38 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-TestDeviceGroup.md
+++ b/docs/_pwsh/cmdlets/New-TestDeviceGroup.md
@@ -19,6 +19,8 @@ Create a new test device group
 New-TestDeviceGroup
 	[[-Name] <String>]
 	[-Type <String>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -58,7 +60,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: Testgroup
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -74,6 +76,38 @@ Aliases:
 Required: False
 Position: Named
 Default value: Group
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-TestEvent.md
+++ b/docs/_pwsh/cmdlets/New-TestEvent.md
@@ -19,6 +19,8 @@ Create a new test event
 New-TestEvent
 	[[-Device] <Object>]
 	[-WithBinary]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -60,7 +62,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -75,6 +77,38 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-TestGroup.md
+++ b/docs/_pwsh/cmdlets/New-TestGroup.md
@@ -18,6 +18,8 @@ Create a test user group
 ```
 New-TestGroup
 	[[-Name] <String>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -51,6 +53,38 @@ Aliases:
 Required: False
 Position: 1
 Default value: Testgroup
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-TestMeasurement.md
+++ b/docs/_pwsh/cmdlets/New-TestMeasurement.md
@@ -18,11 +18,13 @@ Create a new test measurement
 ```
 New-TestMeasurement
 	[[-Device] <Object>]
-	[[-ValueFragmentType] <String>]
-	[[-ValueFragmentSeries] <String>]
-	[[-Type] <String>]
-	[[-Value] <Double>]
-	[[-Unit] <String>]
+	[-ValueFragmentType <String>]
+	[-ValueFragmentSeries <String>]
+	[-Type <String>]
+	[-Value <Double>]
+	[-Unit <String>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -64,7 +66,7 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -77,7 +79,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: Named
 Default value: C8y_Temperature
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -92,7 +94,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: Named
 Default value: T
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -107,7 +109,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: C8yTemperatureReading
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -122,7 +124,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: 1.2345
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -139,8 +141,40 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: Named
 Default value: °C
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-TestOperation.md
+++ b/docs/_pwsh/cmdlets/New-TestOperation.md
@@ -18,6 +18,8 @@ Create a new test operation
 ```
 New-TestOperation
 	[[-Device] <Object>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -58,6 +60,38 @@ Aliases:
 
 Required: False
 Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/New-TestUser.md
+++ b/docs/_pwsh/cmdlets/New-TestUser.md
@@ -18,6 +18,8 @@ Create a new test user
 ```
 New-TestUser
 	[[-Name] <String>]
+	[-Template <String>]
+	[-TemplateVars <String>]
 	[-Force]
 	[-WhatIf]
 	[-Confirm]
@@ -57,6 +59,38 @@ Aliases:
 Required: False
 Position: 1
 Default value: Testuser
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/_pwsh/cmdlets/New-User.md
+++ b/docs/_pwsh/cmdlets/New-User.md
@@ -27,6 +27,8 @@ New-User
 	[-SendPasswordResetEmail]
 	[[-CustomProperties] <Object>]
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -206,6 +208,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -230,7 +264,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -260,7 +294,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -275,7 +309,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Register-Device.md
+++ b/docs/_pwsh/cmdlets/Register-Device.md
@@ -18,6 +18,8 @@ Register a new device (request)
 ```
 Register-Device
 	[-Id] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -61,6 +63,38 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -85,7 +119,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -115,7 +149,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -130,7 +164,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Request-DeviceCredentials.md
+++ b/docs/_pwsh/cmdlets/Request-DeviceCredentials.md
@@ -18,6 +18,8 @@ Request credentials for a new device
 ```
 Request-DeviceCredentials
 	[-Id] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -64,6 +66,38 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -88,7 +122,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -118,7 +152,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -133,7 +167,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Reset-UserPassword.md
+++ b/docs/_pwsh/cmdlets/Reset-UserPassword.md
@@ -20,6 +20,8 @@ Reset-UserPassword
 	[-Id] <Object[]>
 	[[-NewPassword] <String>]
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -99,6 +101,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -123,7 +157,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -153,7 +187,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -168,7 +202,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Set-DeviceRequiredAvailability.md
+++ b/docs/_pwsh/cmdlets/Set-DeviceRequiredAvailability.md
@@ -19,6 +19,8 @@ Set the required availability of a device
 Set-DeviceRequiredAvailability
 	[-Device] <Object[]>
 	[-Interval] <Int64>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -86,6 +88,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -110,7 +144,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -140,7 +174,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -155,7 +189,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Agent.md
+++ b/docs/_pwsh/cmdlets/Update-Agent.md
@@ -20,6 +20,8 @@ Update-Agent
 	[-Id] <Object[]>
 	[[-NewName] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -104,6 +106,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -158,7 +192,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,7 +207,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Alarm.md
+++ b/docs/_pwsh/cmdlets/Update-Alarm.md
@@ -22,6 +22,8 @@ Update-Alarm
 	[[-Severity] <String>]
 	[[-Text] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -136,6 +138,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -160,7 +194,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -190,7 +224,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -205,7 +239,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-AlarmCollection.md
+++ b/docs/_pwsh/cmdlets/Update-AlarmCollection.md
@@ -25,6 +25,8 @@ Update-AlarmCollection
 	[[-DateFrom] <String>]
 	[[-DateTo] <String>]
 	[-NewStatus] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -165,6 +167,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -189,7 +223,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -219,7 +253,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -234,7 +268,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Application.md
+++ b/docs/_pwsh/cmdlets/Update-Application.md
@@ -27,6 +27,8 @@ Update-Application
 	[[-ResourcesUsername] <String>]
 	[[-ResourcesPassword] <String>]
 	[[-ExternalUrl] <String>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -203,6 +205,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 12
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -227,7 +261,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -257,7 +291,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 12
+Position: 14
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -272,7 +306,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 13
+Position: 15
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Binary.md
+++ b/docs/_pwsh/cmdlets/Update-Binary.md
@@ -19,6 +19,8 @@ Update inventory binary
 Update-Binary
 	[-Id] <String>
 	[-File] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,6 +76,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -98,7 +132,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,7 +177,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-CurrentApplication.md
+++ b/docs/_pwsh/cmdlets/Update-CurrentApplication.md
@@ -26,6 +26,8 @@ Update-CurrentApplication
 	[[-ResourcesUsername] <String>]
 	[[-ResourcesPassword] <String>]
 	[[-ExternalUrl] <String>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -186,6 +188,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -210,7 +244,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -240,7 +274,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -255,7 +289,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 12
+Position: 14
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-CurrentUser.md
+++ b/docs/_pwsh/cmdlets/Update-CurrentUser.md
@@ -23,6 +23,8 @@ Update-CurrentUser
 	[[-Email] <String>]
 	[[-Enabled] <String>]
 	[[-Password] <String>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -141,6 +143,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -165,7 +199,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -195,7 +229,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -210,7 +244,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-DataBrokerConnector.md
+++ b/docs/_pwsh/cmdlets/Update-DataBrokerConnector.md
@@ -20,6 +20,8 @@ Update-DataBrokerConnector
 	[-Id] <String>
 	[-Status] <String>
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -91,6 +93,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -115,7 +149,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -145,7 +179,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -160,7 +194,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Device.md
+++ b/docs/_pwsh/cmdlets/Update-Device.md
@@ -20,6 +20,8 @@ Update-Device
 	[-Id] <Object[]>
 	[[-NewName] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -104,6 +106,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -158,7 +192,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,7 +207,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-DeviceGroup.md
+++ b/docs/_pwsh/cmdlets/Update-DeviceGroup.md
@@ -20,6 +20,8 @@ Update-DeviceGroup
 	[-Id] <Object[]>
 	[[-Name] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -104,6 +106,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -158,7 +192,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,7 +207,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Event.md
+++ b/docs/_pwsh/cmdlets/Update-Event.md
@@ -20,6 +20,8 @@ Update-Event
 	[-Id] <String>
 	[[-Text] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -104,6 +106,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -158,7 +192,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -173,7 +207,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-EventBinary.md
+++ b/docs/_pwsh/cmdlets/Update-EventBinary.md
@@ -19,6 +19,8 @@ Update event binary
 Update-EventBinary
 	[-Id] <String>
 	[-File] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,6 +76,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -98,7 +132,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,7 +177,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Group.md
+++ b/docs/_pwsh/cmdlets/Update-Group.md
@@ -20,6 +20,8 @@ Update-Group
 	[-Id] <Object[]>
 	[[-Name] <String>]
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -97,6 +99,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -121,7 +155,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,7 +185,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -166,7 +200,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-ManagedObject.md
+++ b/docs/_pwsh/cmdlets/Update-ManagedObject.md
@@ -20,6 +20,8 @@ Update-ManagedObject
 	[-Id] <String>
 	[[-NewName] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -97,6 +99,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -121,7 +155,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -151,7 +185,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -166,7 +200,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Microservice.md
+++ b/docs/_pwsh/cmdlets/Update-Microservice.md
@@ -23,6 +23,8 @@ Update-Microservice
 	[[-Availability] <String>]
 	[[-ContextPath] <String>]
 	[[-ResourcesUrl] <String>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -139,6 +141,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -163,7 +197,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -193,7 +227,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -208,7 +242,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Operation.md
+++ b/docs/_pwsh/cmdlets/Update-Operation.md
@@ -21,6 +21,8 @@ Update-Operation
 	[-Status] <String>
 	[[-FailureReason] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -117,6 +119,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -141,7 +175,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -171,7 +205,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -186,7 +220,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 9
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-RetentionRule.md
+++ b/docs/_pwsh/cmdlets/Update-RetentionRule.md
@@ -25,6 +25,8 @@ Update-RetentionRule
 	[[-MaximumAge] <Int64>]
 	[-Editable]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -180,6 +182,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -204,7 +238,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 10
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -234,7 +268,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -249,7 +283,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-Tenant.md
+++ b/docs/_pwsh/cmdlets/Update-Tenant.md
@@ -25,6 +25,8 @@ Update-Tenant
 	[[-ContactName] <String>]
 	[[-ContactPhone] <String>]
 	[[-Data] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -172,6 +174,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -196,7 +230,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -226,7 +260,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -241,7 +275,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-TenantOption.md
+++ b/docs/_pwsh/cmdlets/Update-TenantOption.md
@@ -20,6 +20,8 @@ Update-TenantOption
 	[-Category] <String>
 	[-Key] <String>
 	[-Value] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -90,6 +92,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -114,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -159,7 +193,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-TenantOptionBulk.md
+++ b/docs/_pwsh/cmdlets/Update-TenantOptionBulk.md
@@ -19,6 +19,8 @@ Update multiple tenant options in provided category
 Update-TenantOptionBulk
 	[-Category] <String>
 	[-Data] <Object>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -74,6 +76,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -98,7 +132,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -128,7 +162,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -143,7 +177,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-TenantOptionEditable.md
+++ b/docs/_pwsh/cmdlets/Update-TenantOptionEditable.md
@@ -20,6 +20,8 @@ Update-TenantOptionEditable
 	[-Category] <String>
 	[-Key] <String>
 	[-Editable] <String>
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -90,6 +92,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -114,7 +148,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -144,7 +178,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -159,7 +193,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: 8
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/_pwsh/cmdlets/Update-User.md
+++ b/docs/_pwsh/cmdlets/Update-User.md
@@ -27,6 +27,8 @@ Update-User
 	[-SendPasswordResetEmail]
 	[[-CustomProperties] <Object>]
 	[[-Tenant] <Object>]
+	[[-Template] <String>]
+	[[-TemplateVars] <String>]
 	[-Raw]
 	[[-OutputFile] <String>]
 	[-NoProxy]
@@ -205,6 +207,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Template
+Template (jsonnet) file to use to create the request body.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TemplateVars
+Variables to be used when evaluating the Template.
+Accepts a file path, json or json shorthand, i.e.
+"name=peter"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Raw
 Show the full (raw) response from Cumulocity including pagination information
 
@@ -229,7 +263,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 11
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -259,7 +293,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 12
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -274,7 +308,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 11
+Position: 13
 Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/examples/templates/alarm.jsonnet
+++ b/examples/templates/alarm.jsonnet
@@ -1,0 +1,5 @@
+local severity(idx) = ["MAJOR", "CRITICAL", "MINOR", "WARNING"][std.clamp(idx, 0, 3)];
+{    
+    // Measurement (other fields will be added)
+    severity: severity(rand.int % 5),
+}

--- a/examples/templates/alarm.jsonnet
+++ b/examples/templates/alarm.jsonnet
@@ -1,5 +1,5 @@
-local severity(idx) = ["MAJOR", "CRITICAL", "MINOR", "WARNING"][std.clamp(idx, 0, 3)];
+local severity(idx, len=4) = ["MAJOR", "CRITICAL", "MINOR", "WARNING"][std.clamp(idx, 0, len-1)];
 {    
     // Measurement (other fields will be added)
-    severity: severity(rand.int % 5),
+    severity: severity(rand.int % 4),
 }

--- a/examples/templates/device.simple.json
+++ b/examples/templates/device.simple.json
@@ -1,0 +1,4 @@
+{
+    name: var("name"),
+    type: "something"
+}

--- a/examples/templates/device.template.jsonnet
+++ b/examples/templates/device.template.jsonnet
@@ -5,18 +5,11 @@ local newSoftware(i) = {
     url: "",
 };
 
-// Settings: Default values:
-local defaults = {
-    name: "test",
-    type: "defaultType",
-    softwareCount: 2,
-} + vars;
-
 // Output: Device Managed Object
 {
     name: "name1",
-    value: defaults.name,
-    type: defaults.type,
-    ["c8y_" + defaults.type]: {},
-    c8y_SoftwareList: [ newSoftware(i) for i in std.range(1, defaults.softwareCount)],
+    value: var("name", "defaultName"),
+    type: var("type"),
+    ["c8y_" + var("type")]: {},
+    c8y_SoftwareList: [ mylib.newSoftware(i) for i in std.range(1, var("softwareCount", 1))],
 }

--- a/examples/templates/device.template.jsonnet
+++ b/examples/templates/device.template.jsonnet
@@ -1,0 +1,22 @@
+// Helper: Create software entry
+local newSoftware(i) = {
+    name: "app" + i,
+    version: "1.0." + i,
+    url: "",
+};
+
+// Settings: Default values:
+local defaults = {
+    name: "test",
+    type: "defaultType",
+    softwareCount: 2,
+} + vars;
+
+// Output: Device Managed Object
+{
+    name: "name1",
+    value: defaults.name,
+    type: defaults.type,
+    ["c8y_" + defaults.type]: {},
+    c8y_SoftwareList: [ newSoftware(i) for i in std.range(1, defaults.softwareCount)],
+}

--- a/examples/templates/event.jsonnet
+++ b/examples/templates/event.jsonnet
@@ -1,0 +1,5 @@
+local selectType(idx, len) = ["DiskUsage", "RAM", "Network"][std.clamp(idx, 0, len-1)];
+{    
+    // Measurement (other fields will be added)
+    type: "c8y_" + selectType(rand.int % 3, 3),
+}

--- a/examples/templates/measurement.advanced.jsonnet
+++ b/examples/templates/measurement.advanced.jsonnet
@@ -1,0 +1,15 @@
+{
+    name: "name1",
+    type: var("type", "c8y_Temparature"),
+    
+    ["c8y_" + var("type", "c8y_Temperature")]: {
+        sensor1: {
+            value: rand.int,
+            unit: "°C",
+        },
+        barometricPressure: {
+            value: rand.float * 100 + 1000,
+            unit: "Pa",
+        },
+    },
+}

--- a/examples/templates/measurement.jsonnet
+++ b/examples/templates/measurement.jsonnet
@@ -1,0 +1,15 @@
+{    
+    // Measurement (other fields will be added)
+    c8y_Weather: {
+        temperature: {
+            value: rand.int,
+            unit: "°C",
+        },
+        barometricPressure: {
+            value: rand.float * 100 + 1000,
+            value2: if rand.bool then -20 else rand.int * 10,
+            value3: rand.int % 5,
+            unit: "Pa",
+        },
+    },
+}

--- a/examples/templates/measurement.jsonnet
+++ b/examples/templates/measurement.jsonnet
@@ -7,9 +7,8 @@
         },
         barometricPressure: {
             value: rand.float * 100 + 1000,
-            value2: if rand.bool then -20 else rand.int * 10,
-            value3: rand.int % 5,
             unit: "Pa",
         },
     },
+    type: "c8y_Weather",
 }

--- a/examples/templates/vars.json
+++ b/examples/templates/vars.json
@@ -1,0 +1,5 @@
+{
+    "name": "testdevice",
+    "type": "myCustomType",
+    "softwareCount": 10
+}

--- a/pkg/cmd/addDeviceToGroupCmd.auto.go
+++ b/pkg/cmd/addDeviceToGroupCmd.auto.go
@@ -89,6 +89,9 @@ func (n *addDeviceToGroupCmd) addDeviceToGroup(cmd *cobra.Command, args []string
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addDeviceToGroupCmd.auto.go
+++ b/pkg/cmd/addDeviceToGroupCmd.auto.go
@@ -92,6 +92,9 @@ func (n *addDeviceToGroupCmd) addDeviceToGroup(cmd *cobra.Command, args []string
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addGroupToGroupCmd.auto.go
+++ b/pkg/cmd/addGroupToGroupCmd.auto.go
@@ -89,6 +89,9 @@ func (n *addGroupToGroupCmd) addGroupToGroup(cmd *cobra.Command, args []string) 
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addGroupToGroupCmd.auto.go
+++ b/pkg/cmd/addGroupToGroupCmd.auto.go
@@ -92,6 +92,9 @@ func (n *addGroupToGroupCmd) addGroupToGroup(cmd *cobra.Command, args []string) 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addRoleToGroupCmd.auto.go
+++ b/pkg/cmd/addRoleToGroupCmd.auto.go
@@ -90,6 +90,9 @@ func (n *addRoleToGroupCmd) addRoleToGroup(cmd *cobra.Command, args []string) er
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addRoleToGroupCmd.auto.go
+++ b/pkg/cmd/addRoleToGroupCmd.auto.go
@@ -87,6 +87,9 @@ func (n *addRoleToGroupCmd) addRoleToGroup(cmd *cobra.Command, args []string) er
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addRoleToUserCmd.auto.go
+++ b/pkg/cmd/addRoleToUserCmd.auto.go
@@ -86,6 +86,9 @@ func (n *addRoleToUserCmd) addRoleToUser(cmd *cobra.Command, args []string) erro
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addRoleToUserCmd.auto.go
+++ b/pkg/cmd/addRoleToUserCmd.auto.go
@@ -89,6 +89,9 @@ func (n *addRoleToUserCmd) addRoleToUser(cmd *cobra.Command, args []string) erro
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addUserToGroupCmd.auto.go
+++ b/pkg/cmd/addUserToGroupCmd.auto.go
@@ -87,6 +87,9 @@ func (n *addUserToGroupCmd) addUserToGroup(cmd *cobra.Command, args []string) er
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/addUserToGroupCmd.auto.go
+++ b/pkg/cmd/addUserToGroupCmd.auto.go
@@ -90,6 +90,9 @@ func (n *addUserToGroupCmd) addUserToGroup(cmd *cobra.Command, args []string) er
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/approveNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/approveNewDeviceRequestCmd.auto.go
@@ -75,6 +75,9 @@ func (n *approveNewDeviceRequestCmd) approveNewDeviceRequest(cmd *cobra.Command,
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "status", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/approveNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/approveNewDeviceRequestCmd.auto.go
@@ -78,6 +78,9 @@ func (n *approveNewDeviceRequestCmd) approveNewDeviceRequest(cmd *cobra.Command,
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/constants.go
+++ b/pkg/cmd/constants.go
@@ -1,5 +1,7 @@
 package cmd
 
 const (
-	FlagDataName = "data"
+	FlagDataName                  = "data"
+	FlagDataTemplateName          = "dataTemplate"
+	FlagDataTemplateVariablesName = "templateVars"
 )

--- a/pkg/cmd/constants.go
+++ b/pkg/cmd/constants.go
@@ -2,6 +2,6 @@ package cmd
 
 const (
 	FlagDataName                  = "data"
-	FlagDataTemplateName          = "dataTemplate"
+	FlagDataTemplateName          = "template"
 	FlagDataTemplateVariablesName = "templateVars"
 )

--- a/pkg/cmd/createAgentCmd.auto.go
+++ b/pkg/cmd/createAgentCmd.auto.go
@@ -93,6 +93,9 @@ func (n *createAgentCmd) createAgent(cmd *cobra.Command, args []string) error {
   com_cumulocity_model_Agent: {},
 }
 `, false)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/createAgentCmd.auto.go
+++ b/pkg/cmd/createAgentCmd.auto.go
@@ -88,13 +88,19 @@ func (n *createAgentCmd) createAgent(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "type", err))
 	}
-	body.MergeJsonnet(`
+	bodyErr := body.MergeJsonnet(`
 {  c8y_IsDevice: {},
   com_cumulocity_model_Agent: {},
 }
 `, false)
+	if bodyErr != nil {
+		return newSystemError("Template error. ", bodyErr)
+	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/createDeviceCmd.auto.go
+++ b/pkg/cmd/createDeviceCmd.auto.go
@@ -95,6 +95,9 @@ func (n *createDeviceCmd) createDevice(cmd *cobra.Command, args []string) error 
 {  c8y_IsDevice: {},
 }
 `, false)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/createDeviceCmd.auto.go
+++ b/pkg/cmd/createDeviceCmd.auto.go
@@ -91,12 +91,18 @@ func (n *createDeviceCmd) createDevice(cmd *cobra.Command, args []string) error 
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "type", err))
 	}
-	body.MergeJsonnet(`
+	bodyErr := body.MergeJsonnet(`
 {  c8y_IsDevice: {},
 }
 `, false)
+	if bodyErr != nil {
+		return newSystemError("Template error. ", bodyErr)
+	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/createDeviceGroupCmd.auto.go
+++ b/pkg/cmd/createDeviceGroupCmd.auto.go
@@ -87,13 +87,19 @@ func (n *createDeviceGroupCmd) createDeviceGroup(cmd *cobra.Command, args []stri
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "type", err))
 	}
-	body.MergeJsonnet(`
+	bodyErr := body.MergeJsonnet(`
 {  type: "c8y_DeviceGroup",
   c8y_IsDeviceGroup: {},
 }
 `, true)
+	if bodyErr != nil {
+		return newSystemError("Template error. ", bodyErr)
+	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/createDeviceGroupCmd.auto.go
+++ b/pkg/cmd/createDeviceGroupCmd.auto.go
@@ -92,6 +92,9 @@ func (n *createDeviceGroupCmd) createDeviceGroup(cmd *cobra.Command, args []stri
   c8y_IsDeviceGroup: {},
 }
 `, true)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/cumulocityProperties.go
+++ b/pkg/cmd/cumulocityProperties.go
@@ -1,0 +1,29 @@
+package cmd
+
+// CumulocityProperties contain a map of the static properties which are generally read-only and only
+// controlled internally by Cumulocity or by other API calls
+var CumulocityProperties = map[string]bool{
+	"additionParents": true,
+	"assetParents":    true,
+	"childAdditions":  true,
+	"childAssets":     true,
+	"childDevices":    true,
+	"deviceParents":   true,
+	"creationTime":    true,
+	"lastUpdated":     true,
+	"self":            true,
+}
+
+// RemoveCumulocityProperties removes cumulocity properties from a map so it can be
+// re-used in further Cumulocity requests, or the data view can be simplified
+func RemoveCumulocityProperties(data map[string]interface{}, removeID bool) map[string]interface{} {
+	for key := range CumulocityProperties {
+		delete(data, key)
+	}
+
+	if removeID {
+		delete(data, "id")
+		delete(data, "owner")
+	}
+	return data
+}

--- a/pkg/cmd/cumulocityProperties_test.go
+++ b/pkg/cmd/cumulocityProperties_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func Test_RemoveCumulocityPropertiesWithID(t *testing.T) {
+
+	jsonStr := `
+	{
+		"owner": "user@example.com",
+		"additionParents": {
+			"self": "https://example.com/inventory/managedObjects/45872/additionParents",
+			"references": []
+		},
+		"childDevices": {
+			"self": "https://example.com/inventory/managedObjects/45872/childDevices",
+			"references": []
+		},
+		"childAssets": {
+			"self": "https://example.com/inventory/managedObjects/45872/childAssets",
+			"references": []
+		},
+		"creationTime": "2020-09-26T07:05:24.010Z",
+		"lastUpdated": "2020-09-26T07:05:24.010Z",
+		"childAdditions": {
+			"self": "https://example.com/inventory/managedObjects/45872/childAdditions",
+			"references": []
+		},
+		"name": "testdevice_qfwd5y6bkl",
+		"assetParents": {
+			"self": "https://example.com/inventory/managedObjects/45872/assetParents",
+			"references": []
+		},
+		"deviceParents": {
+			"self": "https://example.com/inventory/managedObjects/45872/deviceParents",
+			"references": []
+		},
+		"self": "https://example.com/inventory/managedObjects/45872",
+		"id": "45872",
+		"c8y_IsDevice": {}
+	}
+	`
+	data := RemoveCumulocityProperties(MustParseJSON(jsonStr), true)
+
+	if _, ok := data["id"]; ok {
+		t.Errorf("%s field should not exist. wanted=not-exists, got=exists", "id")
+	}
+
+	if _, ok := data["creationTime"]; ok {
+		t.Errorf("%s field should not exist. wanted=not-exists, got=exists", "creationTime")
+	}
+
+	data = RemoveCumulocityProperties(MustParseJSON(jsonStr), false)
+
+	if _, ok := data["id"]; !ok {
+		t.Errorf("%s field should exist. wanted=exists, got=not-exists", "id")
+	}
+}

--- a/pkg/cmd/enableApplicationOnTenantCmd.auto.go
+++ b/pkg/cmd/enableApplicationOnTenantCmd.auto.go
@@ -88,6 +88,9 @@ func (n *enableApplicationOnTenantCmd) enableApplicationOnTenant(cmd *cobra.Comm
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/enableApplicationOnTenantCmd.auto.go
+++ b/pkg/cmd/enableApplicationOnTenantCmd.auto.go
@@ -85,6 +85,9 @@ func (n *enableApplicationOnTenantCmd) enableApplicationOnTenant(cmd *cobra.Comm
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/enableMicroserviceCmd.auto.go
+++ b/pkg/cmd/enableMicroserviceCmd.auto.go
@@ -92,6 +92,9 @@ func (n *enableMicroserviceCmd) enableMicroservice(cmd *cobra.Command, args []st
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/enableMicroserviceCmd.auto.go
+++ b/pkg/cmd/enableMicroserviceCmd.auto.go
@@ -89,6 +89,9 @@ func (n *enableMicroserviceCmd) enableMicroservice(cmd *cobra.Command, args []st
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/executeTemplateCmd.manual.go
+++ b/pkg/cmd/executeTemplateCmd.manual.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/jsonUtilities"
+	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
+	"github.com/spf13/cobra"
+	"github.com/tidwall/pretty"
+)
+
+type executeTemplateCmd struct {
+	*baseCmd
+}
+
+func newExecuteTemplateCmd() *executeTemplateCmd {
+	ccmd := &executeTemplateCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "execute",
+		Short: "Execute a jsonnet template",
+		Long:  `Execute a jsonnet template and return the output. Useful when creating new templates`,
+		Example: `
+Example 1:
+$ c8y template execute --template ./mytemplate.jsonnet
+
+Verify a jsonnet template and show the output after it is evaluated
+
+Example 2:
+$ c8y template execute --template ./mytemplate.jsonnet --templateVars "name=testme" --data "name=myDeviceName"
+
+Verify a jsonnet template and specify input data to be used as the input when evaluating the template
+		`,
+		RunE: ccmd.newTemplate,
+	}
+
+	cmd.SilenceUsage = true
+
+	addDataFlag(cmd)
+
+	// Required flags
+	cmd.MarkFlagRequired(FlagDataTemplateName)
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *executeTemplateCmd) newTemplate(cmd *cobra.Command, args []string) error {
+
+	// body
+	body := mapbuilder.NewMapBuilder()
+	body.SetMap(getDataFlag(cmd))
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
+
+	responseText, err := body.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	isJSONResponse := jsonUtilities.IsValidJSON([]byte(responseText))
+
+	outputEnding := ""
+	if len(responseText) > 0 {
+		outputEnding = "\n"
+	}
+
+	if globalFlagPrettyPrint && isJSONResponse {
+		fmt.Printf("%s%s", pretty.Pretty(bytes.TrimSpace(responseText)), outputEnding)
+	} else {
+		fmt.Printf("%s%s", bytes.TrimSpace(responseText), outputEnding)
+	}
+	return nil
+}

--- a/pkg/cmd/genericRestCmd.go
+++ b/pkg/cmd/genericRestCmd.go
@@ -122,9 +122,9 @@ func (n *getGenericRestCmd) getGenericRest(cmd *cobra.Command, args []string) er
 	if method == "PUT" || method == "POST" {
 		req.Body = getDataFlag(cmd)
 
-		if !cmd.Flags().Changed(FlagDataName) && !cmd.Flags().Changed("file") {
-			return newUserError("Missing required arguments. Either --data or --file are required")
-		}
+		//if !cmd.Flags().Changed(FlagDataName) && !cmd.Flags().Changed("file") {
+		//	return newUserError("Missing required arguments. Either --data or --file are required")
+		//}
 
 		// get file info
 		req.FormData = make(map[string]io.Reader)

--- a/pkg/cmd/inventoryFlags.go
+++ b/pkg/cmd/inventoryFlags.go
@@ -65,9 +65,12 @@ func getDataFlag(cmd *cobra.Command) map[string]interface{} {
 
 func setDataTemplateFromFlags(cmd *cobra.Command, body *mapbuilder.MapBuilder) error {
 
+	if !cmd.Flags().Changed(FlagDataTemplateName) {
+		return nil
+	}
+
 	if value, err := cmd.Flags().GetString(FlagDataTemplateVariablesName); err == nil {
 		content := getContents(value)
-		MustParseJSON(content)
 		Logger.Infof("Template variables: %s\n", content)
 		body.SetTemplateVariables(MustParseJSON(content))
 	}

--- a/pkg/cmd/inventoryFlags.go
+++ b/pkg/cmd/inventoryFlags.go
@@ -52,6 +52,10 @@ func addDataFlag(cmd *cobra.Command) {
 	cmd.Flags().String(FlagDataTemplateVariablesName, "", "Body template variables")
 }
 
+func addDataFlagWithoutTemplates(cmd *cobra.Command) {
+	cmd.Flags().StringP(FlagDataName, "d", "", "json")
+}
+
 func getDataFlag(cmd *cobra.Command) map[string]interface{} {
 	if value, err := cmd.Flags().GetString(FlagDataName); err == nil {
 		return RemoveCumulocityProperties(MustParseJSON(getContents(value)), true)

--- a/pkg/cmd/inventoryFlags.go
+++ b/pkg/cmd/inventoryFlags.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
 	"github.com/spf13/cobra"
 )
@@ -70,14 +70,10 @@ func setDataTemplateFromFlags(cmd *cobra.Command, body *mapbuilder.MapBuilder) e
 
 	if value, err := cmd.Flags().GetString(FlagDataTemplateName); err == nil {
 		contents := getContents(value)
-		Logger.Infof("Template: %s\n", contents)
-		tempVars, err := body.GetTemplateVariablesJsonnet()
-		Logger.Infof("Template: %s\n", tempVars)
 		body.SetTemplate(contents)
-		body.ApplyTemplate(false)
-
-		output, err := body.MarshalJSON()
-		Logger.Infof("Body after applying template\n: %s\nerr: %s\n", output, err)
+		if err := body.ApplyTemplate(false); err != nil {
+			return errors.Wrap(err, "Template error")
+		}
 	}
 
 	return nil

--- a/pkg/cmd/inventoryFlags.go
+++ b/pkg/cmd/inventoryFlags.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
 	"github.com/spf13/cobra"
 )
 
@@ -49,9 +50,23 @@ func addDataFlag(cmd *cobra.Command) {
 
 func getDataFlag(cmd *cobra.Command) map[string]interface{} {
 	if value, err := cmd.Flags().GetString(FlagDataName); err == nil {
-		return MustParseJSON(getContents(value))
+		return RemoveCumulocityProperties(MustParseJSON(getContents(value)), true)
 	}
 	return make(map[string]interface{})
+}
+
+func setDataTemplateFromFlags(cmd *cobra.Command, body *mapbuilder.MapBuilder) error {
+
+	if value, err := cmd.Flags().GetString(FlagDataTemplateVariablesName); err == nil {
+		body.SetTemplateVariables(MustParseJSON(getContents(value)))
+	}
+
+	if value, err := cmd.Flags().GetString(FlagDataTemplateName); err == nil {
+		body.SetTemplate(value)
+		body.ApplyTemplate(false)
+	}
+
+	return nil
 }
 
 // getContents checks whether the given string is a file reference if so it returns the contents, otherwise it returns the

--- a/pkg/cmd/listSettingsCmd.manual.go
+++ b/pkg/cmd/listSettingsCmd.manual.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tidwall/pretty"
+)
+
+type listSettingsCmd struct {
+	*baseCmd
+}
+
+func newListSettingsCmd() *listSettingsCmd {
+	ccmd := &listSettingsCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Show the current settings",
+		Long:  `Show the current settings which are being used by the cli tool`,
+		Example: `
+$ c8y settings list
+
+Show the active cli settings
+		`,
+		RunE: ccmd.listSettings,
+	}
+
+	cmd.SilenceUsage = true
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *listSettingsCmd) listSettings(cmd *cobra.Command, args []string) error {
+
+	settings := map[string]interface{}{}
+
+	settings["session.home"] = getSessionHomeDir()
+
+	settings[SettingsTemplatePath] = globalFlagTemplatePath
+	settings[SettingsDefaultPageSize] = globalFlagPageSize
+	settings[SettingsIncludeAllPageSize] = globalFlagIncludeAllPageSize
+	settings[SettingsIncludeAllDelayMS] = globalFlagIncludeAllDelayMS
+
+	responseText, err := json.Marshal(settings)
+
+	if err != nil {
+		return newUserError("Settings error. ", err)
+	}
+
+	if globalFlagPrettyPrint {
+		fmt.Printf("%s", pretty.Pretty(bytes.TrimSpace(responseText)))
+	} else {
+		fmt.Printf("%s\n", bytes.TrimSpace(responseText))
+	}
+	return nil
+}

--- a/pkg/cmd/newAlarmCmd.auto.go
+++ b/pkg/cmd/newAlarmCmd.auto.go
@@ -128,6 +128,9 @@ func (n *newAlarmCmd) newAlarm(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "status", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newAlarmCmd.auto.go
+++ b/pkg/cmd/newAlarmCmd.auto.go
@@ -33,18 +33,15 @@ Create a new alarm for device
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject that the alarm originated from (required)")
-	cmd.Flags().String("type", "", "Identifies the type of this alarm, e.g. 'com_cumulocity_events_TamperEvent'. (required)")
-	cmd.Flags().String("time", "0s", "Time of the alarm.")
-	cmd.Flags().String("text", "", "Text description of the alarm. (required)")
-	cmd.Flags().String("severity", "", "The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case. (required)")
+	cmd.Flags().String("type", "", "Identifies the type of this alarm, e.g. 'com_cumulocity_events_TamperEvent'.")
+	cmd.Flags().String("time", "0s", "Time of the alarm. Defaults to current timestamp.")
+	cmd.Flags().String("text", "", "Text description of the alarm.")
+	cmd.Flags().String("severity", "", "The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case.")
 	cmd.Flags().String("status", "", "The status of the alarm: ACTIVE, ACKNOWLEDGED or CLEARED. If status was not appeared, new alarm will have status ACTIVE. Must be upper-case.")
 	addDataFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
-	cmd.MarkFlagRequired("type")
-	cmd.MarkFlagRequired("text")
-	cmd.MarkFlagRequired("severity")
 
 	ccmd.baseCmd = newBaseCmd(cmd)
 
@@ -130,6 +127,10 @@ func (n *newAlarmCmd) newAlarm(cmd *cobra.Command, args []string) error {
 	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	body.SetRequiredKeys("type", "text", "time", "severity")
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/newApplicationBinaryCmd.auto.go
+++ b/pkg/cmd/newApplicationBinaryCmd.auto.go
@@ -75,6 +75,9 @@ func (n *newApplicationBinaryCmd) newApplicationBinary(cmd *cobra.Command, args 
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
 	getFileFlag(cmd, "file", formData)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newApplicationBinaryCmd.auto.go
+++ b/pkg/cmd/newApplicationBinaryCmd.auto.go
@@ -78,6 +78,9 @@ func (n *newApplicationBinaryCmd) newApplicationBinary(cmd *cobra.Command, args 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newApplicationCmd.auto.go
+++ b/pkg/cmd/newApplicationCmd.auto.go
@@ -144,6 +144,9 @@ func (n *newApplicationCmd) newApplication(cmd *cobra.Command, args []string) er
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newApplicationCmd.auto.go
+++ b/pkg/cmd/newApplicationCmd.auto.go
@@ -141,6 +141,9 @@ func (n *newApplicationCmd) newApplication(cmd *cobra.Command, args []string) er
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "externalUrl", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newAuditCmd.auto.go
+++ b/pkg/cmd/newAuditCmd.auto.go
@@ -33,7 +33,7 @@ Create an audit record for a custom managed object update
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("type", "", "Identifies the type of this audit record. (required)")
-	cmd.Flags().String("time", "0s", "Time of the audit record.")
+	cmd.Flags().String("time", "0s", "Time of the audit record. Defaults to current timestamp.")
 	cmd.Flags().String("text", "", "Text description of the audit record. (required)")
 	cmd.Flags().String("source", "", "An optional ManagedObject that the audit record originated from (required)")
 	cmd.Flags().String("activity", "", "The activity that was carried out. (required)")
@@ -137,6 +137,9 @@ func (n *newAuditCmd) newAudit(cmd *cobra.Command, args []string) error {
 	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/newAuditCmd.auto.go
+++ b/pkg/cmd/newAuditCmd.auto.go
@@ -135,6 +135,9 @@ func (n *newAuditCmd) newAudit(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "application", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newBinaryCmd.auto.go
+++ b/pkg/cmd/newBinaryCmd.auto.go
@@ -68,6 +68,9 @@ func (n *newBinaryCmd) newBinary(cmd *cobra.Command, args []string) error {
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
 	getFileFlag(cmd, "file", formData)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newBinaryCmd.auto.go
+++ b/pkg/cmd/newBinaryCmd.auto.go
@@ -75,6 +75,9 @@ func (n *newBinaryCmd) newBinary(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newBinaryCmd.auto.go
+++ b/pkg/cmd/newBinaryCmd.auto.go
@@ -26,6 +26,9 @@ func newNewBinaryCmd() *newBinaryCmd {
 		Example: `
 $ c8y binaries create --file ./output.log
 Upload a log file
+
+$ c8y binaries create --file "myConfig.json" --data "c8y_Global={},type=c8y_upload"
+Upload a config file and make it globally accessible for all users
 		`,
 		RunE: ccmd.newBinary,
 	}
@@ -33,6 +36,7 @@ Upload a log file
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
+	addDataFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("file")

--- a/pkg/cmd/newEventBinaryCmd.auto.go
+++ b/pkg/cmd/newEventBinaryCmd.auto.go
@@ -70,6 +70,9 @@ func (n *newEventBinaryCmd) newEventBinary(cmd *cobra.Command, args []string) er
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
 	getFileFlag(cmd, "file", formData)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newEventBinaryCmd.auto.go
+++ b/pkg/cmd/newEventBinaryCmd.auto.go
@@ -73,6 +73,9 @@ func (n *newEventBinaryCmd) newEventBinary(cmd *cobra.Command, args []string) er
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newEventCmd.auto.go
+++ b/pkg/cmd/newEventCmd.auto.go
@@ -33,15 +33,13 @@ Create a new event for a device
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject which is the source of this event. (required)")
-	cmd.Flags().String("time", "0s", "Time of the event.")
-	cmd.Flags().String("type", "", "Identifies the type of this event. (required)")
-	cmd.Flags().String("text", "", "Text description of the event. (required)")
+	cmd.Flags().String("time", "0s", "Time of the event. Defaults to current timestamp.")
+	cmd.Flags().String("type", "", "Identifies the type of this event.")
+	cmd.Flags().String("text", "", "Text description of the event.")
 	addDataFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
-	cmd.MarkFlagRequired("type")
-	cmd.MarkFlagRequired("text")
 
 	ccmd.baseCmd = newBaseCmd(cmd)
 
@@ -113,6 +111,10 @@ func (n *newEventCmd) newEvent(cmd *cobra.Command, args []string) error {
 	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	body.SetRequiredKeys("type", "text", "time")
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/newEventCmd.auto.go
+++ b/pkg/cmd/newEventCmd.auto.go
@@ -111,6 +111,9 @@ func (n *newEventCmd) newEvent(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "text", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newExternalIDCmd.auto.go
+++ b/pkg/cmd/newExternalIDCmd.auto.go
@@ -85,6 +85,9 @@ func (n *newExternalIDCmd) newExternalID(cmd *cobra.Command, args []string) erro
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "name", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newExternalIDCmd.auto.go
+++ b/pkg/cmd/newExternalIDCmd.auto.go
@@ -88,6 +88,9 @@ func (n *newExternalIDCmd) newExternalID(cmd *cobra.Command, args []string) erro
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newGroupCmd.auto.go
+++ b/pkg/cmd/newGroupCmd.auto.go
@@ -74,6 +74,9 @@ func (n *newGroupCmd) newGroup(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "name", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newGroupCmd.auto.go
+++ b/pkg/cmd/newGroupCmd.auto.go
@@ -77,6 +77,9 @@ func (n *newGroupCmd) newGroup(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
@@ -106,6 +106,9 @@ func (n *newManagedObjectChildAssetCmd) newManagedObjectChildAsset(cmd *cobra.Co
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
@@ -103,6 +103,9 @@ func (n *newManagedObjectChildAssetCmd) newManagedObjectChildAsset(cmd *cobra.Co
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
@@ -86,6 +86,9 @@ func (n *newManagedObjectChildDeviceCmd) newManagedObjectChildDevice(cmd *cobra.
 			}
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
@@ -89,6 +89,9 @@ func (n *newManagedObjectChildDeviceCmd) newManagedObjectChildDevice(cmd *cobra.
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newManagedObjectCmd.auto.go
+++ b/pkg/cmd/newManagedObjectCmd.auto.go
@@ -82,6 +82,9 @@ func (n *newManagedObjectCmd) newManagedObject(cmd *cobra.Command, args []string
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "type", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newManagedObjectCmd.auto.go
+++ b/pkg/cmd/newManagedObjectCmd.auto.go
@@ -85,6 +85,9 @@ func (n *newManagedObjectCmd) newManagedObject(cmd *cobra.Command, args []string
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newMeasurementCmd.auto.go
+++ b/pkg/cmd/newMeasurementCmd.auto.go
@@ -103,6 +103,9 @@ func (n *newMeasurementCmd) newMeasurement(cmd *cobra.Command, args []string) er
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "type", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newMeasurementCmd.auto.go
+++ b/pkg/cmd/newMeasurementCmd.auto.go
@@ -33,14 +33,12 @@ Create measurement
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject which is the source of this measurement. (required)")
-	cmd.Flags().String("time", "", "Time of the measurement. (required)")
-	cmd.Flags().String("type", "", "The most specific type of this entire measurement. (required)")
+	cmd.Flags().String("time", "0s", "Time of the measurement. Defaults to current timestamp.")
+	cmd.Flags().String("type", "", "The most specific type of this entire measurement.")
 	addDataFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
-	cmd.MarkFlagRequired("time")
-	cmd.MarkFlagRequired("type")
 
 	ccmd.baseCmd = newBaseCmd(cmd)
 
@@ -105,6 +103,10 @@ func (n *newMeasurementCmd) newMeasurement(cmd *cobra.Command, args []string) er
 	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	body.SetRequiredKeys("type", "time")
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/newMicroserviceBinaryCmd.auto.go
+++ b/pkg/cmd/newMicroserviceBinaryCmd.auto.go
@@ -78,6 +78,9 @@ func (n *newMicroserviceBinaryCmd) newMicroserviceBinary(cmd *cobra.Command, arg
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newMicroserviceBinaryCmd.auto.go
+++ b/pkg/cmd/newMicroserviceBinaryCmd.auto.go
@@ -75,6 +75,9 @@ func (n *newMicroserviceBinaryCmd) newMicroserviceBinary(cmd *cobra.Command, arg
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
 	getFileFlag(cmd, "file", formData)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newMicroserviceCmd.go
+++ b/pkg/cmd/newMicroserviceCmd.go
@@ -45,7 +45,7 @@ Create new microservice
 
 	cmd.SilenceUsage = true
 
-	addDataFlag(cmd)
+	addDataFlagWithoutTemplates(cmd)
 	cmd.Flags().StringVar(&ccmd.file, "file", "", "Microservice file to be uploaded (or Cumulocity.json) file")
 	cmd.Flags().StringVar(&ccmd.name, "name", "", "Name of application")
 	cmd.Flags().StringVar(&ccmd.key, "key", "", "Shared secret of application")
@@ -81,7 +81,7 @@ func (n *newMicroserviceCmd) getApplicationDetails() *c8y.Application {
 		app.Name = n.name
 	}
 
-	app.Key = app.Name + "-microservice-key"
+	app.Key = app.Name
 	if n.key != "" {
 		app.Key = n.key
 	}

--- a/pkg/cmd/newOperationCmd.auto.go
+++ b/pkg/cmd/newOperationCmd.auto.go
@@ -93,6 +93,9 @@ func (n *newOperationCmd) newOperation(cmd *cobra.Command, args []string) error 
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "description", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newOperationCmd.auto.go
+++ b/pkg/cmd/newOperationCmd.auto.go
@@ -96,6 +96,9 @@ func (n *newOperationCmd) newOperation(cmd *cobra.Command, args []string) error 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newRetentionRuleCmd.auto.go
+++ b/pkg/cmd/newRetentionRuleCmd.auto.go
@@ -114,6 +114,9 @@ func (n *newRetentionRuleCmd) newRetentionRule(cmd *cobra.Command, args []string
 			return newUserError("Flag does not exist")
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newRetentionRuleCmd.auto.go
+++ b/pkg/cmd/newRetentionRuleCmd.auto.go
@@ -117,6 +117,9 @@ func (n *newRetentionRuleCmd) newRetentionRule(cmd *cobra.Command, args []string
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newTenantCmd.auto.go
+++ b/pkg/cmd/newTenantCmd.auto.go
@@ -127,6 +127,9 @@ func (n *newTenantCmd) newTenant(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newTenantCmd.auto.go
+++ b/pkg/cmd/newTenantCmd.auto.go
@@ -124,6 +124,9 @@ func (n *newTenantCmd) newTenant(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "tenantId", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newTenantOptionCmd.auto.go
+++ b/pkg/cmd/newTenantOptionCmd.auto.go
@@ -95,6 +95,9 @@ func (n *newTenantOptionCmd) newTenantOption(cmd *cobra.Command, args []string) 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newTenantOptionCmd.auto.go
+++ b/pkg/cmd/newTenantOptionCmd.auto.go
@@ -92,6 +92,9 @@ func (n *newTenantOptionCmd) newTenantOption(cmd *cobra.Command, args []string) 
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "value", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newUserCmd.auto.go
+++ b/pkg/cmd/newUserCmd.auto.go
@@ -142,6 +142,9 @@ func (n *newUserCmd) newUser(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/newUserCmd.auto.go
+++ b/pkg/cmd/newUserCmd.auto.go
@@ -139,6 +139,9 @@ func (n *newUserCmd) newUser(cmd *cobra.Command, args []string) error {
 			return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "customProperties", err))
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/registerNewDeviceCmd.auto.go
+++ b/pkg/cmd/registerNewDeviceCmd.auto.go
@@ -77,6 +77,9 @@ func (n *registerNewDeviceCmd) registerNewDevice(cmd *cobra.Command, args []stri
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/registerNewDeviceCmd.auto.go
+++ b/pkg/cmd/registerNewDeviceCmd.auto.go
@@ -74,6 +74,9 @@ func (n *registerNewDeviceCmd) registerNewDevice(cmd *cobra.Command, args []stri
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "id", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/requestDeviceCredentialsCmd.auto.go
+++ b/pkg/cmd/requestDeviceCredentialsCmd.auto.go
@@ -77,6 +77,9 @@ func (n *requestDeviceCredentialsCmd) requestDeviceCredentials(cmd *cobra.Comman
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/requestDeviceCredentialsCmd.auto.go
+++ b/pkg/cmd/requestDeviceCredentialsCmd.auto.go
@@ -74,6 +74,9 @@ func (n *requestDeviceCredentialsCmd) requestDeviceCredentials(cmd *cobra.Comman
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "id", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/resetUserPasswordCmd.auto.go
+++ b/pkg/cmd/resetUserPasswordCmd.auto.go
@@ -79,6 +79,9 @@ func (n *resetUserPasswordCmd) resetUserPassword(cmd *cobra.Command, args []stri
 	body.MergeJsonnet(`
 addIfEmptyString(base, "password", {sendPasswordResetEmail: true})
 `, false)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/resetUserPasswordCmd.auto.go
+++ b/pkg/cmd/resetUserPasswordCmd.auto.go
@@ -76,11 +76,17 @@ func (n *resetUserPasswordCmd) resetUserPassword(cmd *cobra.Command, args []stri
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "newPassword", err))
 	}
-	body.MergeJsonnet(`
+	bodyErr := body.MergeJsonnet(`
 addIfEmptyString(base, "password", {sendPasswordResetEmail: true})
 `, false)
+	if bodyErr != nil {
+		return newSystemError("Template error. ", bodyErr)
+	}
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
 	}
 
 	// path parameters

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -108,6 +108,7 @@ func checkSessionExists(cmd *cobra.Command, args []string) error {
 	localCmds := []string{
 		"completion",
 		"sessions",
+		"template",
 		"version",
 	}
 
@@ -168,6 +169,9 @@ func Execute() {
 
 	// generic commands
 	rootCmd.AddCommand(newGetGenericRestCmd().getCommand())
+
+	// template commands
+	rootCmd.AddCommand(newTemplateRootCmd().getCommand())
 
 	// Auto generated commands
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -74,6 +74,7 @@ var (
 	globalFlagTimeout            uint
 	globalFlagUseTenantPrefix    bool
 	globalUseNonDefaultPageSize  bool
+	globalFlagTemplatePath       string
 )
 
 // CumulocityDefaultPageSize is the default page size used by Cumulocity
@@ -91,6 +92,9 @@ const (
 
 	// SettingsConfigPath configuration path
 	SettingsConfigPath string = "settings.path"
+
+	// SettingsTemplatePath template path where the template files are located
+	SettingsTemplatePath string = "settings.template.path"
 )
 
 // SettingsGlobalName name of the settings file (without extension)
@@ -172,6 +176,9 @@ func Execute() {
 
 	// template commands
 	rootCmd.AddCommand(newTemplateRootCmd().getCommand())
+
+	// settings commands
+	rootCmd.AddCommand(newSettingsRootCmd().getCommand())
 
 	// Auto generated commands
 
@@ -452,6 +459,7 @@ func loadConfiguration() error {
 	bindEnv(SettingsIncludeAllPageSize, 2000)
 	bindEnv(SettingsDefaultPageSize, CumulocityDefaultPageSize)
 	bindEnv(SettingsIncludeAllDelayMS, 0)
+	bindEnv(SettingsTemplatePath, "")
 
 	return nil
 }
@@ -461,10 +469,12 @@ func readConfiguration() error {
 	globalFlagIncludeAllPageSize = viper.GetInt(SettingsIncludeAllPageSize)
 	globalFlagPageSize = viper.GetInt(SettingsDefaultPageSize)
 	globalFlagIncludeAllDelayMS = viper.GetInt64(SettingsIncludeAllDelayMS)
+	globalFlagTemplatePath = viper.GetString(SettingsTemplatePath)
 
 	Logger.Infof("%s: %d", SettingsDefaultPageSize, globalFlagPageSize)
 	Logger.Infof("%s: %d", SettingsIncludeAllPageSize, globalFlagIncludeAllPageSize)
 	Logger.Infof("%s: %d", SettingsIncludeAllDelayMS, globalFlagIncludeAllDelayMS)
+	Logger.Infof("%s: %s", SettingsTemplatePath, globalFlagTemplatePath)
 
 	return nil
 }

--- a/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
+++ b/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
@@ -74,6 +74,9 @@ func (n *setDeviceRequiredAvailabilityCmd) setDeviceRequiredAvailability(cmd *co
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "interval", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
+++ b/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
@@ -77,6 +77,9 @@ func (n *setDeviceRequiredAvailabilityCmd) setDeviceRequiredAvailability(cmd *co
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/settingsRootCmd.go
+++ b/pkg/cmd/settingsRootCmd.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type settingsCmd struct {
+	*baseCmd
+}
+
+func newSettingsRootCmd() *settingsCmd {
+	ccmd := &settingsCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "settings",
+		Short: "Settings",
+		Long:  `Settings commands`,
+	}
+
+	// Subcommands
+	cmd.AddCommand(newListSettingsCmd().getCommand())
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}

--- a/pkg/cmd/templateRootCmd.go
+++ b/pkg/cmd/templateRootCmd.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type templateCmd struct {
+	*baseCmd
+}
+
+func newTemplateRootCmd() *templateCmd {
+	ccmd := &templateCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Template utilities",
+		Long:  `Template utilities which can be used for testing out the templating language without sending any data to Cumulocity`,
+	}
+
+	// Subcommands
+	cmd.AddCommand(newExecuteTemplateCmd().getCommand())
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}

--- a/pkg/cmd/updateAgentCmd.auto.go
+++ b/pkg/cmd/updateAgentCmd.auto.go
@@ -79,6 +79,9 @@ func (n *updateAgentCmd) updateAgent(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateAgentCmd.auto.go
+++ b/pkg/cmd/updateAgentCmd.auto.go
@@ -76,6 +76,9 @@ func (n *updateAgentCmd) updateAgent(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "newName", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateAlarmCmd.auto.go
+++ b/pkg/cmd/updateAlarmCmd.auto.go
@@ -98,6 +98,9 @@ func (n *updateAlarmCmd) updateAlarm(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateAlarmCmd.auto.go
+++ b/pkg/cmd/updateAlarmCmd.auto.go
@@ -95,6 +95,9 @@ func (n *updateAlarmCmd) updateAlarm(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "text", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/updateAlarmCollectionCmd.auto.go
@@ -135,6 +135,9 @@ func (n *updateAlarmCollectionCmd) updateAlarmCollection(cmd *cobra.Command, arg
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/updateAlarmCollectionCmd.auto.go
@@ -132,6 +132,9 @@ func (n *updateAlarmCollectionCmd) updateAlarmCollection(cmd *cobra.Command, arg
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "newStatus", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateApplicationCmd.auto.go
+++ b/pkg/cmd/updateApplicationCmd.auto.go
@@ -132,6 +132,9 @@ func (n *updateApplicationCmd) updateApplication(cmd *cobra.Command, args []stri
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "externalUrl", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateApplicationCmd.auto.go
+++ b/pkg/cmd/updateApplicationCmd.auto.go
@@ -135,6 +135,9 @@ func (n *updateApplicationCmd) updateApplication(cmd *cobra.Command, args []stri
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateBinaryCmd.auto.go
+++ b/pkg/cmd/updateBinaryCmd.auto.go
@@ -74,6 +74,9 @@ func (n *updateBinaryCmd) updateBinary(cmd *cobra.Command, args []string) error 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateBinaryCmd.auto.go
+++ b/pkg/cmd/updateBinaryCmd.auto.go
@@ -71,6 +71,9 @@ func (n *updateBinaryCmd) updateBinary(cmd *cobra.Command, args []string) error 
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
 	getFileFlag(cmd, "file", formData)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateCurrentApplicationCmd.auto.go
+++ b/pkg/cmd/updateCurrentApplicationCmd.auto.go
@@ -133,6 +133,9 @@ func (n *updateCurrentApplicationCmd) updateCurrentApplication(cmd *cobra.Comman
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateCurrentApplicationCmd.auto.go
+++ b/pkg/cmd/updateCurrentApplicationCmd.auto.go
@@ -130,6 +130,9 @@ func (n *updateCurrentApplicationCmd) updateCurrentApplication(cmd *cobra.Comman
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "externalUrl", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateDataBrokerCmd.auto.go
+++ b/pkg/cmd/updateDataBrokerCmd.auto.go
@@ -80,6 +80,9 @@ func (n *updateDataBrokerCmd) updateDataBroker(cmd *cobra.Command, args []string
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateDataBrokerCmd.auto.go
+++ b/pkg/cmd/updateDataBrokerCmd.auto.go
@@ -77,6 +77,9 @@ func (n *updateDataBrokerCmd) updateDataBroker(cmd *cobra.Command, args []string
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "status", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateDeviceCmd.auto.go
+++ b/pkg/cmd/updateDeviceCmd.auto.go
@@ -76,6 +76,9 @@ func (n *updateDeviceCmd) updateDevice(cmd *cobra.Command, args []string) error 
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "newName", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateDeviceCmd.auto.go
+++ b/pkg/cmd/updateDeviceCmd.auto.go
@@ -79,6 +79,9 @@ func (n *updateDeviceCmd) updateDevice(cmd *cobra.Command, args []string) error 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateDeviceGroupCmd.auto.go
+++ b/pkg/cmd/updateDeviceGroupCmd.auto.go
@@ -80,6 +80,9 @@ func (n *updateDeviceGroupCmd) updateDeviceGroup(cmd *cobra.Command, args []stri
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateDeviceGroupCmd.auto.go
+++ b/pkg/cmd/updateDeviceGroupCmd.auto.go
@@ -77,6 +77,9 @@ func (n *updateDeviceGroupCmd) updateDeviceGroup(cmd *cobra.Command, args []stri
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "name", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateEventBinaryCmd.auto.go
+++ b/pkg/cmd/updateEventBinaryCmd.auto.go
@@ -71,6 +71,9 @@ func (n *updateEventBinaryCmd) updateEventBinary(cmd *cobra.Command, args []stri
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
 	getFileFlag(cmd, "file", formData)
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateEventBinaryCmd.auto.go
+++ b/pkg/cmd/updateEventBinaryCmd.auto.go
@@ -74,6 +74,9 @@ func (n *updateEventBinaryCmd) updateEventBinary(cmd *cobra.Command, args []stri
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateEventCmd.auto.go
+++ b/pkg/cmd/updateEventCmd.auto.go
@@ -82,6 +82,9 @@ func (n *updateEventCmd) updateEvent(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateEventCmd.auto.go
+++ b/pkg/cmd/updateEventCmd.auto.go
@@ -79,6 +79,9 @@ func (n *updateEventCmd) updateEvent(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "text", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateGroupCmd.auto.go
+++ b/pkg/cmd/updateGroupCmd.auto.go
@@ -79,6 +79,9 @@ func (n *updateGroupCmd) updateGroup(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateGroupCmd.auto.go
+++ b/pkg/cmd/updateGroupCmd.auto.go
@@ -76,6 +76,9 @@ func (n *updateGroupCmd) updateGroup(cmd *cobra.Command, args []string) error {
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "name", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateManagedObjectCmd.auto.go
+++ b/pkg/cmd/updateManagedObjectCmd.auto.go
@@ -79,6 +79,9 @@ func (n *updateManagedObjectCmd) updateManagedObject(cmd *cobra.Command, args []
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateManagedObjectCmd.auto.go
+++ b/pkg/cmd/updateManagedObjectCmd.auto.go
@@ -76,6 +76,9 @@ func (n *updateManagedObjectCmd) updateManagedObject(cmd *cobra.Command, args []
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "newName", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateMicroserviceCmd.auto.go
+++ b/pkg/cmd/updateMicroserviceCmd.auto.go
@@ -104,6 +104,9 @@ func (n *updateMicroserviceCmd) updateMicroservice(cmd *cobra.Command, args []st
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateMicroserviceCmd.auto.go
+++ b/pkg/cmd/updateMicroserviceCmd.auto.go
@@ -101,6 +101,9 @@ func (n *updateMicroserviceCmd) updateMicroservice(cmd *cobra.Command, args []st
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "resourcesUrl", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateOperationCmd.auto.go
+++ b/pkg/cmd/updateOperationCmd.auto.go
@@ -86,6 +86,9 @@ func (n *updateOperationCmd) updateOperation(cmd *cobra.Command, args []string) 
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "failureReason", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateOperationCmd.auto.go
+++ b/pkg/cmd/updateOperationCmd.auto.go
@@ -89,6 +89,9 @@ func (n *updateOperationCmd) updateOperation(cmd *cobra.Command, args []string) 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateRetentionRuleCmd.auto.go
+++ b/pkg/cmd/updateRetentionRuleCmd.auto.go
@@ -119,6 +119,9 @@ func (n *updateRetentionRuleCmd) updateRetentionRule(cmd *cobra.Command, args []
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateRetentionRuleCmd.auto.go
+++ b/pkg/cmd/updateRetentionRuleCmd.auto.go
@@ -116,6 +116,9 @@ func (n *updateRetentionRuleCmd) updateRetentionRule(cmd *cobra.Command, args []
 			return newUserError("Flag does not exist")
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantCmd.auto.go
+++ b/pkg/cmd/updateTenantCmd.auto.go
@@ -119,6 +119,9 @@ func (n *updateTenantCmd) updateTenant(cmd *cobra.Command, args []string) error 
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantCmd.auto.go
+++ b/pkg/cmd/updateTenantCmd.auto.go
@@ -116,6 +116,9 @@ func (n *updateTenantCmd) updateTenant(cmd *cobra.Command, args []string) error 
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "contactPhone", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantOptionBulkCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionBulkCmd.auto.go
@@ -72,6 +72,9 @@ func (n *updateTenantOptionBulkCmd) updateTenantOptionBulk(cmd *cobra.Command, a
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantOptionBulkCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionBulkCmd.auto.go
@@ -69,6 +69,9 @@ func (n *updateTenantOptionBulkCmd) updateTenantOptionBulk(cmd *cobra.Command, a
 	// body
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantOptionCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionCmd.auto.go
@@ -81,6 +81,9 @@ func (n *updateTenantOptionCmd) updateTenantOption(cmd *cobra.Command, args []st
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantOptionCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionCmd.auto.go
@@ -78,6 +78,9 @@ func (n *updateTenantOptionCmd) updateTenantOption(cmd *cobra.Command, args []st
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "value", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantOptionEditableCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionEditableCmd.auto.go
@@ -82,6 +82,9 @@ func (n *updateTenantOptionEditableCmd) updateTenantOptionEditable(cmd *cobra.Co
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateTenantOptionEditableCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionEditableCmd.auto.go
@@ -79,6 +79,9 @@ func (n *updateTenantOptionEditableCmd) updateTenantOptionEditable(cmd *cobra.Co
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "editable", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateUserCmd.auto.go
+++ b/pkg/cmd/updateUserCmd.auto.go
@@ -132,6 +132,9 @@ func (n *updateUserCmd) updateUser(cmd *cobra.Command, args []string) error {
 			return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "customProperties", err))
 		}
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateUserCmd.auto.go
+++ b/pkg/cmd/updateUserCmd.auto.go
@@ -135,6 +135,9 @@ func (n *updateUserCmd) updateUser(cmd *cobra.Command, args []string) error {
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateUserCurrentCmd.auto.go
+++ b/pkg/cmd/updateUserCurrentCmd.auto.go
@@ -114,6 +114,9 @@ func (n *updateUserCurrentCmd) updateUserCurrent(cmd *cobra.Command, args []stri
 	} else {
 		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "password", err))
 	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/updateUserCurrentCmd.auto.go
+++ b/pkg/cmd/updateUserCurrentCmd.auto.go
@@ -117,6 +117,9 @@ func (n *updateUserCurrentCmd) updateUserCurrent(cmd *cobra.Command, args []stri
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
 
 	// path parameters
 	pathParameters := make(map[string]string)

--- a/pkg/cmd/utilities.go
+++ b/pkg/cmd/utilities.go
@@ -35,6 +35,25 @@ func MustParseJSON(value string) map[string]interface{} {
 	return data
 }
 
+// ParseJSON parses a string and returns the map structure. It will parse json and shorthand json.
+func ParseJSON(value string, data map[string]interface{}) error {
+	if data == nil {
+		return errors.Errorf("data is nil. Can parse json into an empty map")
+	}
+
+	if isJSONString(value) {
+		if err := parseJSONStructure(value, data); err != nil {
+			return errors.Wrap(err, "Invalid JSON")
+		}
+		return nil
+	}
+
+	if err := parseShorthandJSONStructure(value, data); err != nil {
+		return errors.Wrap(err, "Invalid shorthand JSON")
+	}
+	return nil
+}
+
 func isJSONString(value string) bool {
 	value = strings.TrimSpace(value)
 	return strings.HasPrefix(value, "{") && strings.HasSuffix(value, "}")

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -160,7 +160,9 @@ func (b *MapBuilder) GetTemplateVariablesJsonnet() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("local vars = %s;\n", jsonStr), nil
+
+	varsHelper := `local var(prop, defaultValue="") = if std.objectHas(vars, prop) then vars[prop] else defaultValue;`
+	return fmt.Sprintf("local vars = %s;\n%s\n", jsonStr, varsHelper), nil
 }
 
 // SetMap sets a new map to the body. This will remove any existing values in the body

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -183,7 +183,7 @@ func (b *MapBuilder) GetTemplateVariablesJsonnet() (string, error) {
 	// Seed random otherwise it will not change with execution
 	rand.Seed(time.Now().UTC().UnixNano())
 	randomHelper := fmt.Sprintf(`local rand = { bool: %t, int: %d, int2: %d, float: %f, float2: %f, float3: %f, float4: %f };`, rand.Float32() > 0.5, rand.Intn(100), rand.Intn(100), rand.Float32(), rand.Float32(), rand.Float32(), rand.Float32())
-	return fmt.Sprintf("local vars = %s;\n%s\n%s\n", jsonStr, varsHelper, randomHelper), nil
+	return fmt.Sprintf("\nlocal vars = %s;\n%s\n%s\n", jsonStr, varsHelper, randomHelper), nil
 }
 
 // SetMap sets a new map to the body. This will remove any existing values in the body

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -116,6 +116,17 @@
                 }
             }
         }
+
+        #
+        # Add support for user defined templates to control body
+        #
+        $BodyUserTemplateCode = @"
+        if err := setDataTemplateFromFlags(cmd, body); err != nil {
+            return newUserError("Template error. ", err)
+        }
+"@.TrimStart()
+        $null = $RESTBodyBuilder.AppendLine($BodyUserTemplateCode)
+        
     }
 
     #

--- a/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
+++ b/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
@@ -293,6 +293,37 @@
         $null = $CmdletParameters.Add($IncludeAllParam)
     }
 
+    # Template parameters (only for PUT)
+    if ($Specification.Method -match "PUT|POST") {
+        #
+        # Template
+        #
+        $TemplateParam = New-Object System.Text.StringBuilder
+        $null = $TemplateParam.AppendLine('        # Template (jsonnet) file to use to create the request body.')
+        $null = $TemplateParam.AppendLine('        [Parameter()]')
+        $null = $TemplateParam.AppendLine('        [string]')
+        $null = $TemplateParam.Append('        $Template')
+        $null = $CmdletParameters.Add($TemplateParam)
+
+        $null = $BeginParameterBuilder.AppendLine("        if (`$PSBoundParameters.ContainsKey(`"Template`") -and `$Template) {")
+        $null = $BeginParameterBuilder.AppendLine("            `$Parameters[`"template`"] = `$Template")
+        $null = $BeginParameterBuilder.AppendLine("        }")
+
+        #
+        # Template Variables
+        #
+        $TemplateVarsParam = New-Object System.Text.StringBuilder
+        $null = $TemplateVarsParam.AppendLine('        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"')
+        $null = $TemplateVarsParam.AppendLine('        [Parameter()]')
+        $null = $TemplateVarsParam.AppendLine('        [string]')
+        $null = $TemplateVarsParam.Append('        $TemplateVars')
+        $null = $CmdletParameters.Add($TemplateVarsParam)
+
+        $null = $BeginParameterBuilder.AppendLine("        if (`$PSBoundParameters.ContainsKey(`"TemplateVars`") -and `$TemplateVars) {")
+        $null = $BeginParameterBuilder.AppendLine("            `$Parameters[`"templateVars`"] = `$TemplateVars")
+        $null = $BeginParameterBuilder.AppendLine("        }")
+    }
+
     $RawParam = New-Object System.Text.StringBuilder
     $null = $RawParam.AppendLine('        # Show the full (raw) response from Cumulocity including pagination information')
     $null = $RawParam.AppendLine('        [Parameter()]')

--- a/tools/PSc8y/PSc8y.psd1
+++ b/tools/PSc8y/PSc8y.psd1
@@ -265,6 +265,7 @@ FunctionsToExport = @(
 	'Get-C8ySessionProperty',
 	'Get-ClientBinary',
 	'Get-ClientBinaryVersion',
+	'Get-ClientSetting',
 	'Get-CurrentTenantApplicationCollection',
 	'Get-DeviceBootstrapCredential',
 	'Get-DeviceCollection',

--- a/tools/PSc8y/PSc8y.psd1
+++ b/tools/PSc8y/PSc8y.psd1
@@ -274,6 +274,7 @@ FunctionsToExport = @(
 	'Get-SessionCollection',
 	'Install-ClientBinary',
 	'Invoke-ClientRequest',
+	'Invoke-Template',
 	'New-HostedApplication',
 	'New-Microservice',
 	'New-RandomPassword',

--- a/tools/PSc8y/Public-manual/Expand-Device.ps1
+++ b/tools/PSc8y/Public-manual/Expand-Device.ps1
@@ -45,7 +45,17 @@ Get all the device object (with app in their name). Note the Expand cmdlet won't
                 $iDevice
             } else {
                 if ($iDevice -match "^\d+$") {
-                    Get-ManagedObject -Id $iDevice
+                    
+                    if ($WhatIfPreference) {
+                        # Fake the reponse of the managed object
+                        [PSCustomObject]@{
+                            id = $iDevice
+                            # Dummy value
+                            name = "name of $iDevice"
+                        }
+                    } else {
+                        Get-ManagedObject -Id $iDevice -WhatIf:$false
+                    }
                 } else {
                     Get-DeviceCollection -Name $iDevice -WhatIf:$false
                 }

--- a/tools/PSc8y/Public-manual/Get-ClientSetting.ps1
+++ b/tools/PSc8y/Public-manual/Get-ClientSetting.ps1
@@ -1,0 +1,26 @@
+Function Get-ClientSetting {
+    <#
+    .SYNOPSIS
+    Get the Cumulocity binary settings
+    
+    .DESCRIPTION
+    Get the Cumulocity binary settings which used by the cli tool
+    
+    .EXAMPLE
+    Get-ClientSetting
+    
+    Show the current c8y cli tool settings
+    #>
+    [cmdletbinding()]
+    Param()
+
+    $c8ybinary = Get-ClientBinary
+    $settings = & $c8ybinary settings list --pretty=false
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Client error when getting settings"
+        return
+    }
+
+    $settings | ConvertFrom-JSON
+}

--- a/tools/PSc8y/Public-manual/Invoke-Template.ps1
+++ b/tools/PSc8y/Public-manual/Invoke-Template.ps1
@@ -1,0 +1,94 @@
+Function Invoke-Template {
+    <#
+    .SYNOPSIS
+    Execute a jsonnet data template
+    
+    .DESCRIPTION
+    Execute a jsonnet data template and show the output of the template. Useful when developing new templates
+    
+    .EXAMPLE
+    PS> Invoke-Template -Template ./template.jsonnet
+    
+    Execute a jsonnet template
+
+    .EXAMPLE
+    PS> Invoke-Template -Template ./template.jsonnet -TemplateVars "name=input"
+    
+    Execute a jsonnet template
+
+    .OUTPUTS
+    String
+    
+    #>
+        [cmdletbinding(SupportsShouldProcess = $false,
+                       PositionalBinding=$true,
+                       HelpUri='',
+                       ConfirmImpact = 'None')]
+        [Alias()]
+        [OutputType([object])]
+        Param(    
+            # Template (jsonnet) file to use to create the request body.
+            [Parameter(
+                Mandatory = $true,
+                Position = 0
+            )]
+            [string]
+            $Template,
+    
+            # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+            [Parameter()]
+            [string]
+            $TemplateVars,
+
+            # Template input data
+            [Parameter(
+                ValueFromPipeline = $true,
+                ValueFromPipelineByPropertyName = $true
+            )]
+            [object[]]
+            $Data,
+            
+            # Output compressed/minified json
+            [switch] $Compress
+        )
+    
+        Begin {
+            $c8yArgs = New-Object System.Collections.ArrayList
+            $null = $c8yArgs.AddRange(@("template", "execute"))
+
+            if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+                $null = $c8yArgs.AddRange(@("--template", $Template))
+            }
+            if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+                $null = $c8yArgs.AddRange(@("--templateVars", $TemplateVars))
+            }
+
+            if ($Compress) {
+                $null = $c8yArgs.Add("--pretty=false")
+            } else {
+                $null = $c8yArgs.Add("--pretty=true")
+            }
+
+            $c8ybinary = Get-ClientBinary
+        }
+    
+        Process {
+            $InputData = @($null)
+
+            if ($null -ne $Data) {
+                $InputData = $Data
+            }
+
+            foreach ($iData in $InputData) {
+                $ic8yArgs = $c8yArgs.Clone()
+
+                if ($iData) {
+                    $null = $ic8yArgs.AddRange(@("--data", (ConvertTo-JsonArgument $iData)))
+                }
+
+                & $c8ybinary $ic8yArgs
+            }
+        }
+    
+        End {}
+    }

--- a/tools/PSc8y/Public-manual/New-HostedApplication.ps1
+++ b/tools/PSc8y/Public-manual/New-HostedApplication.ps1
@@ -64,6 +64,16 @@ Upload application zip file containing the web application
         [switch]
         $SkipActivation,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Include raw response including pagination information
         [Parameter()]
         [switch]
@@ -126,6 +136,12 @@ Upload application zip file containing the web application
         }
         if ($PSBoundParameters.ContainsKey("SkipUpload")) {
             $Parameters["skipUpload"] = $SkipUpload.ToString().ToLower()
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public-manual/New-Microservice.ps1
+++ b/tools/PSc8y/Public-manual/New-Microservice.ps1
@@ -11,6 +11,9 @@ The zip file needs to follow the Cumulocity Microservice format.
 
 This cmdlet has several operations
 
+.NOTES
+This cmdlet does not support template variables
+
 .EXAMPLE
 PS> New-Microservice -File "myapp.zip"
 
@@ -54,6 +57,11 @@ This example is usefuly for local development only, when you want to run the mic
         [Parameter(Mandatory = $false)]
         [string]
         $Name,
+
+        # Shared secret of application. Defaults to application name if not provided.
+        [Parameter()]
+        [string]
+        $Key,
 
         # Access level for other tenants.  Possible values are : MARKET, PRIVATE (default)
         [Parameter()]
@@ -117,6 +125,9 @@ This example is usefuly for local development only, when you want to run the mic
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Name")) {
             $Parameters["name"] = $Name
+        }
+        if ($PSBoundParameters.ContainsKey("Key")) {
+            $Parameters["key"] = $Key
         }
         if ($PSBoundParameters.ContainsKey("Availability")) {
             $Parameters["availability"] = $Availability

--- a/tools/PSc8y/Public-manual/New-TestAgent.ps1
+++ b/tools/PSc8y/Public-manual/New-TestAgent.ps1
@@ -27,23 +27,39 @@ Create 10 test agents all with unique names
         # Agent name prefix which is added before the randomized string
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [string] $Name = "testagent",
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
-    $Data = @{
-        c8y_IsDevice = @{}
-        com_cumulocity_model_Agent = @{}
+    Process {
+        $Data = @{
+            c8y_IsDevice = @{}
+            com_cumulocity_model_Agent = @{}
+        }
+
+        $AgentName = New-RandomString -Prefix "${Name}_"
+        $TestAgent = PSc8y\New-ManagedObject `
+            -Name $AgentName `
+            -Data $Data `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
+            -Force:$Force
+
+        $TestAgent
     }
-
-    $AgentName = New-RandomString -Prefix "${Name}_"
-    $TestAgent = PSc8y\New-ManagedObject `
-        -Name $AgentName `
-        -Data $Data `
-        -Force:$Force
-
-    $TestAgent
 }

--- a/tools/PSc8y/Public-manual/New-TestAlarm.ps1
+++ b/tools/PSc8y/Public-manual/New-TestAlarm.ps1
@@ -32,6 +32,16 @@ Create an alarm on the existing device "myExistingDevice"
         )]
         [object] $Device,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
@@ -55,6 +65,8 @@ Create an alarm on the existing device "myExistingDevice"
                 -Type "c8y_ci_TestAlarm" `
                 -Severity MAJOR `
                 -Text "Test CI Alarm" `
+                -Template:$Template `
+                -TemplateVars:$TemplateVars `
                 -Force:$Force
         }
     }

--- a/tools/PSc8y/Public-manual/New-TestDevice.ps1
+++ b/tools/PSc8y/Public-manual/New-TestDevice.ps1
@@ -32,6 +32,8 @@ Create 10 test devices (with agent functionality) all with unique names
         # Device name prefix which is added before the randomized string
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [string] $Name = "testdevice",
@@ -39,20 +41,34 @@ Create 10 test devices (with agent functionality) all with unique names
         # Add agent fragment to the device
         [switch] $AsAgent,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
-    $Data = @{
-        c8y_IsDevice = @{}
-    }
-    if ($AsAgent) {
-        $Data.com_cumulocity_model_Agent = @{}
-    }
-    $DeviceName = New-RandomString -Prefix "${Name}_"
-    $TestDevice = PSc8y\New-ManagedObject `
-        -Name $DeviceName `
-        -Data $Data `
-        -Force
+    Process {
+        $Data = @{
+            c8y_IsDevice = @{}
+        }
+        if ($AsAgent) {
+            $Data.com_cumulocity_model_Agent = @{}
+        }
+        $DeviceName = New-RandomString -Prefix "${Name}_"
+        $TestDevice = PSc8y\New-ManagedObject `
+            -Name $DeviceName `
+            -Data $Data `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
+            -Force
 
-    $TestDevice
+        $TestDevice
+    }
 }

--- a/tools/PSc8y/Public-manual/New-TestDeviceGroup.ps1
+++ b/tools/PSc8y/Public-manual/New-TestDeviceGroup.ps1
@@ -24,6 +24,8 @@ Create 10 test device groups all with unique names
         # Device group name prefix which is added before the randomized string
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [string] $Name = "testgroup",
@@ -32,27 +34,42 @@ Create 10 test device groups all with unique names
         [ValidateSet("Group", "SubGroup")]
         [string] $Type = "Group",
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
-    $Data = @{
-        c8y_IsDeviceGroup = @{ }
-    }
 
-    switch ($Type) {
-        "SubGroup" {
-            $Data.type = "c8y_DeviceSubGroup"
-            break;
+    Process {
+        $Data = @{
+            c8y_IsDeviceGroup = @{ }
         }
-        default {
-            $Data.type = "c8y_DeviceGroup"
-            break;
-        }
-    }
 
-    $GroupName = New-RandomString -Prefix "${Name}_"
-    PSc8y\New-ManagedObject `
-        -Name $GroupName `
-        -Data $Data `
-        -Force:$Force
+        switch ($Type) {
+            "SubGroup" {
+                $Data.type = "c8y_DeviceSubGroup"
+                break;
+            }
+            default {
+                $Data.type = "c8y_DeviceGroup"
+                break;
+            }
+        }
+
+        $GroupName = New-RandomString -Prefix "${Name}_"
+        PSc8y\New-ManagedObject `
+            -Name $GroupName `
+            -Data $Data `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
+            -Force:$Force
+    }
 }

--- a/tools/PSc8y/Public-manual/New-TestEvent.ps1
+++ b/tools/PSc8y/Public-manual/New-TestEvent.ps1
@@ -26,6 +26,8 @@ Create an event on the existing device "myExistingDevice"
         # Device id, name or object. If left blank then a randomized device will be created
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [object] $Device,
@@ -33,42 +35,57 @@ Create an event on the existing device "myExistingDevice"
         # Add a dummy file to the event
         [switch] $WithBinary,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
 
-    if ($null -ne $Device) {
-        $iDevice = Expand-Device $Device
-    } else {
-        $iDevice = PSc8y\New-TestDevice -Force:$Force
-    }
+    Process {
 
-    # Fake device (if whatif prevented it from being created)
-    if ($WhatIfPreference -and $null -eq $iDevice) {
-        $iDevice = @{ id = "12345" }
-    }
-
-    $c8yEvent = PSc8y\New-Event `
-        -Device $iDevice.id `
-        -Time "1970-01-01" `
-        -Type "c8y_ci_TestEvent" `
-        -Text "Test CI Event" `
-        -Force:$Force
-
-    if ($WithBinary) {
-        if ($WhatIfPreference -and $null -eq $iDevice) {
-            $c8yEvent = @{ id = "12345" }
+        if ($null -ne $Device) {
+            $iDevice = Expand-Device $Device
+        } else {
+            $iDevice = PSc8y\New-TestDevice -Force:$Force
         }
-
-        $tempfile = New-TemporaryFile
-        "Cumulocity test content" | Out-File -LiteralPath $tempfile
-        $null = PSc8y\New-EventBinary `
-            -Id $c8yEvent.id `
-            -File $tempfile `
+        
+        # Fake device (if whatif prevented it from being created)
+        if ($WhatIfPreference -and $null -eq $iDevice) {
+            $iDevice = @{ id = "12345" }
+        }
+        
+        $c8yEvent = PSc8y\New-Event `
+            -Device $iDevice.id `
+            -Time "1970-01-01" `
+            -Type "c8y_ci_TestEvent" `
+            -Text "Test CI Event" `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
             -Force:$Force
-
-        Remove-Item $tempfile
+        
+        if ($WithBinary) {
+            if ($WhatIfPreference -and $null -eq $iDevice) {
+                $c8yEvent = @{ id = "12345" }
+            }
+            
+            $tempfile = New-TemporaryFile
+            "Cumulocity test content" | Out-File -LiteralPath $tempfile
+            $null = PSc8y\New-EventBinary `
+                -Id $c8yEvent.id `
+                -File $tempfile `
+                -Force:$Force
+            
+            Remove-Item $tempfile
+        }
+        
+        $c8yEvent
     }
-
-    $c8yEvent
 }

--- a/tools/PSc8y/Public-manual/New-TestGroup.ps1
+++ b/tools/PSc8y/Public-manual/New-TestGroup.ps1
@@ -19,16 +19,33 @@ Create a new user group with the prefix "mygroup". A random postfix will be adde
         # Name of the user group. A random postfix will be added to it to make it unique
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [string] $Name = "testgroup",
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Don't prompt for confirmation
         [switch] $Force
     )
 
-    $GroupName = New-RandomString -Prefix "${Name}_"
-    $TestGroup = PSc8y\New-Group -Name $GroupName -Force:$Force
-
-    $TestGroup
+    Process {
+        $GroupName = New-RandomString -Prefix "${Name}_"
+        $TestGroup = PSc8y\New-Group `
+            -Name $GroupName `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
+            -Force:$Force
+        $TestGroup
+    }
 }

--- a/tools/PSc8y/Public-manual/New-TestHostedApplication.ps1
+++ b/tools/PSc8y/Public-manual/New-TestHostedApplication.ps1
@@ -22,6 +22,16 @@ Create a test hosted web application
         # Application folder or file
         [string] $File = "$PSScriptRoot/../Tests/TestData/hosted-application/simple-helloworld",
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
@@ -35,6 +45,14 @@ Create a test hosted web application
     }
     if ($File) {
         $options.File = $File
+    }
+
+    if ($Template) {
+        $options.Template = $Template
+    }
+
+    if ($TemplateVars) {
+        $options.TemplateVars = $TemplateVars
     }
 
     New-HostedApplication @options

--- a/tools/PSc8y/Public-manual/New-TestMicroservice.ps1
+++ b/tools/PSc8y/Public-manual/New-TestMicroservice.ps1
@@ -20,6 +20,16 @@ Create a new test microservice
         # Skip the subscription for the microservice
         [switch] $SkipSubscription,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Don't prompt for confirmation
         [switch] $Force
     )
@@ -33,6 +43,8 @@ Create a new test microservice
         File = $File
         SkipUpload = $SkipUpload
         SkipSubscription = $SkipSubscription
+        Template = $Template
+        TemplateVars = $TemplateVars
         Force = $Force
     }
 

--- a/tools/PSc8y/Public-manual/New-TestOperation.ps1
+++ b/tools/PSc8y/Public-manual/New-TestOperation.ps1
@@ -26,33 +26,49 @@ Create an operation on the existing device "myExistingDevice"
         # Device id, name or object. If left blank then a randomized device will be created
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [object] $Device,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Don't prompt for confirmation
         [switch] $Force
     )
 
-    if ($null -ne $Device) {
-        $iAgent = Expand-Device $Device
-    }
-    else {
-        $iAgent = PSc8y\New-TestAgent -Force:$Force
-    }
+    Process {
+        if ($null -ne $Device) {
+            $iAgent = Expand-Device $Device
+        }
+        else {
+            $iAgent = PSc8y\New-TestAgent -Force:$Force
+        }
 
-    # Fake device (if whatif prevented it from being created)
-    if ($WhatIfPreference -and $null -eq $iAgent) {
-        $iAgent = @{ id = "12345" }
-    }
+        # Fake device (if whatif prevented it from being created)
+        if ($WhatIfPreference -and $null -eq $iAgent) {
+            $iAgent = @{ id = "12345" }
+        }
 
-    PSc8y\New-Operation `
-        -Device $iAgent.id `
-        -Description "Test operation" `
-        -Data @{
-        c8y_Restart = @{
-                parameters = @{ }
-            }
-        } `
-        -Force:$Force
+        PSc8y\New-Operation `
+            -Device $iAgent.id `
+            -Description "Test operation" `
+            -Data @{
+            c8y_Restart = @{
+                    parameters = @{ }
+                }
+            } `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
+            -Force:$Force
+    }
 }

--- a/tools/PSc8y/Public-manual/New-TestUser.ps1
+++ b/tools/PSc8y/Public-manual/New-TestUser.ps1
@@ -24,15 +24,34 @@ Create a new test user with a custom username prefix
         # Name of the username. A random postfix will be added to it to make it unique
         [Parameter(
             Mandatory = $false,
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 0
         )]
         [string] $Name = "testuser",
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Don't prompt for confirmation
         [switch] $Force
     )
 
-    $Username = New-RandomString -Prefix "${Name}_"
-
-    PSc8y\New-User -UserName $Username -Password (New-RandomString) -Force:$Force
+    Process {
+        $Username = New-RandomString -Prefix "${Name}_"
+        
+        PSc8y\New-User `
+            -UserName $Username `
+            -Password (New-RandomString) `
+            -Template:$Template `
+            -TemplateVars:$TemplateVars `
+            -Force:$Force
+    }
 }

--- a/tools/PSc8y/Public-manual/Set-Session.ps1
+++ b/tools/PSc8y/Public-manual/Set-Session.ps1
@@ -84,9 +84,6 @@ String
             }
         }
 
-        # Format path
-        $Path = Resolve-Path $Path -ErrorAction SilentlyContinue
-
         if (!$Path -or !(Test-Path $Path)) {
             Write-Warning "Invalid path"
             return

--- a/tools/PSc8y/Public/Add-AssetToGroup.ps1
+++ b/tools/PSc8y/Public/Add-AssetToGroup.ps1
@@ -38,6 +38,16 @@ Create group heirachy (parent group -> child group)
         [object[]]
         $NewChildGroup,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -76,6 +86,12 @@ Create group heirachy (parent group -> child group)
         }
         if ($PSBoundParameters.ContainsKey("NewChildGroup")) {
             $Parameters["newChildGroup"] = $NewChildGroup
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Add-ChildDeviceToDevice.ps1
+++ b/tools/PSc8y/Public/Add-ChildDeviceToDevice.ps1
@@ -38,6 +38,16 @@ Assign a device as a child device to an existing device (using pipeline)
         [object[]]
         $NewChild,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -73,6 +83,12 @@ Assign a device as a child device to an existing device (using pipeline)
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Device")) {
             $Parameters["device"] = $Device
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Add-ChildGroupToGroup.ps1
+++ b/tools/PSc8y/Public/Add-ChildGroupToGroup.ps1
@@ -40,6 +40,16 @@ to filter for a collection of devices and assign the results to a single group.
         [object[]]
         $NewChildGroup,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -75,6 +85,12 @@ to filter for a collection of devices and assign the results to a single group.
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Group")) {
             $Parameters["group"] = $Group
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Add-DeviceToGroup.ps1
+++ b/tools/PSc8y/Public/Add-DeviceToGroup.ps1
@@ -40,6 +40,16 @@ to filter for a collection of devices and assign the results to a single group.
         [object[]]
         $NewChildDevice,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -75,6 +85,12 @@ to filter for a collection of devices and assign the results to a single group.
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Group")) {
             $Parameters["group"] = $Group
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Add-RoleToGroup.ps1
+++ b/tools/PSc8y/Public/Add-RoleToGroup.ps1
@@ -43,6 +43,16 @@ Add a role to a group using wildcards (using pipeline)
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -81,6 +91,12 @@ Add a role to a group using wildcards (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Add-RoleToUser.ps1
+++ b/tools/PSc8y/Public/Add-RoleToUser.ps1
@@ -47,6 +47,16 @@ Add a role to a user using wildcards (using pipeline)
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -85,6 +95,12 @@ Add a role to a user using wildcards (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Add-UserToGroup.ps1
+++ b/tools/PSc8y/Public/Add-UserToGroup.ps1
@@ -38,6 +38,16 @@ Add a user to a user group
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -76,6 +86,12 @@ Add a user to a user group
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Approve-DeviceRequest.ps1
+++ b/tools/PSc8y/Public/Approve-DeviceRequest.ps1
@@ -34,6 +34,16 @@ Approve a new device request
         [string]
         $Status,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -72,6 +82,12 @@ Approve a new device request
         }
         if ($PSBoundParameters.ContainsKey("Status")) {
             $Parameters["status"] = $Status
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Copy-Application.ps1
+++ b/tools/PSc8y/Public/Copy-Application.ps1
@@ -33,6 +33,16 @@ Copy an existing application
         [object[]]
         $Id,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -66,6 +76,12 @@ Copy an existing application
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Enable-Application.ps1
+++ b/tools/PSc8y/Public/Enable-Application.ps1
@@ -33,6 +33,16 @@ Enable an application of a tenant
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -68,6 +78,12 @@ Enable an application of a tenant
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Enable-Microservice.ps1
+++ b/tools/PSc8y/Public/Enable-Microservice.ps1
@@ -34,6 +34,16 @@ Enable (subscribe) to a microservice
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +79,12 @@ Enable (subscribe) to a microservice
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Agent.ps1
+++ b/tools/PSc8y/Public/New-Agent.ps1
@@ -43,6 +43,16 @@ Create agent with custom properties
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -84,6 +94,12 @@ Create agent with custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Alarm.ps1
+++ b/tools/PSc8y/Public/New-Alarm.ps1
@@ -33,23 +33,23 @@ Create a new alarm for device (using pipeline)
         [object[]]
         $Device,
 
-        # Identifies the type of this alarm, e.g. 'com_cumulocity_events_TamperEvent'. (required)
-        [Parameter(Mandatory = $true)]
+        # Identifies the type of this alarm, e.g. 'com_cumulocity_events_TamperEvent'.
+        [Parameter()]
         [string]
         $Type,
 
-        # Time of the alarm.
+        # Time of the alarm. Defaults to current timestamp.
         [Parameter()]
         [string]
         $Time,
 
-        # Text description of the alarm. (required)
-        [Parameter(Mandatory = $true)]
+        # Text description of the alarm.
+        [Parameter()]
         [string]
         $Text,
 
-        # The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case. (required)
-        [Parameter(Mandatory = $true)]
+        # The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case.
+        [Parameter()]
         [ValidateSet('CRITICAL','MAJOR','MINOR','WARNING')]
         [string]
         $Severity,
@@ -64,6 +64,16 @@ Create a new alarm for device (using pipeline)
         [Parameter()]
         [object]
         $Data,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
@@ -115,6 +125,12 @@ Create a new alarm for device (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Application.ps1
+++ b/tools/PSc8y/Public/New-Application.ps1
@@ -73,6 +73,16 @@ Create a new hosted application
         [string]
         $ExternalUrl,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -135,6 +145,12 @@ Create a new hosted application
         }
         if ($PSBoundParameters.ContainsKey("ExternalUrl")) {
             $Parameters["externalUrl"] = $ExternalUrl
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-ApplicationBinary.ps1
+++ b/tools/PSc8y/Public/New-ApplicationBinary.ps1
@@ -38,6 +38,16 @@ Upload application microservice binary
         [string]
         $File,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -73,6 +83,12 @@ Upload application microservice binary
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-AuditRecord.ps1
+++ b/tools/PSc8y/Public/New-AuditRecord.ps1
@@ -26,7 +26,7 @@ Create an audit record for a custom managed object update
         [string]
         $Type,
 
-        # Time of the audit record.
+        # Time of the audit record. Defaults to current timestamp.
         [Parameter()]
         [string]
         $Time,
@@ -66,6 +66,16 @@ Create an audit record for a custom managed object update
         [Parameter()]
         [object]
         $Data,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
@@ -126,6 +136,12 @@ Create an audit record for a custom managed object update
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Binary.ps1
+++ b/tools/PSc8y/Public/New-Binary.ps1
@@ -36,6 +36,16 @@ Upload a config file and make it globally accessible for all users
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -74,6 +84,12 @@ Upload a config file and make it globally accessible for all users
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Binary.ps1
+++ b/tools/PSc8y/Public/New-Binary.ps1
@@ -12,6 +12,11 @@ PS> New-Binary -File $File
 
 Upload a log file
 
+.EXAMPLE
+PS> New-Binary -File $File -Data @{ c8y_Global = @{}; type = "c8y_upload" }
+
+Upload a config file and make it globally accessible for all users
+
 
 #>
     [cmdletbinding(SupportsShouldProcess = $true,
@@ -25,6 +30,11 @@ Upload a log file
         [Parameter(Mandatory = $true)]
         [string]
         $File,
+
+        # Additional properties to be added to the binary.
+        [Parameter()]
+        [object]
+        $Data,
 
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
@@ -61,6 +71,9 @@ Upload a log file
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("Data")) {
+            $Parameters["data"] = ConvertTo-JsonArgument $Data
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Device.ps1
+++ b/tools/PSc8y/Public/New-Device.ps1
@@ -44,6 +44,16 @@ Create device with custom properties
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -82,6 +92,12 @@ Create device with custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/New-DeviceGroup.ps1
@@ -43,6 +43,16 @@ Create device group with custom properties
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -84,6 +94,12 @@ Create device group with custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Event.ps1
+++ b/tools/PSc8y/Public/New-Event.ps1
@@ -33,18 +33,18 @@ Create a new event for a device (using pipeline)
         [object[]]
         $Device,
 
-        # Time of the event.
+        # Time of the event. Defaults to current timestamp.
         [Parameter()]
         [string]
         $Time,
 
-        # Identifies the type of this event. (required)
-        [Parameter(Mandatory = $true)]
+        # Identifies the type of this event.
+        [Parameter()]
         [string]
         $Type,
 
-        # Text description of the event. (required)
-        [Parameter(Mandatory = $true)]
+        # Text description of the event.
+        [Parameter()]
         [string]
         $Text,
 
@@ -52,6 +52,16 @@ Create a new event for a device (using pipeline)
         [Parameter()]
         [object]
         $Data,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
@@ -97,6 +107,12 @@ Create a new event for a device (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-EventBinary.ps1
+++ b/tools/PSc8y/Public/New-EventBinary.ps1
@@ -33,6 +33,16 @@ Add a binary to an event
         [string]
         $File,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -68,6 +78,12 @@ Add a binary to an event
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-ExternalId.ps1
+++ b/tools/PSc8y/Public/New-ExternalId.ps1
@@ -8,9 +8,14 @@ Create a new external id
 Create a new external id
 
 .EXAMPLE
-PS> New-ExternalId -Device {{ randomdevice }} -Type "$my_SerialNumber" -Name "myserialnumber"
+PS> New-ExternalId -Device $Device.id -Type "$my_SerialNumber" -Name "myserialnumber"
 
-Get external identity
+Create external identity
+
+.EXAMPLE
+PS> Get-Device $Device.id | New-ExternalId -Type "$my_SerialNumber" -Name "myserialnumber"
+
+Create external identity (using pipeline)
 
 
 #>
@@ -22,7 +27,9 @@ Get external identity
     [OutputType([object])]
     Param(
         # The ManagedObject linked to the external ID. (required)
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true)]
         [object[]]
         $Device,
 
@@ -35,6 +42,16 @@ Get external identity
         [Parameter(Mandatory = $true)]
         [string]
         $Name,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
@@ -69,14 +86,17 @@ Get external identity
 
     Begin {
         $Parameters = @{}
-        if ($PSBoundParameters.ContainsKey("Device")) {
-            $Parameters["device"] = $Device
-        }
         if ($PSBoundParameters.ContainsKey("Type")) {
             $Parameters["type"] = $Type
         }
         if ($PSBoundParameters.ContainsKey("Name")) {
             $Parameters["name"] = $Name
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
@@ -94,7 +114,10 @@ Get external identity
     }
 
     Process {
-        foreach ($item in @("")) {
+        foreach ($item in (PSc8y\Expand-Device $Device)) {
+            if ($item) {
+                $Parameters["device"] = if ($item.id) { $item.id } else { $item }
+            }
 
             if (!$Force -and
                 !$WhatIfPreference -and

--- a/tools/PSc8y/Public/New-Group.ps1
+++ b/tools/PSc8y/Public/New-Group.ps1
@@ -31,6 +31,16 @@ Create a user group
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +79,12 @@ Create a user group
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-ManagedObject.ps1
+++ b/tools/PSc8y/Public/New-ManagedObject.ps1
@@ -36,6 +36,16 @@ Create a managed object
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +87,12 @@ Create a managed object
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Measurement.ps1
+++ b/tools/PSc8y/Public/New-Measurement.ps1
@@ -28,13 +28,13 @@ Create measurement
         [object[]]
         $Device,
 
-        # Time of the measurement. (required)
-        [Parameter(Mandatory = $true)]
+        # Time of the measurement. Defaults to current timestamp.
+        [Parameter()]
         [string]
         $Time,
 
-        # The most specific type of this entire measurement. (required)
-        [Parameter(Mandatory = $true)]
+        # The most specific type of this entire measurement.
+        [Parameter()]
         [string]
         $Type,
 
@@ -42,6 +42,16 @@ Create measurement
         [Parameter()]
         [object]
         $Data,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
 
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
@@ -84,6 +94,12 @@ Create measurement
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-MicroserviceBinary.ps1
+++ b/tools/PSc8y/Public/New-MicroserviceBinary.ps1
@@ -38,6 +38,16 @@ Upload microservice binary
         [string]
         $File,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -73,6 +83,12 @@ Upload microservice binary
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Operation.ps1
+++ b/tools/PSc8y/Public/New-Operation.ps1
@@ -43,6 +43,16 @@ Create operation for a device (using pipeline)
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -81,6 +91,12 @@ Create operation for a device (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-RetentionRule.ps1
+++ b/tools/PSc8y/Public/New-RetentionRule.ps1
@@ -53,6 +53,16 @@ Create a retention rule to delete all alarms after 180 days
         [switch]
         $Editable,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -103,6 +113,12 @@ Create a retention rule to delete all alarms after 180 days
         }
         if ($PSBoundParameters.ContainsKey("Editable")) {
             $Parameters["editable"] = $Editable
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-Tenant.ps1
+++ b/tools/PSc8y/Public/New-Tenant.ps1
@@ -61,6 +61,16 @@ Create a new tenant (from the management tenant)
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -117,6 +127,12 @@ Create a new tenant (from the management tenant)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-TenantOption.ps1
+++ b/tools/PSc8y/Public/New-TenantOption.ps1
@@ -36,6 +36,16 @@ Create a tenant option
         [string]
         $Value,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +87,12 @@ Create a tenant option
         }
         if ($PSBoundParameters.ContainsKey("Value")) {
             $Parameters["value"] = $Value
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/New-User.ps1
+++ b/tools/PSc8y/Public/New-User.ps1
@@ -72,6 +72,16 @@ Create a user
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -134,6 +144,12 @@ Create a user
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Register-Device.ps1
+++ b/tools/PSc8y/Public/Register-Device.ps1
@@ -28,6 +28,16 @@ Register a new device
         [string]
         $Id,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -63,6 +73,12 @@ Register a new device
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Id")) {
             $Parameters["id"] = $Id
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Request-DeviceCredentials.ps1
+++ b/tools/PSc8y/Public/Request-DeviceCredentials.ps1
@@ -28,6 +28,16 @@ Request credentials for a new device
         [string]
         $Id,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -63,6 +73,12 @@ Request credentials for a new device
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Id")) {
             $Parameters["id"] = $Id
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Reset-UserPassword.ps1
+++ b/tools/PSc8y/Public/Reset-UserPassword.ps1
@@ -43,6 +43,16 @@ Resets a user's password by generating a new password
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -81,6 +91,12 @@ Resets a user's password by generating a new password
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Set-DeviceRequiredAvailability.ps1
+++ b/tools/PSc8y/Public/Set-DeviceRequiredAvailability.ps1
@@ -38,6 +38,16 @@ Set the required availability of a device (using pipeline)
         [long]
         $Interval,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -73,6 +83,12 @@ Set the required availability of a device (using pipeline)
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Interval")) {
             $Parameters["interval"] = $Interval
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Agent.ps1
+++ b/tools/PSc8y/Public/Update-Agent.ps1
@@ -48,6 +48,16 @@ Update agent custom properties
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -86,6 +96,12 @@ Update agent custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Alarm.ps1
+++ b/tools/PSc8y/Public/Update-Alarm.ps1
@@ -60,6 +60,16 @@ Update severity of an existing alarm to CRITICAL
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -104,6 +114,12 @@ Update severity of an existing alarm to CRITICAL
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Update-AlarmCollection.ps1
@@ -65,6 +65,16 @@ Update the status of all active alarms on a device to ACKNOWLEDGED (using pipeli
         [string]
         $NewStatus,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -115,6 +125,12 @@ Update the status of all active alarms on a device to ACKNOWLEDGED (using pipeli
         }
         if ($PSBoundParameters.ContainsKey("NewStatus")) {
             $Parameters["newStatus"] = $NewStatus
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Application.ps1
+++ b/tools/PSc8y/Public/Update-Application.ps1
@@ -74,6 +74,16 @@ Update application availability to MARKET
         [string]
         $ExternalUrl,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -133,6 +143,12 @@ Update application availability to MARKET
         }
         if ($PSBoundParameters.ContainsKey("ExternalUrl")) {
             $Parameters["externalUrl"] = $ExternalUrl
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Binary.ps1
+++ b/tools/PSc8y/Public/Update-Binary.ps1
@@ -34,6 +34,16 @@ Update an existing binary file
         [string]
         $File,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +79,12 @@ Update an existing binary file
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-CurrentApplication.ps1
+++ b/tools/PSc8y/Public/Update-CurrentApplication.ps1
@@ -67,6 +67,16 @@ Update custom properties of the current application (requires using application 
         [string]
         $ExternalUrl,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -126,6 +136,12 @@ Update custom properties of the current application (requires using application 
         }
         if ($PSBoundParameters.ContainsKey("ExternalUrl")) {
             $Parameters["externalUrl"] = $ExternalUrl
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-CurrentUser.ps1
+++ b/tools/PSc8y/Public/Update-CurrentUser.ps1
@@ -53,6 +53,16 @@ Update the current user's lastname
         [string]
         $Password,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -103,6 +113,12 @@ Update the current user's lastname
         }
         if ($PSBoundParameters.ContainsKey("Password")) {
             $Parameters["password"] = $Password
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-DataBrokerConnector.ps1
+++ b/tools/PSc8y/Public/Update-DataBrokerConnector.ps1
@@ -39,6 +39,16 @@ Change the status of a specific data broker connector by given connector id
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +87,12 @@ Change the status of a specific data broker connector by given connector id
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Device.ps1
+++ b/tools/PSc8y/Public/Update-Device.ps1
@@ -48,6 +48,16 @@ Update device custom properties
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -86,6 +96,12 @@ Update device custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/Update-DeviceGroup.ps1
@@ -49,6 +49,16 @@ Update device group custom properties
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -87,6 +97,12 @@ Update device group custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Event.ps1
+++ b/tools/PSc8y/Public/Update-Event.ps1
@@ -48,6 +48,16 @@ Update custom properties of an existing event (using pipeline)
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -86,6 +96,12 @@ Update custom properties of an existing event (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-EventBinary.ps1
+++ b/tools/PSc8y/Public/Update-EventBinary.ps1
@@ -34,6 +34,16 @@ Update a binary related to an event
         [string]
         $File,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +79,12 @@ Update a binary related to an event
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Group.ps1
+++ b/tools/PSc8y/Public/Update-Group.ps1
@@ -43,6 +43,16 @@ Update a user group (using pipeline)
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -81,6 +91,12 @@ Update a user group (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Update-ManagedObject.ps1
@@ -43,6 +43,16 @@ Update a managed object (using pipeline)
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -81,6 +91,12 @@ Update a managed object (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Microservice.ps1
+++ b/tools/PSc8y/Public/Update-Microservice.ps1
@@ -55,6 +55,16 @@ Update microservice availability to MARKET
         [string]
         $ResourcesUrl,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -102,6 +112,12 @@ Update microservice availability to MARKET
         }
         if ($PSBoundParameters.ContainsKey("ResourcesUrl")) {
             $Parameters["resourcesUrl"] = $ResourcesUrl
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Operation.ps1
+++ b/tools/PSc8y/Public/Update-Operation.ps1
@@ -50,6 +50,16 @@ Update multiple operations
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -91,6 +101,12 @@ Update multiple operations
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-RetentionRule.ps1
+++ b/tools/PSc8y/Public/Update-RetentionRule.ps1
@@ -70,6 +70,16 @@ Update a retention rule (using pipeline)
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -123,6 +133,12 @@ Update a retention rule (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-Tenant.ps1
+++ b/tools/PSc8y/Public/Update-Tenant.ps1
@@ -62,6 +62,16 @@ Update a tenant by name (from the mangement tenant)
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -115,6 +125,12 @@ Update a tenant by name (from the mangement tenant)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-TenantOption.ps1
+++ b/tools/PSc8y/Public/Update-TenantOption.ps1
@@ -36,6 +36,16 @@ Update a tenant option
         [string]
         $Value,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +87,12 @@ Update a tenant option
         }
         if ($PSBoundParameters.ContainsKey("Value")) {
             $Parameters["value"] = $Value
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-TenantOptionBulk.ps1
+++ b/tools/PSc8y/Public/Update-TenantOptionBulk.ps1
@@ -31,6 +31,16 @@ Update multiple tenant options
         [object]
         $Data,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +79,12 @@ Update multiple tenant options
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-TenantOptionEditable.ps1
+++ b/tools/PSc8y/Public/Update-TenantOptionEditable.ps1
@@ -38,6 +38,16 @@ Update editable property for an existing tenant option
         [string]
         $Editable,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -79,6 +89,12 @@ Update editable property for an existing tenant option
         }
         if ($PSBoundParameters.ContainsKey("Editable")) {
             $Parameters["editable"] = $Editable
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Update-User.ps1
+++ b/tools/PSc8y/Public/Update-User.ps1
@@ -74,6 +74,16 @@ Update a user
         [object]
         $Tenant,
 
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -133,6 +143,12 @@ Update a user
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Tests/Get-ClientSetting.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Get-ClientSetting.manual.Tests.ps1
@@ -1,0 +1,10 @@
+. $PSScriptRoot/imports.ps1
+
+Describe -Name "Get-ClientSetting" {
+
+    It "shows a list of client settings" {
+        $Response = Get-ClientSetting
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+}

--- a/tools/PSc8y/Tests/Invoke-Template.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Invoke-Template.manual.Tests.ps1
@@ -1,0 +1,68 @@
+. $PSScriptRoot/imports.ps1 -ErrorAction SilentlyContinue -SkipSessionTest
+
+Describe -Tag "Template" -Name "Invoke-Template" {
+
+    It "executes a jsonnet template from a string" {
+        $Template = @"
+{
+    name: 'testName',
+    value: 1 + 2,
+}
+"@
+
+        $resp = Invoke-Template -Template $Template
+        $LASTEXITCODE | Should -BeExactly 0
+
+        $resp | Should -Not -BeNullOrEmpty
+
+        $obj = $resp | ConvertFrom-Json
+
+        $obj.name | Should -BeExactly "testName"
+        $obj.value | Should -BeExactly 3
+    }
+
+    It "executes a jsonnet template with input values" {
+        $Template = @"
+{
+    name: var('name', 'testName'),
+    value: 1 + 2,
+}
+"@
+
+        $resp = Invoke-Template -Template $Template -TemplateVars "name=myName2"
+        $LASTEXITCODE | Should -BeExactly 0
+
+        $resp | Should -Not -BeNullOrEmpty
+
+        $obj = $resp | ConvertFrom-Json
+
+        $obj.name | Should -BeExactly "myName2"
+        $obj.value | Should -BeExactly 3
+    }
+
+    It "executes a jsonnet template using pipeline input" {
+        $Template = @"
+{
+    type: base.name + '_' + rand.int,
+    value: 1 + 2,
+}
+"@
+        $InputData = @(
+            @{ name = "name" },
+            @{ name = "name2" }
+        )
+        $templateOutput = $InputData | Invoke-Template -Template $Template -Compress | ConvertFrom-Json
+        $LASTEXITCODE | Should -BeExactly 0
+
+        $templateOutput | Should -Not -BeNullOrEmpty
+        $templateOutput | Should -HaveCount 2
+
+        $templateOutput[0].name | Should -BeExactly "name"
+        $templateOutput[0].type | Should -Match "^name_\d+$"
+        $templateOutput[0].value | Should -BeExactly 3
+
+        $templateOutput[1].name | Should -BeExactly "name2"
+        $templateOutput[1].type | Should -Match "^name2_\d+$"
+        $templateOutput[1].value | Should -BeExactly 3
+    }
+}

--- a/tools/PSc8y/Tests/New-Binary.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/New-Binary.auto.Tests.ps1
@@ -13,6 +13,12 @@ Describe -Name "New-Binary" {
         $Response | Should -Not -BeNullOrEmpty
     }
 
+    It "Upload a config file and make it globally accessible for all users" {
+        $Response = PSc8y\New-Binary -File $File -Data @{ c8y_Global = @{}; type = "c8y_upload" }
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
 
     AfterEach {
         Remove-Item $File

--- a/tools/PSc8y/Tests/New-Binary.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/New-Binary.manual.Tests.ps1
@@ -1,0 +1,37 @@
+. $PSScriptRoot/imports.ps1
+
+Describe -Name "New-Binary" {
+    BeforeEach {
+        $File = New-TestFile
+        $FileName = (Get-Item $File).Name
+
+    }
+
+    It "Upload a log file with custom properties" {
+        $Response = PSc8y\New-Binary -File $File -Data @{ type = "c8y_upload"; c8y_Global = @{} }
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        $Response.id | Should -MatchExactly "^\d+$"
+        $Response.type | Should -BeExactly "c8y_upload"
+        $Response.c8y_Global | Should -BeTrue
+    }
+
+    It "Upload a log file with custom properties but let file type be detected" {
+        $Response = PSc8y\New-Binary -File $File -Data @{ c8y_Global = @{} }
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        $Response.id | Should -MatchExactly "^\d+$"
+        $Response.type | Should -BeExactly "application/octet-stream"
+        $Response.c8y_Global | Should -BeTrue
+    }
+
+
+    AfterEach {
+        Remove-Item $File
+        Find-ManagedObjectCollection -Query "has(c8y_IsBinary) and (name eq '$FileName')" | Remove-Binary
+
+    }
+}
+

--- a/tools/PSc8y/Tests/New-ExternalId.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/New-ExternalId.auto.Tests.ps1
@@ -3,21 +3,25 @@
 Describe -Name "New-ExternalId" {
     BeforeEach {
         $my_SerialNumber = New-RandomString -Prefix "my_SerialNumber"
-        $TestDevice = PSc8y\New-TestDevice
+        $Device = New-TestDevice
 
     }
 
-    It "Get external identity" {
-        $Response = PSc8y\New-ExternalId -Device $TestDevice.id -Type "$my_SerialNumber" -Name "myserialnumber"
+    It "Create external identity" {
+        $Response = PSc8y\New-ExternalId -Device $Device.id -Type "$my_SerialNumber" -Name "myserialnumber"
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It "Create external identity (using pipeline)" {
+        $Response = PSc8y\Get-Device $Device.id | New-ExternalId -Type "$my_SerialNumber" -Name "myserialnumber"
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }
 
 
     AfterEach {
-        if ($TestDevice.id) {
-            PSc8y\Remove-ManagedObject -Id $TestDevice.id -ErrorAction SilentlyContinue
-        }
+        PSc8y\Remove-ManagedObject -Id $Device.id
 
     }
 }

--- a/tools/PSc8y/Tests/New-Microservice.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/New-Microservice.manual.Tests.ps1
@@ -18,7 +18,7 @@ Describe -Name "New-Microservice" {
             # Remove microservice (if exists)
             Get-Microservice -Id $Name | Remove-Microservice
 
-            $App = New-Microservice -File $CustomZip
+            $App = New-Microservice -File $CustomZip -Key $Name
 
             $AppList.Add($App.id)
 
@@ -30,6 +30,7 @@ Describe -Name "New-Microservice" {
             $LASTEXITCODE | Should -Be 0
             $App | Should -Not -BeNullOrEmpty
             $App.name | Should -BeExactly $Name
+            $App.key | Should -BeExactly $Name
         }
 
         It "Creates a new microservice from a zip file with a custom name" {
@@ -40,6 +41,7 @@ Describe -Name "New-Microservice" {
             $LASTEXITCODE | Should -Be 0
             $App | Should -Not -BeNullOrEmpty
             $App.name | Should -BeExactly $AppName
+            $App.key | Should -BeExactly $AppName
         }
 
         It "Update existing (enabled) microservice" {

--- a/tools/PSc8y/Tests/template.Tests.ps1
+++ b/tools/PSc8y/Tests/template.Tests.ps1
@@ -1,0 +1,76 @@
+. $PSScriptRoot/imports.ps1
+
+Describe -Name "New-ManagedObject Templates" {
+    BeforeEach {
+        $items = New-Object System.Collections.ArrayList
+    }
+
+    It "Create a managed object using templates" {
+        $template = @"
+{
+    type: var("type"),
+    dummyFragment: {
+        value: rand.int,
+    },
+}
+"@
+        $TemplateFile = New-TemporaryFile
+        $template | Out-File $TemplateFile
+        $Response = PSc8y\New-ManagedObject -Name "testMO" -Template $TemplateFile
+
+        if ($Response.id) {
+            $null = $items.Add($Response.id)
+        }
+
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+        $Response.dummyFragment.value | Should -Not -BeNullOrEmpty
+        $Response.type | Should -BeExactly ""
+        $Response.name | Should -BeExactly "testMO"
+    }
+
+    It "Creates a managed objects using template variables" {
+        $template = @"
+{
+    type: var('type', 'defaultValue'),
+    subtype: var('subtype'),
+    values: {
+        bool: rand.bool,
+        int: rand.int,
+        int2: rand.int2,
+        float: rand.float,
+        float2: rand.float2,
+        float3: rand.float3,
+        float4: rand.float4,
+    },
+}
+"@
+        $Response = PSc8y\New-ManagedObject -Name "testMO" -Template $template -TemplateVar "subtype=customName"
+
+        if ($Response.id) {
+            $null = $items.Add($Response.id)
+        }
+
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        $Response.name | Should -BeExactly "testMO"
+        $Response.type | Should -BeExactly "defaultValue"
+        $Response.subtype | Should -BeExactly "customName"
+        $Response.values.bool | Should -Not -BeNullOrEmpty
+        $Response.values.int | Should -Not -BeNullOrEmpty
+        $Response.values.int2 | Should -Not -BeNullOrEmpty
+        $Response.values.float | Should -Not -BeNullOrEmpty
+        $Response.values.float2 | Should -Not -BeNullOrEmpty
+        $Response.values.float3 | Should -Not -BeNullOrEmpty
+        $Response.values.float4 | Should -Not -BeNullOrEmpty
+    }
+
+    AfterEach {
+        foreach ($item in $items) {
+            if ($item) {
+                PSc8y\Remove-ManagedObject -Id $item
+            }
+        }
+    }
+}

--- a/tools/PSc8y/format-data/session.ps1xml
+++ b/tools/PSc8y/format-data/session.ps1xml
@@ -33,7 +33,17 @@
                             <CustomItem>
                                 <Text>path: </Text>
                                 <ExpressionBinding>
-                                    <ScriptBlock>$_.path -replace "$env:USERNAME", "******"</ScriptBlock>
+                                    <ScriptBlock>
+                                        $sanitziedPath = $_.path
+                                        if ($HOME) {
+                                            $sanitziedPath = $sanitziedPath -replace "$HOME", "******"
+                                        }
+
+                                        if ($Env:USERNAME) {
+                                            $sanitziedPath = $sanitziedPath -replace "$env:USERNAME", "******"
+                                        }
+                                        $sanitziedPath
+                                    </ScriptBlock>
                                 </ExpressionBinding>
                                 <NewLine/>
                             </CustomItem>

--- a/tools/PSc8y/test.parallel.ps1
+++ b/tools/PSc8y/test.parallel.ps1
@@ -55,7 +55,7 @@ $results = $Tests | ForEach-Object -ThrottleLimit:$ThrottleLimit -Parallel {
 
     Write-Host ("Starting file: {0}" -f $TestFile.Name) -ForegroundColor Gray
 
-    $ReportOutput = "./reports/Report_$($TestFile.BaseName)_Pester.xml"
+    $ReportOutput = Join-Path (Resolve-Path ".") -ChildPath "reports/Report_$($TestFile.BaseName)_Pester.xml"
 
     $PesterConfig = [PesterConfiguration]@{
         Run = @{

--- a/tools/schema/session.schema.json
+++ b/tools/schema/session.schema.json
@@ -55,6 +55,10 @@
                     "description": "Delay in milliseconds between fetching the next result when using the includeAll option. If value is 0 or less, then it will be ignored",
                     "type": "integer",
                     "minimum": 0
+                },
+                "template.path": {
+                    "description": "Path / Folder where the templates are located. If the user gives a template name (without path), then a matching filename will be search for in this folder",
+                    "type": "string"
                 }
             }
         }


### PR DESCRIPTION
* Added command to read the current configuration settings as json

    **PowerShell**

    ```powershell
    Get-ClientSetting
    ```

    **Bash/zsh**

    ```sh
    c8y settings list
    ```

* Added support for templates and template variables for all POST and PUT commands. See the [templates concept documentation](https://reubenmiller.github.io/go-c8y-cli/docs/concepts/templates/) for full details.

    `jsonnet` templates can be used to create json data

    *File: custom.device.jsonnet*

    ```jsonnet
    {
        name: "my device",
        type: vars("type", "defaultType"),
        cpuThreshold: rand.int,
        c8y_IsDevice: {},
    }
    ```

    **Usage: Bash/zsh**

    ```sh
    c8y inventory create \
        --template ./examples/templates/device.jsonnet \
        --templateVars "type=myCustomType1" \
        --dry
    ```

    **Usage: PowerShell**

    ```sh
    New-ManagedObject `
        -Template ./examples/templates/measurement.jsonnet `
        -TemplateVars "type=myCustomType1" `
        -WhatIf
    ```

    **Output**

    These command would produce the following body which would be sent to Cumulocity.

    ```json
    {
        "name": "my device",
        "type": "myCustomType1",
        "c8y_IsDevice": {},
        "cpuThreshold": 88,
    }
    ```

    To help with the development of templates, there is a command which evaluates a template and prints the output to the console.

    **Bash/zsh**

    ```sh
    c8y template execute --template ./mytemplate.jsonnet
    ```

    **PowerShell**

    ```powershell
    Invoke-Template -Template ./template.jsonnet
    ```

* Added support for setting additional properties when uploading a binary file

    **PowerShell**

    ```powershell
    New-Binary -File "myfile.json" -Data @{ c8y_Global = @{}; type = "c8y_upload" }
    ```

    **Bash/zsh**

    ```sh
    c8y binaries create --file "myfile.json" --data "c8y_Global={},type=c8y_upload"
    ```