### PR TITLE
Feat/read only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+**Breaking Changes**
+
+* Added support for disabling create/update/delete command individually to prevent accidental data loss. See the [session concept documentation](https://reubenmiller.github.io/go-c8y-cli/docs/concepts/sessions/) for full details.
+    * create/update/delete command are disabled by default! They must be enabled otherwise the commands will return an error. Commands can be enabled/disabled from the session properties
+    * commands can be temporarily enabled/disabled in the session via environment variables without persisting them in the session settings
+    * CI mode which enables all commands via one environment variable
+
+**Features**
+
 * Added command to read the current configuration settings as json
 
     **PowerShell**

--- a/docs/_docs/concepts/sessions.md
+++ b/docs/_docs/concepts/sessions.md
@@ -106,7 +106,6 @@ All of the values in the sessions file, can also be overridden using environment
 | useTenantPrefix | C8Y_USETENANTPREFIX |
 
 
-
 ### Continuous Integration usage (environment variables)
 
 Alternatively, the Cumulocity session can be controlled purely by environment variables.
@@ -119,6 +118,7 @@ Then the Cumulocity settings can be set by the following environment variables.
 * C8Y_TENANT (example "myTenant")
 * C8Y_USER
 * C8Y_PASSWORD
+* C8Y_SETTINGS_CI
 
 
 ### Switching sessions for a single command
@@ -137,4 +137,92 @@ c8y devices list --session myother.tenant
 
 ```powershell
 Get-DeviceCollection -Session myother.tenant
+```
+
+### Protection against accidental data loss
+
+The c8y cli tool provides a large number of commands which can be potentially destructive if used incorrectly. Therefore all commands which create, update and/or delete data are disabled by default, to protect against accidental usage.
+
+The commands can be enabled per session or in global settings, however explicitily enabling it per session is the perferred method.
+
+Ideally for production sessions, the settings should be left disabled to protect yourself against accidental data loss, especially if you have a large number of tenants, and are constantly switching between them.
+
+The following shows how the functions can be controlled via session settings:
+
+*File: mysession.json*
+
+```json
+{
+  "settings": {
+    "mode.enableCreate": false,
+    "mode.enableUpdate": false,
+    "mode.enableDelete": false
+  }
+}
+```
+
+#### Enabling create/update/delete command temporarily
+
+When the commands are disabled in the session settings, they can be temporarily activated on the console by using the following command:
+
+**PowerShell**
+
+```powershell
+Set-ClientConsoleSetting -EnableCreateCommands -EnableUpdateCommands -EnableDeleteCommands
+```
+
+**Bash/zsh**
+
+```sh
+export C8Y_SETTINGS_MODE_ENABLECREATE=true
+export C8Y_SETTINGS_MODE_ENABLEUPDATE=true
+export C8Y_SETTINGS_MODE_ENABLEDELETE=true
+```
+
+The commands will remain enabled until the next time you call `set-session`.
+
+Afterwards you can disable them again using:
+
+**PowerShell**
+
+```powershell
+Set-ClientConsoleSetting -DisableCommands
+```
+
+**Bash/zsh**
+
+```sh
+unset C8Y_SETTINGS_MODE_ENABLECREATE
+unset C8Y_SETTINGS_MODE_ENABLEUPDATE
+unset C8Y_SETTINGS_MODE_ENABLEDELETE
+```
+
+#### CI/CD
+
+When used in a CI/CD environment, all commands (create/update/delete) can be enabled by setting the `settings.ci` property to `true`.
+
+The setting can also be set via an environment variable:
+
+**Bash/zsh**
+
+```sh
+export C8Y_SETTINGS_CI=true
+```
+
+**PowerShell**
+
+```sh
+$env:C8Y_SETTINGS_CI=true
+```
+
+Or alternatively, using setting it via the session file:
+
+*File: mysession.json*
+
+```json
+{
+  "settings": {
+    "ci": true
+  }
+}
 ```

--- a/docs/_docs/configuration/options.md
+++ b/docs/_docs/configuration/options.md
@@ -27,6 +27,10 @@ The following table lists the available settings, the environment variable equiv
 | includeAll.pageSize | `C8Y_SETTINGS_INCLUDEALL_PAGESIZE` | Default page size when using the includeAll parameter |
 | includeAll.delayMS | `C8Y_SETTINGS_INCLUDEALL_DELAYMS` | Delay between fetching the next page when using the includeAll parameter |
 | template.path | `C8Y_SETTINGS_TEMPLATE_PATH` | Path / Folder where the templates are located. If the user gives a template name (without path), then a matching filename will be search for in this folder |
+| ci | `C8Y_SETTINGS_CI` | Enable CI/CD mode where any command restrictions will be disabled |
+| mode.enableCreate | `C8Y_SETTINGS_MODE_ENABLECREATE` | Enable/disable create commands |
+| mode.enableUpdate | `C8Y_SETTINGS_MODE_ENABLEUPDATE` | Enable/disable update commands |
+| mode.enableDelete | `C8Y_SETTINGS_MODE_ENABLEDELETE` | Enable/disable delete commands |
 
 ### Example: Set global defaults to use in each c8y session
 

--- a/pkg/cmd/addDeviceToGroupCmd.auto.go
+++ b/pkg/cmd/addDeviceToGroupCmd.auto.go
@@ -29,8 +29,9 @@ Add a device to a group
 
 $ c8y inventoryReferences assignDeviceToGroup --group 12345 --newChildDevice 43234, 99292, 12222
 Add multiple devices to a group
-		`,
-		RunE: ccmd.addDeviceToGroup,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.addDeviceToGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/addGroupToGroupCmd.auto.go
+++ b/pkg/cmd/addGroupToGroupCmd.auto.go
@@ -29,8 +29,9 @@ Add a group to a group
 
 $ c8y inventoryReferences assignGroupToGroup --group 12345 --newChildGroup 43234, 99292, 12222
 Add multiple groups to a group
-		`,
-		RunE: ccmd.addGroupToGroup,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.addGroupToGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/addRoleToGroupCmd.auto.go
+++ b/pkg/cmd/addRoleToGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newAddRoleToGroupCmd() *addRoleToGroupCmd {
 		Example: `
 $ c8y userRoles addRoleToGroup --group "customGroup1*" --role "*ALARM*"
 Add a role to the admin group
-		`,
-		RunE: ccmd.addRoleToGroup,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.addRoleToGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/addRoleToUserCmd.auto.go
+++ b/pkg/cmd/addRoleToUserCmd.auto.go
@@ -26,8 +26,9 @@ func newAddRoleToUserCmd() *addRoleToUserCmd {
 		Example: `
 $ c8y userRoles addRoleTouser --user "myuser" --role "ROLE_ALARM_READ"
 Add a role (ROLE_ALARM_READ) to a user
-		`,
-		RunE: ccmd.addRoleToUser,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.addRoleToUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/addUserToGroupCmd.auto.go
+++ b/pkg/cmd/addUserToGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newAddUserToGroupCmd() *addUserToGroupCmd {
 		Example: `
 $ c8y userReferences addUserToGroup --group 1 --user myuser
 List the users within a user group
-		`,
-		RunE: ccmd.addUserToGroup,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.addUserToGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/approveNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/approveNewDeviceRequestCmd.auto.go
@@ -26,8 +26,9 @@ func newApproveNewDeviceRequestCmd() *approveNewDeviceRequestCmd {
 		Example: `
 $ c8y devices approveDeviceRequest --id "1234010101s01ldk208"
 Approve a new device request
-		`,
-		RunE: ccmd.approveNewDeviceRequest,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.approveNewDeviceRequest,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/copyApplicationCmd.auto.go
+++ b/pkg/cmd/copyApplicationCmd.auto.go
@@ -31,8 +31,9 @@ Required role ROLE_APPLICATION_MANAGMENT_ADMIN
 		Example: `
 $ c8y applications copy --id my-example-app
 Copy an existing application
-		`,
-		RunE: ccmd.copyApplication,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.copyApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/createAgentCmd.auto.go
+++ b/pkg/cmd/createAgentCmd.auto.go
@@ -31,8 +31,9 @@ Create agent
 
 $ c8y agents create --name myAgent --data "custom_value1=1234"
 Create agent with custom properties
-		`,
-		RunE: ccmd.createAgent,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.createAgent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/createDeviceCmd.auto.go
+++ b/pkg/cmd/createDeviceCmd.auto.go
@@ -30,8 +30,9 @@ Create device
 
 $ c8y devices create --name myDevice --data "custom_value1=1234"
 Create device with custom properties
-		`,
-		RunE: ccmd.createDevice,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.createDevice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/createDeviceGroupCmd.auto.go
+++ b/pkg/cmd/createDeviceGroupCmd.auto.go
@@ -30,8 +30,9 @@ Create device group
 
 $ c8y devices createGroup --name mygroup --data "custom_value1=1234"
 Create device group with custom properties
-		`,
-		RunE: ccmd.createDeviceGroup,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.createDeviceGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/currentTenantCmd.auto.go
+++ b/pkg/cmd/currentTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newCurrentTenantCmd() *currentTenantCmd {
 		Example: `
 $ c8y tenants getCurrentTenant
 Get the current tenant (based on your current credentials)
-		`,
-		RunE: ccmd.currentTenant,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.currentTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteAgentCmd.auto.go
+++ b/pkg/cmd/deleteAgentCmd.auto.go
@@ -28,8 +28,9 @@ func newDeleteAgentCmd() *deleteAgentCmd {
 		Example: `
 $ c8y agents delete --id 12345
 Get agent by id
-		`,
-		RunE: ccmd.deleteAgent,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteAgent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/deleteAlarmCollectionCmd.auto.go
@@ -29,8 +29,9 @@ Remove alarms on the device with the severity set to MAJOR
 
 $ c8y alarms deleteCollection --device mydevice --dateFrom "-10m" --status ACTIVE
 Remove alarms on the device which are active and created in the last 10 minutes
-		`,
-		RunE: ccmd.deleteAlarmCollection,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteAlarmCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteApplicationCmd.auto.go
+++ b/pkg/cmd/deleteApplicationCmd.auto.go
@@ -29,8 +29,9 @@ Delete an application by id
 
 $ c8y applications delete --id my-temp-app
 Delete an application by name
-		`,
-		RunE: ccmd.deleteApplication,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteAssetFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteAssetFromGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteAssetFromGroupCmd() *deleteAssetFromGroupCmd {
 		Example: `
 $ c8y inventoryReferences unassignAssetFromGroup --device 12345 --childDevice 22553
 Unassign a child device from its parent device
-		`,
-		RunE: ccmd.deleteAssetFromGroup,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteAssetFromGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteBinaryCmd.auto.go
+++ b/pkg/cmd/deleteBinaryCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteBinaryCmd() *deleteBinaryCmd {
 		Example: `
 $ c8y binaries delete --id 12345
 Delete a binary
-		`,
-		RunE: ccmd.deleteBinary,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteDeviceCmd.auto.go
+++ b/pkg/cmd/deleteDeviceCmd.auto.go
@@ -27,8 +27,9 @@ func newDeleteDeviceCmd() *deleteDeviceCmd {
 		Example: `
 $ c8y devices delete --id 12345
 Get device by id
-		`,
-		RunE: ccmd.deleteDevice,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteDevice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteDeviceFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteDeviceFromGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteDeviceFromGroupCmd() *deleteDeviceFromGroupCmd {
 		Example: `
 $ c8y inventoryReferences unassignDeviceFromGroup --group 12345 --childDevice 22553
 Unassign a child device from its parent device
-		`,
-		RunE: ccmd.deleteDeviceFromGroup,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteDeviceFromGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteDeviceGroupCmd.auto.go
+++ b/pkg/cmd/deleteDeviceGroupCmd.auto.go
@@ -27,8 +27,9 @@ func newDeleteDeviceGroupCmd() *deleteDeviceGroupCmd {
 		Example: `
 $ c8y devices deleteGroup --id 12345
 Get device group by id
-		`,
-		RunE: ccmd.deleteDeviceGroup,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteDeviceGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteEventBinaryCmd.auto.go
+++ b/pkg/cmd/deleteEventBinaryCmd.auto.go
@@ -27,8 +27,9 @@ func newDeleteEventBinaryCmd() *deleteEventBinaryCmd {
 		Example: `
 $ c8y events deleteBinary --id 12345
 Delete an binary attached to an event
-		`,
-		RunE: ccmd.deleteEventBinary,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteEventBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteEventCmd.auto.go
+++ b/pkg/cmd/deleteEventCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteEventCmd() *deleteEventCmd {
 		Example: `
 $ c8y events delete --id 12345
 Delete an event
-		`,
-		RunE: ccmd.deleteEvent,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteEvent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteEventCollectionCmd.auto.go
+++ b/pkg/cmd/deleteEventCollectionCmd.auto.go
@@ -29,8 +29,9 @@ Remove events with type 'my_CustomType' that were created in the last 10 days
 
 $ c8y events deleteCollection --device mydevice
 Remove events from a device
-		`,
-		RunE: ccmd.deleteEventCollection,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteEventCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteExternalIDCmd.auto.go
+++ b/pkg/cmd/deleteExternalIDCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteExternalIDCmd() *deleteExternalIDCmd {
 		Example: `
 $ c8y identity delete --type test --name myserialnumber
 Delete external identity
-		`,
-		RunE: ccmd.deleteExternalID,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteExternalID,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteGroupCmd.auto.go
+++ b/pkg/cmd/deleteGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteGroupCmd() *deleteGroupCmd {
 		Example: `
 $ c8y userGroups delete --id 12345
 Delete a user group
-		`,
-		RunE: ccmd.deleteGroup,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteManagedObjectChildAssetReferenceCmd.auto.go
+++ b/pkg/cmd/deleteManagedObjectChildAssetReferenceCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteManagedObjectChildAssetReferenceCmd() *deleteManagedObjectChildAss
 		Example: `
 $ c8y inventoryReferences unassignAssetFromGroup --group 12345 --childDevice 22553
 Unassign a child device from its parent device
-		`,
-		RunE: ccmd.deleteManagedObjectChildAssetReference,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteManagedObjectChildAssetReference,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteManagedObjectChildDeviceReferenceCmd.auto.go
+++ b/pkg/cmd/deleteManagedObjectChildDeviceReferenceCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteManagedObjectChildDeviceReferenceCmd() *deleteManagedObjectChildDe
 		Example: `
 $ c8y inventoryReferences unassignChildDevice --device 12345 --childDevice 22553
 Unassign a child device from its parent device
-		`,
-		RunE: ccmd.deleteManagedObjectChildDeviceReference,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteManagedObjectChildDeviceReference,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteManagedObjectCmd.auto.go
+++ b/pkg/cmd/deleteManagedObjectCmd.auto.go
@@ -29,8 +29,9 @@ Delete a managed object
 
 $ c8y inventory delete --id 12345 --cascade
 Delete a managed object
-		`,
-		RunE: ccmd.deleteManagedObject,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteManagedObject,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteMeasurementCmd.auto.go
+++ b/pkg/cmd/deleteMeasurementCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteMeasurementCmd() *deleteMeasurementCmd {
 		Example: `
 $ c8y measurements delete --id 12345
 Delete measurement
-		`,
-		RunE: ccmd.deleteMeasurement,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteMeasurement,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteMeasurementCollectionCmd.auto.go
+++ b/pkg/cmd/deleteMeasurementCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteMeasurementCollectionCmd() *deleteMeasurementCollectionCmd {
 		Example: `
 $ c8y measurements deleteCollection --device $Measurement.source.id
 Delete measurement collection for a device
-		`,
-		RunE: ccmd.deleteMeasurementCollection,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteMeasurementCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteMicroserviceCmd.auto.go
+++ b/pkg/cmd/deleteMicroserviceCmd.auto.go
@@ -29,8 +29,9 @@ Delete an microservice by id
 
 $ c8y microservices delete --id my-temp-app
 Delete a microservice by name
-		`,
-		RunE: ccmd.deleteMicroservice,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteMicroservice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/deleteNewDeviceRequestCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteNewDeviceRequestCmd() *deleteNewDeviceRequestCmd {
 		Example: `
 $ c8y devices deleteNewDeviceRequest --id "91019192078"
 Delete a new device request
-		`,
-		RunE: ccmd.deleteNewDeviceRequest,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteNewDeviceRequest,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteOperationCollectionCmd.auto.go
+++ b/pkg/cmd/deleteOperationCollectionCmd.auto.go
@@ -27,8 +27,9 @@ func newDeleteOperationCollectionCmd() *deleteOperationCollectionCmd {
 		Example: `
 $ c8y operations deleteCollection --device mydevice --status PENDING
 Remove all pending operations for a given device
-		`,
-		RunE: ccmd.deleteOperationCollection,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteOperationCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteRetentionRuleCmd.auto.go
+++ b/pkg/cmd/deleteRetentionRuleCmd.auto.go
@@ -27,8 +27,9 @@ func newDeleteRetentionRuleCmd() *deleteRetentionRuleCmd {
 		Example: `
 $ c8y retentionRules delete --id 12345
 Delete a retention rule
-		`,
-		RunE: ccmd.deleteRetentionRule,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteRetentionRule,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteRoleFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteRoleFromGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteRoleFromGroupCmd() *deleteRoleFromGroupCmd {
 		Example: `
 $ c8y userRoles deleteRoleFromGroup --group "myuser" --role "ROLE_MEASUREMENT_READ"
 Remove a role from the given user
-		`,
-		RunE: ccmd.deleteRoleFromGroup,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteRoleFromGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteRoleFromUserCmd.auto.go
+++ b/pkg/cmd/deleteRoleFromUserCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteRoleFromUserCmd() *deleteRoleFromUserCmd {
 		Example: `
 $ c8y userRoles deleteRoleFromUser --user "myuser" --role "ROLE_MEASUREMENT_READ"
 Remove a role from the given user
-		`,
-		RunE: ccmd.deleteRoleFromUser,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteRoleFromUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteTenantCmd.auto.go
+++ b/pkg/cmd/deleteTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteTenantCmd() *deleteTenantCmd {
 		Example: `
 $ c8y tenants delete --id "mycompany"
 Delete a tenant by name (from the mangement tenant)
-		`,
-		RunE: ccmd.deleteTenant,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteTenantOptionCmd.auto.go
+++ b/pkg/cmd/deleteTenantOptionCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteTenantOptionCmd() *deleteTenantOptionCmd {
 		Example: `
 $ c8y tenantOptions delete --category "c8y_cli_tests" --key "option3"
 Get a tenant option
-		`,
-		RunE: ccmd.deleteTenantOption,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteTenantOption,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteUserCmd.auto.go
+++ b/pkg/cmd/deleteUserCmd.auto.go
@@ -28,8 +28,9 @@ Alternatively a user can be disabled via updating the users properties instead o
 		Example: `
 $ c8y users delete --id "myuser"
 Delete a user
-		`,
-		RunE: ccmd.deleteUser,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/deleteUserFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteUserFromGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newDeleteUserFromGroupCmd() *deleteUserFromGroupCmd {
 		Example: `
 $ c8y userReferences deleteUserFromGroup --group 1 --user myuser
 List the users within a user group
-		`,
-		RunE: ccmd.deleteUserFromGroup,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteUserFromGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/disableApplicationFromTenantCmd.auto.go
+++ b/pkg/cmd/disableApplicationFromTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newDisableApplicationFromTenantCmd() *disableApplicationFromTenantCmd {
 		Example: `
 $ c8y tenants disableApplication --tenant "mycompany" --application "myMicroservice"
 Disable an application of a tenant by name
-		`,
-		RunE: ccmd.disableApplicationFromTenant,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.disableApplicationFromTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/disableMicroserviceCmd.auto.go
+++ b/pkg/cmd/disableMicroserviceCmd.auto.go
@@ -30,8 +30,9 @@ Disable (unsubscribe) to a microservice
 
 $ c8y microservices disable --id myapp
 Disable (unsubscribe) to a microservice
-		`,
-		RunE: ccmd.disableMicroservice,
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.disableMicroservice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/downloadCmd.auto.go
+++ b/pkg/cmd/downloadCmd.auto.go
@@ -30,8 +30,9 @@ Get a binary and display the contents on the console
 
 $ c8y binaries get --id 12345 --outputFile "./download-binary1.txt"
 Get a binary and save it to a file
-		`,
-		RunE: ccmd.download,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.download,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/enableApplicationOnTenantCmd.auto.go
+++ b/pkg/cmd/enableApplicationOnTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newEnableApplicationOnTenantCmd() *enableApplicationOnTenantCmd {
 		Example: `
 $ c8y tenants enableApplication --tenant "mycompany" --application "myMicroservice"
 Enable an application of a tenant by name
-		`,
-		RunE: ccmd.enableApplicationOnTenant,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.enableApplicationOnTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/enableMicroserviceCmd.auto.go
+++ b/pkg/cmd/enableMicroserviceCmd.auto.go
@@ -30,8 +30,9 @@ Enable (subscribe) to a microservice
 
 $ c8y microservices enable --id myapp
 Enable (subscribe) to a microservice
-		`,
-		RunE: ccmd.enableMicroservice,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.enableMicroservice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/genericRestCmd.go
+++ b/pkg/cmd/genericRestCmd.go
@@ -96,6 +96,22 @@ func (n *getGenericRestCmd) getGenericRest(cmd *cobra.Command, args []string) er
 		return newUserError("Invalid method. Only GET, PUT, POST and DELETE are accepted")
 	}
 
+	if method == "PUT" {
+		if err := validateUpdateMode(cmd, args); err != nil {
+			return err
+		}
+	}
+	if method == "POST" {
+		if err := validateCreateMode(cmd, args); err != nil {
+			return err
+		}
+	}
+	if method == "DELETE" {
+		if err := validateDeleteMode(cmd, args); err != nil {
+			return err
+		}
+	}
+
 	baseURL, _ := url.Parse(uri)
 
 	var host string

--- a/pkg/cmd/getAgentCmd.auto.go
+++ b/pkg/cmd/getAgentCmd.auto.go
@@ -26,8 +26,9 @@ func newGetAgentCmd() *getAgentCmd {
 		Example: `
 $ c8y agents get --id 12345
 Get agent by id
-		`,
-		RunE: ccmd.getAgent,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getAgent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getAlarmCmd.auto.go
+++ b/pkg/cmd/getAlarmCmd.auto.go
@@ -26,8 +26,9 @@ func newGetAlarmCmd() *getAlarmCmd {
 		Example: `
 $ c8y alarms get --id 12345
 Get alarm
-		`,
-		RunE: ccmd.getAlarm,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getAlarm,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/getAlarmCollectionCmd.auto.go
@@ -29,8 +29,9 @@ Get alarms with the severity set to MAJOR
 
 $ c8y alarms list --dateFrom "-10m" --status ACTIVE
 Get collection of active alarms which occurred in the last 10 minutes
-		`,
-		RunE: ccmd.getAlarmCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getAlarmCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getAllTenantUsageStatisticsSummaryCollectionCmd.auto.go
+++ b/pkg/cmd/getAllTenantUsageStatisticsSummaryCollectionCmd.auto.go
@@ -32,8 +32,9 @@ Get tenant summary statistics collection for the last 30 days
 
 $ c8y tenantStatistics listSummaryAllTenants --dateFrom "-10d" --dateTo "-9d"
 Get tenant summary statistics collection for the last 10 days, only return until the last 9 days
-		`,
-		RunE: ccmd.getAllTenantUsageStatisticsSummaryCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getAllTenantUsageStatisticsSummaryCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getApplicationBinaryCollectionCmd.auto.go
+++ b/pkg/cmd/getApplicationBinaryCollectionCmd.auto.go
@@ -27,8 +27,9 @@ func newGetApplicationBinaryCollectionCmd() *getApplicationBinaryCollectionCmd {
 		Example: `
 $ c8y applications listApplicationBinaries --id 12345
 List all of the binaries related to a Hosted (web) application
-		`,
-		RunE: ccmd.getApplicationBinaryCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getApplicationBinaryCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getApplicationCmd.auto.go
+++ b/pkg/cmd/getApplicationCmd.auto.go
@@ -26,8 +26,9 @@ func newGetApplicationCmd() *getApplicationCmd {
 		Example: `
 $ c8y applications get --id 12345
 Get an application
-		`,
-		RunE: ccmd.getApplication,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getApplicationCollectionCmd.auto.go
+++ b/pkg/cmd/getApplicationCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetApplicationCollectionCmd() *getApplicationCollectionCmd {
 		Example: `
 $ c8y applications list --pageSize 100
 Get applications
-		`,
-		RunE: ccmd.getApplicationCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getApplicationCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getApplicationReferenceCollectionCmd.auto.go
+++ b/pkg/cmd/getApplicationReferenceCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetApplicationReferenceCollectionCmd() *getApplicationReferenceCollectio
 		Example: `
 $ c8y tenants listReferences --tenant "mycompany"
 Get a list of referenced applications on a given tenant (from management tenant)
-		`,
-		RunE: ccmd.getApplicationReferenceCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getApplicationReferenceCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getAuditRecordCmd.auto.go
+++ b/pkg/cmd/getAuditRecordCmd.auto.go
@@ -26,8 +26,9 @@ func newGetAuditRecordCmd() *getAuditRecordCmd {
 		Example: `
 $ c8y auditRecords get --id 12345
 Get an audit record by id
-		`,
-		RunE: ccmd.getAuditRecord,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getAuditRecord,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getAuditRecordCollectionCmd.auto.go
+++ b/pkg/cmd/getAuditRecordCollectionCmd.auto.go
@@ -27,8 +27,9 @@ func newGetAuditRecordCollectionCmd() *getAuditRecordCollectionCmd {
 		Example: `
 $ c8y auditRecords list --pageSize 100
 Get a list of audit records
-		`,
-		RunE: ccmd.getAuditRecordCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getAuditRecordCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getBinaryCollectionCmd.auto.go
+++ b/pkg/cmd/getBinaryCollectionCmd.auto.go
@@ -27,8 +27,9 @@ func newGetBinaryCollectionCmd() *getBinaryCollectionCmd {
 		Example: `
 $ c8y binaries list --pageSize 100
 Get a list of binaries
-		`,
-		RunE: ccmd.getBinaryCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getBinaryCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getCurrentApplicationCmd.auto.go
+++ b/pkg/cmd/getCurrentApplicationCmd.auto.go
@@ -27,8 +27,9 @@ func newGetCurrentApplicationCmd() *getCurrentApplicationCmd {
 		Example: `
 $ c8y currentApplication get
 Get the current application (requires using application credentials)
-		`,
-		RunE: ccmd.getCurrentApplication,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getCurrentApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getCurrentApplicationUserCollectionCmd.auto.go
+++ b/pkg/cmd/getCurrentApplicationUserCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetCurrentApplicationUserCollectionCmd() *getCurrentApplicationUserColle
 		Example: `
 $ c8y currentApplication listSubscriptions
 List the current application users/subscriptions
-		`,
-		RunE: ccmd.getCurrentApplicationUserCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getCurrentApplicationUserCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getCurrentUserInventoryRoleCmd.auto.go
+++ b/pkg/cmd/getCurrentUserInventoryRoleCmd.auto.go
@@ -26,8 +26,9 @@ func newGetCurrentUserInventoryRoleCmd() *getCurrentUserInventoryRoleCmd {
 		Example: `
 $ c8y users getCurrentUserInventoryRole --id 12345
 Get an inventory role of the current user
-		`,
-		RunE: ccmd.getCurrentUserInventoryRole,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getCurrentUserInventoryRole,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getCurrentUserInventoryRoleCollectionCmd.auto.go
+++ b/pkg/cmd/getCurrentUserInventoryRoleCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetCurrentUserInventoryRoleCollectionCmd() *getCurrentUserInventoryRoleC
 		Example: `
 $ c8y currentUser listInventoryRoles
 Get the current user
-		`,
-		RunE: ccmd.getCurrentUserInventoryRoleCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getCurrentUserInventoryRoleCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getDataBrokerCmd.auto.go
+++ b/pkg/cmd/getDataBrokerCmd.auto.go
@@ -26,8 +26,9 @@ func newGetDataBrokerCmd() *getDataBrokerCmd {
 		Example: `
 $ c8y databroker get --id 12345
 Get a data broker connector
-		`,
-		RunE: ccmd.getDataBroker,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getDataBroker,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getDataBrokerConnectorCollectionCmd.auto.go
+++ b/pkg/cmd/getDataBrokerConnectorCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetDataBrokerConnectorCollectionCmd() *getDataBrokerConnectorCollectionC
 		Example: `
 $ c8y databroker list
 Get a list of data broker connectors
-		`,
-		RunE: ccmd.getDataBrokerConnectorCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getDataBrokerConnectorCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getDeviceCmd.auto.go
+++ b/pkg/cmd/getDeviceCmd.auto.go
@@ -26,8 +26,9 @@ func newGetDeviceCmd() *getDeviceCmd {
 		Example: `
 $ c8y devices get --id 12345
 Get device by id
-		`,
-		RunE: ccmd.getDevice,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getDevice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getDeviceGroupCmd.auto.go
+++ b/pkg/cmd/getDeviceGroupCmd.auto.go
@@ -27,8 +27,9 @@ func newGetDeviceGroupCmd() *getDeviceGroupCmd {
 		Example: `
 $ c8y devices getGroup --id 12345
 Get device group by id
-		`,
-		RunE: ccmd.getDeviceGroup,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getDeviceGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getEventBinaryCmd.auto.go
+++ b/pkg/cmd/getEventBinaryCmd.auto.go
@@ -26,8 +26,9 @@ func newGetEventBinaryCmd() *getEventBinaryCmd {
 		Example: `
 $ c8y events downloadBinary --id 12345 --outputFile ./eventbinary.txt
 Download a binary related to an event
-		`,
-		RunE: ccmd.getEventBinary,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getEventBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getEventCmd.auto.go
+++ b/pkg/cmd/getEventCmd.auto.go
@@ -26,8 +26,9 @@ func newGetEventCmd() *getEventCmd {
 		Example: `
 $ c8y events get --id 12345
 Get event
-		`,
-		RunE: ccmd.getEvent,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getEvent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getEventCollectionCmd.auto.go
+++ b/pkg/cmd/getEventCollectionCmd.auto.go
@@ -29,8 +29,9 @@ Get events with type 'my_CustomType' that were created in the last 10 days
 
 $ c8y events list --device mydevice
 Get events from a device
-		`,
-		RunE: ccmd.getEventCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getEventCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getExternalIDCmd.auto.go
+++ b/pkg/cmd/getExternalIDCmd.auto.go
@@ -27,8 +27,9 @@ func newGetExternalIDCmd() *getExternalIDCmd {
 		Example: `
 $ c8y identity get --type test --name myserialnumber
 Get external identity
-		`,
-		RunE: ccmd.getExternalID,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getExternalID,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getExternalIDCollectionCmd.auto.go
+++ b/pkg/cmd/getExternalIDCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetExternalIDCollectionCmd() *getExternalIDCollectionCmd {
 		Example: `
 $ c8y identity list
 Get a list of external ids
-		`,
-		RunE: ccmd.getExternalIDCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getExternalIDCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getGroupByNameCmd.auto.go
+++ b/pkg/cmd/getGroupByNameCmd.auto.go
@@ -26,8 +26,9 @@ func newGetGroupByNameCmd() *getGroupByNameCmd {
 		Example: `
 $ c8y userGroups getByName --name customGroup1
 Get user group by its name
-		`,
-		RunE: ccmd.getGroupByName,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getGroupByName,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getGroupCmd.auto.go
+++ b/pkg/cmd/getGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newGetGroupCmd() *getGroupCmd {
 		Example: `
 $ c8y userGroups get --id 12345
 Get a user group
-		`,
-		RunE: ccmd.getGroup,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getGroupCollectionCmd.auto.go
+++ b/pkg/cmd/getGroupCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetGroupCollectionCmd() *getGroupCollectionCmd {
 		Example: `
 $ c8y userGroups list
 Get a list of user groups for the current tenant
-		`,
-		RunE: ccmd.getGroupCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getGroupCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getManagedObjectChildAssetCollectionCmd.auto.go
+++ b/pkg/cmd/getManagedObjectChildAssetCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetManagedObjectChildAssetCollectionCmd() *getManagedObjectChildAssetCol
 		Example: `
 $ c8y inventoryReferences listChildAssets --device 12345
 Get a list of the child devices of an existing device
-		`,
-		RunE: ccmd.getManagedObjectChildAssetCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObjectChildAssetCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getManagedObjectChildAssetReferenceCmd.auto.go
+++ b/pkg/cmd/getManagedObjectChildAssetReferenceCmd.auto.go
@@ -26,8 +26,9 @@ func newGetManagedObjectChildAssetReferenceCmd() *getManagedObjectChildAssetRefe
 		Example: `
 $ c8y inventoryReferences getChildAsset --asset 12345 --reference 12345
 Get an existing child asset reference
-		`,
-		RunE: ccmd.getManagedObjectChildAssetReference,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObjectChildAssetReference,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getManagedObjectChildDeviceCollectionCmd.auto.go
+++ b/pkg/cmd/getManagedObjectChildDeviceCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetManagedObjectChildDeviceCollectionCmd() *getManagedObjectChildDeviceC
 		Example: `
 $ c8y inventoryReferences listChildDevices --device 12345
 Get a list of the child devices of an existing device
-		`,
-		RunE: ccmd.getManagedObjectChildDeviceCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObjectChildDeviceCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getManagedObjectChildDeviceReferenceCmd.auto.go
+++ b/pkg/cmd/getManagedObjectChildDeviceReferenceCmd.auto.go
@@ -26,8 +26,9 @@ func newGetManagedObjectChildDeviceReferenceCmd() *getManagedObjectChildDeviceRe
 		Example: `
 $ c8y inventoryReferences getChildDevice --device 12345 --reference 12345
 Get an existing child device reference
-		`,
-		RunE: ccmd.getManagedObjectChildDeviceReference,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObjectChildDeviceReference,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getManagedObjectCmd.auto.go
+++ b/pkg/cmd/getManagedObjectCmd.auto.go
@@ -29,8 +29,9 @@ Get a managed object
 
 $ c8y inventory get --id 12345 --withParents
 Get a managed object with parent references
-		`,
-		RunE: ccmd.getManagedObject,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObject,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getManagedObjectCollectionCmd.auto.go
+++ b/pkg/cmd/getManagedObjectCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetManagedObjectCollectionCmd() *getManagedObjectCollectionCmd {
 		Example: `
 $ c8y inventory list
 Get a list of managed objects
-		`,
-		RunE: ccmd.getManagedObjectCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObjectCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getMeasurementCmd.auto.go
+++ b/pkg/cmd/getMeasurementCmd.auto.go
@@ -26,8 +26,9 @@ func newGetMeasurementCmd() *getMeasurementCmd {
 		Example: `
 $ c8y measurements get --id 12345
 Get measurement
-		`,
-		RunE: ccmd.getMeasurement,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getMeasurement,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getMeasurementCollectionCmd.auto.go
+++ b/pkg/cmd/getMeasurementCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetMeasurementCollectionCmd() *getMeasurementCollectionCmd {
 		Example: `
 $ c8y measurements list
 Get a list of measurements
-		`,
-		RunE: ccmd.getMeasurementCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getMeasurementCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getMeasurementSeriesCmd.auto.go
+++ b/pkg/cmd/getMeasurementSeriesCmd.auto.go
@@ -26,8 +26,9 @@ func newGetMeasurementSeriesCmd() *getMeasurementSeriesCmd {
 		Example: `
 $ c8y measurements getSeries -source 12345 --series nx_WEA_29_Delta.MDL10FG001 --series nx_WEA_29_Delta.ST9 --dateFrom "-10min" --dateTo "0s"
 Get a list of series [nx_WEA_29_Delta.MDL10FG001] and [nx_WEA_29_Delta.ST9] for device 12345
-		`,
-		RunE: ccmd.getMeasurementSeries,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getMeasurementSeries,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getMicroserviceBootstrapUserCmd.auto.go
+++ b/pkg/cmd/getMicroserviceBootstrapUserCmd.auto.go
@@ -30,8 +30,9 @@ Get application bootstrap user by app id
 
 $ c8y microservices getBootstrapUser --id myapp
 Get application bootstrap user by app name
-		`,
-		RunE: ccmd.getMicroserviceBootstrapUser,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getMicroserviceBootstrapUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getMicroserviceCmd.auto.go
+++ b/pkg/cmd/getMicroserviceCmd.auto.go
@@ -26,8 +26,9 @@ func newGetMicroserviceCmd() *getMicroserviceCmd {
 		Example: `
 $ c8y microservices get --id 12345
 Get an application
-		`,
-		RunE: ccmd.getMicroservice,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getMicroservice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getMicroserviceCollectionCmd.auto.go
+++ b/pkg/cmd/getMicroserviceCollectionCmd.auto.go
@@ -27,8 +27,9 @@ func newGetMicroserviceCollectionCmd() *getMicroserviceCollectionCmd {
 		Example: `
 $ c8y microservices list --pageSize 100
 Get microservices
-		`,
-		RunE: ccmd.getMicroserviceCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getMicroserviceCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/getNewDeviceRequestCmd.auto.go
@@ -26,8 +26,9 @@ func newGetNewDeviceRequestCmd() *getNewDeviceRequestCmd {
 		Example: `
 $ c8y devices getNewDeviceRequest
 Get a new device request
-		`,
-		RunE: ccmd.getNewDeviceRequest,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getNewDeviceRequest,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getNewDeviceRequestCollectionCmd.auto.go
+++ b/pkg/cmd/getNewDeviceRequestCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetNewDeviceRequestCollectionCmd() *getNewDeviceRequestCollectionCmd {
 		Example: `
 $ c8y devices listNewDeviceRequests
 Get a list of new device requests
-		`,
-		RunE: ccmd.getNewDeviceRequestCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getNewDeviceRequestCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getOperationCmd.auto.go
+++ b/pkg/cmd/getOperationCmd.auto.go
@@ -26,8 +26,9 @@ func newGetOperationCmd() *getOperationCmd {
 		Example: `
 $ c8y operations get --id 12345
 Get operation by id
-		`,
-		RunE: ccmd.getOperation,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getOperation,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getOperationCollectionCmd.auto.go
+++ b/pkg/cmd/getOperationCollectionCmd.auto.go
@@ -32,8 +32,9 @@ Get a list of pending operations for a given agent and all of its child devices
 
 $ c8y operations list --device mydevice --status PENDING
 Get a list of pending operations for a device
-		`,
-		RunE: ccmd.getOperationCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getOperationCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getRetentionRuleCmd.auto.go
+++ b/pkg/cmd/getRetentionRuleCmd.auto.go
@@ -27,8 +27,9 @@ func newGetRetentionRuleCmd() *getRetentionRuleCmd {
 		Example: `
 $ c8y retentionRules get --id 12345
 Get a retention rule
-		`,
-		RunE: ccmd.getRetentionRule,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getRetentionRule,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getRetentionRuleCollectionCmd.auto.go
+++ b/pkg/cmd/getRetentionRuleCollectionCmd.auto.go
@@ -27,8 +27,9 @@ func newGetRetentionRuleCollectionCmd() *getRetentionRuleCollectionCmd {
 		Example: `
 $ c8y retentionRules list
 Get a list of retention rules
-		`,
-		RunE: ccmd.getRetentionRuleCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getRetentionRuleCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getRoleCollectionCmd.auto.go
+++ b/pkg/cmd/getRoleCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetRoleCollectionCmd() *getRoleCollectionCmd {
 		Example: `
 $ c8y userRoles list --pageSize 100
 Get a list of roles
-		`,
-		RunE: ccmd.getRoleCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getRoleCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getRoleReferenceCollectionFromGroupCmd.auto.go
+++ b/pkg/cmd/getRoleReferenceCollectionFromGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newGetRoleReferenceCollectionFromGroupCmd() *getRoleReferenceCollectionFrom
 		Example: `
 $ c8y userRoles getRoleReferenceCollectionFromGroup --group "12345"
 Get a list of role references for a user group
-		`,
-		RunE: ccmd.getRoleReferenceCollectionFromGroup,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getRoleReferenceCollectionFromGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getRoleReferenceCollectionFromUserCmd.auto.go
+++ b/pkg/cmd/getRoleReferenceCollectionFromUserCmd.auto.go
@@ -26,8 +26,9 @@ func newGetRoleReferenceCollectionFromUserCmd() *getRoleReferenceCollectionFromU
 		Example: `
 $ c8y userRoles getRoleReferenceCollectionFromUser --user "myuser"
 Get a list of role references for a user
-		`,
-		RunE: ccmd.getRoleReferenceCollectionFromUser,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getRoleReferenceCollectionFromUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getSupportedMeasurementsCmd.auto.go
+++ b/pkg/cmd/getSupportedMeasurementsCmd.auto.go
@@ -27,8 +27,9 @@ func newGetSupportedMeasurementsCmd() *getSupportedMeasurementsCmd {
 		Example: `
 $ c8y inventory getSupportedMeasurements --device 12345
 Get the supported measurements of a device by name
-		`,
-		RunE: ccmd.getSupportedMeasurements,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getSupportedMeasurements,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getSupportedOperationsCmd.auto.go
+++ b/pkg/cmd/getSupportedOperationsCmd.auto.go
@@ -27,8 +27,9 @@ func newGetSupportedOperationsCmd() *getSupportedOperationsCmd {
 		Example: `
 $ c8y inventory getSupportedOperations --device 12345
 Get the supported operations of a device by name
-		`,
-		RunE: ccmd.getSupportedOperations,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getSupportedOperations,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getSupportedSeriesCmd.auto.go
+++ b/pkg/cmd/getSupportedSeriesCmd.auto.go
@@ -27,8 +27,9 @@ func newGetSupportedSeriesCmd() *getSupportedSeriesCmd {
 		Example: `
 $ c8y inventory getSupportedSeries --device 12345
 Get the supported measurement series of a device by name
-		`,
-		RunE: ccmd.getSupportedSeries,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getSupportedSeries,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getSystemOptionCmd.auto.go
+++ b/pkg/cmd/getSystemOptionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetSystemOptionCmd() *getSystemOptionCmd {
 		Example: `
 $ c8y systemOptions get --category "system" --key "version"
 Get a list of system options
-		`,
-		RunE: ccmd.getSystemOption,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getSystemOption,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getSystemOptionCollectionCmd.auto.go
+++ b/pkg/cmd/getSystemOptionCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetSystemOptionCollectionCmd() *getSystemOptionCollectionCmd {
 		Example: `
 $ c8y systemOptions list
 Get a list of system options
-		`,
-		RunE: ccmd.getSystemOptionCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getSystemOptionCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantCmd.auto.go
+++ b/pkg/cmd/getTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newGetTenantCmd() *getTenantCmd {
 		Example: `
 $ c8y tenants get --id "mycompany"
 Get a tenant by name (from the management tenant)
-		`,
-		RunE: ccmd.getTenant,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantCollectionCmd.auto.go
+++ b/pkg/cmd/getTenantCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetTenantCollectionCmd() *getTenantCollectionCmd {
 		Example: `
 $ c8y tenants list
 Get a list of tenants
-		`,
-		RunE: ccmd.getTenantCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantOptionCmd.auto.go
+++ b/pkg/cmd/getTenantOptionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetTenantOptionCmd() *getTenantOptionCmd {
 		Example: `
 $ c8y tenantOptions get --category "c8y_cli_tests" --key "option2"
 Get a tenant option
-		`,
-		RunE: ccmd.getTenantOption,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantOption,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantOptionCollectionCmd.auto.go
+++ b/pkg/cmd/getTenantOptionCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetTenantOptionCollectionCmd() *getTenantOptionCollectionCmd {
 		Example: `
 $ c8y tenantOptions list
 Get a list of tenant options
-		`,
-		RunE: ccmd.getTenantOptionCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantOptionCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantOptionsForCategoryCmd.auto.go
+++ b/pkg/cmd/getTenantOptionsForCategoryCmd.auto.go
@@ -26,8 +26,9 @@ func newGetTenantOptionsForCategoryCmd() *getTenantOptionsForCategoryCmd {
 		Example: `
 $ c8y tenantOptions getForCategory --category "c8y_cli_tests"
 Get a list of options for a category
-		`,
-		RunE: ccmd.getTenantOptionsForCategory,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantOptionsForCategory,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantUsageStatisticsCollectionCmd.auto.go
+++ b/pkg/cmd/getTenantUsageStatisticsCollectionCmd.auto.go
@@ -32,8 +32,9 @@ Get tenant statistics collection for the last 30 days
 
 $ c8y tenantStatistics list --dateFrom "-3d" --dateTo "-2d"
 Get tenant statistics collection for the day before yesterday
-		`,
-		RunE: ccmd.getTenantUsageStatisticsCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantUsageStatisticsCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantUsageStatisticsSummaryCollectionCmd.auto.go
+++ b/pkg/cmd/getTenantUsageStatisticsSummaryCollectionCmd.auto.go
@@ -32,8 +32,9 @@ Get tenant summary statistics collection for the last 30 days
 
 $ c8y tenantStatistics listSummaryForTenant --dateFrom "-10d" --dateTo "-9d"
 Get tenant summary statistics collection for the last 10 days, only return until the last 9 days
-		`,
-		RunE: ccmd.getTenantUsageStatisticsSummaryCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantUsageStatisticsSummaryCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getTenantVersionCmd.auto.go
+++ b/pkg/cmd/getTenantVersionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetTenantVersionCmd() *getTenantVersionCmd {
 		Example: `
 $ c8y tenants getVersion
 Set the required availability of a device by name to 10 minutes
-		`,
-		RunE: ccmd.getTenantVersion,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getTenantVersion,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getUserByNameCmd.auto.go
+++ b/pkg/cmd/getUserByNameCmd.auto.go
@@ -26,8 +26,9 @@ func newGetUserByNameCmd() *getUserByNameCmd {
 		Example: `
 $ c8y users getUserByName --name "myuser"
 Get a user by name
-		`,
-		RunE: ccmd.getUserByName,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getUserByName,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getUserCmd.auto.go
+++ b/pkg/cmd/getUserCmd.auto.go
@@ -26,8 +26,9 @@ func newGetUserCmd() *getUserCmd {
 		Example: `
 $ c8y users get --id "myuser"
 Get a user
-		`,
-		RunE: ccmd.getUser,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getUserCollectionCmd.auto.go
+++ b/pkg/cmd/getUserCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetUserCollectionCmd() *getUserCollectionCmd {
 		Example: `
 $ c8y users list
 Get a list of users
-		`,
-		RunE: ccmd.getUserCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getUserCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getUserCurrentCmd.auto.go
+++ b/pkg/cmd/getUserCurrentCmd.auto.go
@@ -26,8 +26,9 @@ func newGetUserCurrentCmd() *getUserCurrentCmd {
 		Example: `
 $ c8y users getCurrentUser
 Get the current user
-		`,
-		RunE: ccmd.getUserCurrent,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getUserCurrent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getUserMembershipCollectionCmd.auto.go
+++ b/pkg/cmd/getUserMembershipCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newGetUserMembershipCollectionCmd() *getUserMembershipCollectionCmd {
 		Example: `
 $ c8y users listUserMembership --id "myuser"
 Get a list of groups that a user belongs to
-		`,
-		RunE: ccmd.getUserMembershipCollection,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getUserMembershipCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/getUsersInGroupCmd.auto.go
+++ b/pkg/cmd/getUsersInGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newGetUsersInGroupCmd() *getUsersInGroupCmd {
 		Example: `
 $ c8y userReferences listGroupMembership --group 1
 List the users within a user group
-		`,
-		RunE: ccmd.getUsersInGroup,
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getUsersInGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/inventoryBinaryCreate.go
+++ b/pkg/cmd/inventoryBinaryCreate.go
@@ -30,7 +30,8 @@ func newNewBinaryManagedObjectCmd() *newBinaryManagedObjectCmd {
 		c8y inventory binary upload --file ./test.zip --data "name=test,type=application/json"
 
 		`,
-		RunE: ccmd.newBinaryManagedObject,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newBinaryManagedObject,
 	}
 
 	cmd.Flags().StringArrayVarP(&ccmd.files, inventoryFlagFile, "f", []string{}, "input file to upload as a binary managed object")

--- a/pkg/cmd/inventoryBinaryDelete.go
+++ b/pkg/cmd/inventoryBinaryDelete.go
@@ -22,7 +22,8 @@ func newDeleteBinaryManagedObjectCmd() *deleteBinaryManagedObjectCmd {
 			Delete a binary managed object
 			c8y inventory binary download --id 12345
 		`,
-		RunE: ccmd.deleteBinaryManagedObject,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteBinaryManagedObject,
 	}
 
 	// Flags

--- a/pkg/cmd/listSettingsCmd.manual.go
+++ b/pkg/cmd/listSettingsCmd.manual.go
@@ -46,6 +46,11 @@ func (n *listSettingsCmd) listSettings(cmd *cobra.Command, args []string) error 
 	settings[SettingsIncludeAllPageSize] = globalFlagIncludeAllPageSize
 	settings[SettingsIncludeAllDelayMS] = globalFlagIncludeAllDelayMS
 
+	settings[SettingsModeEnableCreate] = globalModeEnableCreate
+	settings[SettingsModeEnableUpdate] = globalModeEnableUpdate
+	settings[SettingsModeEnableDelete] = globalModeEnableDelete
+	settings[SettingsModeCI] = globalCIMode
+
 	responseText, err := json.Marshal(settings)
 
 	if err != nil {

--- a/pkg/cmd/newAlarmCmd.auto.go
+++ b/pkg/cmd/newAlarmCmd.auto.go
@@ -26,8 +26,9 @@ func newNewAlarmCmd() *newAlarmCmd {
 		Example: `
 $ c8y alarms create --device mydevice --type c8y_TestAlarm --time "-0s" --text "Test alarm" --severity MAJOR
 Create a new alarm for device
-		`,
-		RunE: ccmd.newAlarm,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newAlarm,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newApplicationBinaryCmd.auto.go
+++ b/pkg/cmd/newApplicationBinaryCmd.auto.go
@@ -31,8 +31,9 @@ For the web application, the zip file must include index.html in the root direct
 		Example: `
 $ c8y applications createBinary --id 12345 --file ./helloworld.zip
 Upload application microservice binary
-		`,
-		RunE: ccmd.newApplicationBinary,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newApplicationBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newApplicationCmd.auto.go
+++ b/pkg/cmd/newApplicationCmd.auto.go
@@ -26,8 +26,9 @@ func newNewApplicationCmd() *newApplicationCmd {
 		Example: `
 $ c8y applications create --name myapp --type HOSTED --key "myapp-key" --contextPath "myapp"
 Create a new hosted application
-		`,
-		RunE: ccmd.newApplication,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newAuditCmd.auto.go
+++ b/pkg/cmd/newAuditCmd.auto.go
@@ -26,8 +26,9 @@ func newNewAuditCmd() *newAuditCmd {
 		Example: `
 $ c8y auditRecords create --type "ManagedObject" --time "0s" --text "Managed Object updated: my_Prop: value" --source $Device.id --activity "Managed Object updated" --severity "information"
 Create an audit record for a custom managed object update
-		`,
-		RunE: ccmd.newAudit,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newAudit,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newBinaryCmd.auto.go
+++ b/pkg/cmd/newBinaryCmd.auto.go
@@ -29,8 +29,9 @@ Upload a log file
 
 $ c8y binaries create --file "myConfig.json" --data "c8y_Global={},type=c8y_upload"
 Upload a config file and make it globally accessible for all users
-		`,
-		RunE: ccmd.newBinary,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newEventBinaryCmd.auto.go
+++ b/pkg/cmd/newEventBinaryCmd.auto.go
@@ -26,8 +26,9 @@ func newNewEventBinaryCmd() *newEventBinaryCmd {
 		Example: `
 $ c8y events createBinary --id 12345 --file ./myfile.log
 Add a binary to an event
-		`,
-		RunE: ccmd.newEventBinary,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newEventBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newEventCmd.auto.go
+++ b/pkg/cmd/newEventCmd.auto.go
@@ -26,8 +26,9 @@ func newNewEventCmd() *newEventCmd {
 		Example: `
 $ c8y events create --device mydevice --type c8y_TestAlarm --time "-0s" --text "Test alarm" --severity MAJOR
 Create a new event for a device
-		`,
-		RunE: ccmd.newEvent,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newEvent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newExternalIDCmd.auto.go
+++ b/pkg/cmd/newExternalIDCmd.auto.go
@@ -26,8 +26,9 @@ func newNewExternalIDCmd() *newExternalIDCmd {
 		Example: `
 $ c8y identity create --device 1234 --type test --name myserialnumber
 Create external identity
-		`,
-		RunE: ccmd.newExternalID,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newExternalID,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newGroupCmd.auto.go
+++ b/pkg/cmd/newGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newNewGroupCmd() *newGroupCmd {
 		Example: `
 $ c8y userGroups create --name customGroup1
 Create a user group
-		`,
-		RunE: ccmd.newGroup,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newHostedApplicationCmd.go
+++ b/pkg/cmd/newHostedApplicationCmd.go
@@ -38,7 +38,8 @@ $ c8y applications createHostedApplication --file ./myapp.zip
 
 Create new hosted application from a given zip file
 		`,
-		RunE: ccmd.doProcedure,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.doProcedure,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
@@ -26,8 +26,9 @@ func newNewManagedObjectChildAssetCmd() *newManagedObjectChildAssetCmd {
 		Example: `
 $ c8y inventoryReferences createChildAsset --group 12345 --newChildGroup 43234
 Create group heirachy (parent group -> child group)
-		`,
-		RunE: ccmd.newManagedObjectChildAsset,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newManagedObjectChildAsset,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
@@ -26,8 +26,9 @@ func newNewManagedObjectChildDeviceCmd() *newManagedObjectChildDeviceCmd {
 		Example: `
 $ c8y inventoryReferences assignChildDevice --device 12345 --newChild 44235
 Assign a device as a child device to an existing device
-		`,
-		RunE: ccmd.newManagedObjectChildDevice,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newManagedObjectChildDevice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newManagedObjectCmd.auto.go
+++ b/pkg/cmd/newManagedObjectCmd.auto.go
@@ -26,8 +26,9 @@ func newNewManagedObjectCmd() *newManagedObjectCmd {
 		Example: `
 $ c8y inventory create --name "testMO" --type "custom_type"
 Create a managed object
-		`,
-		RunE: ccmd.newManagedObject,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newManagedObject,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newMeasurementCmd.auto.go
+++ b/pkg/cmd/newMeasurementCmd.auto.go
@@ -26,8 +26,9 @@ func newNewMeasurementCmd() *newMeasurementCmd {
 		Example: `
 $ c8y measurements create --id 12345 --time "0s" --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 1.2345,\"unit\":\"°C\"}}}"
 Create measurement
-		`,
-		RunE: ccmd.newMeasurement,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newMeasurement,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newMicroserviceBinaryCmd.auto.go
+++ b/pkg/cmd/newMicroserviceBinaryCmd.auto.go
@@ -31,8 +31,9 @@ For the web application, the zip file must include index.html in the root direct
 		Example: `
 $ c8y microservices createBinary --id 12345 --file ./helloworld.zip
 Upload microservice binary
-		`,
-		RunE: ccmd.newMicroserviceBinary,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newMicroserviceBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newMicroserviceCmd.go
+++ b/pkg/cmd/newMicroserviceCmd.go
@@ -40,7 +40,8 @@ func newNewMicroserviceCmd() *newMicroserviceCmd {
 $ c8y microservices create --file ./myapp.zip
 Create new microservice
 		`,
-		RunE: ccmd.doProcedure,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.doProcedure,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newOperationCmd.auto.go
+++ b/pkg/cmd/newOperationCmd.auto.go
@@ -26,8 +26,9 @@ func newNewOperationCmd() *newOperationCmd {
 		Example: `
 $ c8y operations create --device mydevice --data "{c8y_Restart:{}}"
 Create operation for a device
-		`,
-		RunE: ccmd.newOperation,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newOperation,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newRetentionRuleCmd.auto.go
+++ b/pkg/cmd/newRetentionRuleCmd.auto.go
@@ -27,8 +27,9 @@ func newNewRetentionRuleCmd() *newRetentionRuleCmd {
 		Example: `
 $ c8y retentionRules create --dataType ALARM --maximumAge 180
 Create a retention rule
-		`,
-		RunE: ccmd.newRetentionRule,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newRetentionRule,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newTenantCmd.auto.go
+++ b/pkg/cmd/newTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newNewTenantCmd() *newTenantCmd {
 		Example: `
 $ c8y tenants create --company "mycompany" --domain "mycompany" --adminName "admin" --password "mys3curep9d8"
 Create a new tenant (from the management tenant)
-		`,
-		RunE: ccmd.newTenant,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newTenantOptionCmd.auto.go
+++ b/pkg/cmd/newTenantOptionCmd.auto.go
@@ -26,8 +26,9 @@ func newNewTenantOptionCmd() *newTenantOptionCmd {
 		Example: `
 $ c8y tenantOptions create --category "c8y_cli_tests" --key "option1" --value "1"
 Create a tenant option
-		`,
-		RunE: ccmd.newTenantOption,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newTenantOption,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/newUserCmd.auto.go
+++ b/pkg/cmd/newUserCmd.auto.go
@@ -26,8 +26,9 @@ func newNewUserCmd() *newUserCmd {
 		Example: `
 $ c8y users create --userName "testuser1" --password "a0)8k2kld9lm,!"
 Create a user
-		`,
-		RunE: ccmd.newUser,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.newUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/registerNewDeviceCmd.auto.go
+++ b/pkg/cmd/registerNewDeviceCmd.auto.go
@@ -26,8 +26,9 @@ func newRegisterNewDeviceCmd() *registerNewDeviceCmd {
 		Example: `
 $ c8y devices registerNewDevice --id "ASDF098SD1J10912UD92JDLCNCU8"
 Register a new device request
-		`,
-		RunE: ccmd.registerNewDevice,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.registerNewDevice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/requestDeviceCredentialsCmd.auto.go
+++ b/pkg/cmd/requestDeviceCredentialsCmd.auto.go
@@ -26,8 +26,9 @@ func newRequestDeviceCredentialsCmd() *requestDeviceCredentialsCmd {
 		Example: `
 $ c8y devices requestDeviceCredentials --id "device-AD76-matrixer"
 Request credentials for a new device
-		`,
-		RunE: ccmd.requestDeviceCredentials,
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.requestDeviceCredentials,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/resetUserPasswordCmd.auto.go
+++ b/pkg/cmd/resetUserPasswordCmd.auto.go
@@ -26,8 +26,9 @@ func newResetUserPasswordCmd() *resetUserPasswordCmd {
 		Example: `
 $ c8y users resetUserPassword --id "myuser"
 Update a user
-		`,
-		RunE: ccmd.resetUserPassword,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.resetUserPassword,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -75,6 +75,11 @@ var (
 	globalFlagUseTenantPrefix    bool
 	globalUseNonDefaultPageSize  bool
 	globalFlagTemplatePath       string
+
+	globalModeEnableCreate bool
+	globalModeEnableUpdate bool
+	globalModeEnableDelete bool
+	globalCIMode           bool
 )
 
 // CumulocityDefaultPageSize is the default page size used by Cumulocity
@@ -95,6 +100,18 @@ const (
 
 	// SettingsTemplatePath template path where the template files are located
 	SettingsTemplatePath string = "settings.template.path"
+
+	// SettingsModeEnableCreate enables create (post) commands
+	SettingsModeEnableCreate string = "settings.mode.enableCreate"
+
+	// SettingsModeEnableUpdate enables update commands
+	SettingsModeEnableUpdate string = "settings.mode.enableUpdate"
+
+	// SettingsModeEnableDelete enables delete commands
+	SettingsModeEnableDelete string = "settings.mode.enableDelete"
+
+	// SettingsModeCI enable continuous integration mode (this will enable all commands)
+	SettingsModeCI string = "settings.ci"
 )
 
 // SettingsGlobalName name of the settings file (without extension)
@@ -460,6 +477,10 @@ func loadConfiguration() error {
 	bindEnv(SettingsDefaultPageSize, CumulocityDefaultPageSize)
 	bindEnv(SettingsIncludeAllDelayMS, 0)
 	bindEnv(SettingsTemplatePath, "")
+	bindEnv(SettingsModeEnableCreate, false)
+	bindEnv(SettingsModeEnableUpdate, false)
+	bindEnv(SettingsModeEnableDelete, false)
+	bindEnv(SettingsModeCI, false)
 
 	return nil
 }
@@ -471,10 +492,18 @@ func readConfiguration() error {
 	globalFlagIncludeAllDelayMS = viper.GetInt64(SettingsIncludeAllDelayMS)
 	globalFlagTemplatePath = viper.GetString(SettingsTemplatePath)
 
+	globalModeEnableCreate = viper.GetBool(SettingsModeEnableCreate)
+	globalModeEnableUpdate = viper.GetBool(SettingsModeEnableUpdate)
+	globalModeEnableDelete = viper.GetBool(SettingsModeEnableDelete)
+
+	globalCIMode = viper.GetBool(SettingsModeCI)
+
 	Logger.Infof("%s: %d", SettingsDefaultPageSize, globalFlagPageSize)
 	Logger.Infof("%s: %d", SettingsIncludeAllPageSize, globalFlagIncludeAllPageSize)
 	Logger.Infof("%s: %d", SettingsIncludeAllDelayMS, globalFlagIncludeAllDelayMS)
 	Logger.Infof("%s: %s", SettingsTemplatePath, globalFlagTemplatePath)
+	Logger.Infof("%s: %b", SettingsModeEnableUpdate, globalModeEnableUpdate)
+	Logger.Infof("%s: %b", SettingsModeEnableDelete, globalModeEnableDelete)
 
 	return nil
 }

--- a/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
+++ b/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
@@ -26,8 +26,9 @@ func newSetDeviceRequiredAvailabilityCmd() *setDeviceRequiredAvailabilityCmd {
 		Example: `
 $ c8y inventory setRequiredAvailability --device 12345 --interval 10
 Set the required availability of a device by name to 10 minutes
-		`,
-		RunE: ccmd.setDeviceRequiredAvailability,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.setDeviceRequiredAvailability,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateAgentCmd.auto.go
+++ b/pkg/cmd/updateAgentCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateAgentCmd() *updateAgentCmd {
 		Example: `
 $ c8y agents update --id 12345
 Update agent by id
-		`,
-		RunE: ccmd.updateAgent,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateAgent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateAlarmCmd.auto.go
+++ b/pkg/cmd/updateAlarmCmd.auto.go
@@ -29,8 +29,9 @@ Acknowledge an existing alarm
 
 $ c8y alarms update --id 12345 --severity CRITICAL
 Update severity of an existing alarm to CRITICAL
-		`,
-		RunE: ccmd.updateAlarm,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateAlarm,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/updateAlarmCollectionCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateAlarmCollectionCmd() *updateAlarmCollectionCmd {
 		Example: `
 $ c8y alarms updateCollection --device mydevice --status ACTIVE --newStatus ACKNOWLEDGED
 Update the status of all active alarms on a device to ACKNOWLEDGED
-		`,
-		RunE: ccmd.updateAlarmCollection,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateAlarmCollection,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateApplicationCmd.auto.go
+++ b/pkg/cmd/updateApplicationCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateApplicationCmd() *updateApplicationCmd {
 		Example: `
 $ c8y applications update --id "helloworld-app" --availability MARKET
 Update application availability to MARKET
-		`,
-		RunE: ccmd.updateApplication,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateBinaryCmd.auto.go
+++ b/pkg/cmd/updateBinaryCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateBinaryCmd() *updateBinaryCmd {
 		Example: `
 $ c8y binaries update --id 12345 --file ./output.log
 Update an existing binary file
-		`,
-		RunE: ccmd.updateBinary,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateCurrentApplicationCmd.auto.go
+++ b/pkg/cmd/updateCurrentApplicationCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateCurrentApplicationCmd() *updateCurrentApplicationCmd {
 		Example: `
 $ c8y currentApplication update --data "mycustomProp=1"
 Update custom properties of the current application (requires using application credentials)
-		`,
-		RunE: ccmd.updateCurrentApplication,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateCurrentApplication,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateDataBrokerCmd.auto.go
+++ b/pkg/cmd/updateDataBrokerCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateDataBrokerCmd() *updateDataBrokerCmd {
 		Example: `
 $ c8y databroker update --id 12345 --status SUSPENDED
 Change the status of a specific data broker connector by given connector id
-		`,
-		RunE: ccmd.updateDataBroker,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateDataBroker,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateDeviceCmd.auto.go
+++ b/pkg/cmd/updateDeviceCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateDeviceCmd() *updateDeviceCmd {
 		Example: `
 $ c8y devices update --id 12345
 Update device by id
-		`,
-		RunE: ccmd.updateDevice,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateDevice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateDeviceGroupCmd.auto.go
+++ b/pkg/cmd/updateDeviceGroupCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateDeviceGroupCmd() *updateDeviceGroupCmd {
 		Example: `
 $ c8y devices updateGroup --id 12345
 Update device group by id
-		`,
-		RunE: ccmd.updateDeviceGroup,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateDeviceGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateEventBinaryCmd.auto.go
+++ b/pkg/cmd/updateEventBinaryCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateEventBinaryCmd() *updateEventBinaryCmd {
 		Example: `
 $ c8y events updateBinary --id 12345 --file ./myfile.log
 Update a binary related to an event
-		`,
-		RunE: ccmd.updateEventBinary,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateEventBinary,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateEventCmd.auto.go
+++ b/pkg/cmd/updateEventCmd.auto.go
@@ -29,8 +29,9 @@ Update the text field of an existing event
 
 $ c8y events update --id 12345 --data "{\"my_event\":{\"active\": true }}"
 Update custom properties of an existing event
-		`,
-		RunE: ccmd.updateEvent,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateEvent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateGroupCmd.auto.go
+++ b/pkg/cmd/updateGroupCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateGroupCmd() *updateGroupCmd {
 		Example: `
 $ c8y userGroups update --id 12345 --name "customGroup2"
 Update a user group
-		`,
-		RunE: ccmd.updateGroup,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateGroup,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateManagedObjectCmd.auto.go
+++ b/pkg/cmd/updateManagedObjectCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateManagedObjectCmd() *updateManagedObjectCmd {
 		Example: `
 $ c8y inventory update --id 12345 --newName "my_custom_name" --data "{\"com_my_props\":{}\"value\":1}"
 Update a managed object
-		`,
-		RunE: ccmd.updateManagedObject,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateManagedObject,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateMicroserviceCmd.auto.go
+++ b/pkg/cmd/updateMicroserviceCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateMicroserviceCmd() *updateMicroserviceCmd {
 		Example: `
 $ c8y microservices update --id "helloworld-app" --availability MARKET
 Update microservice availability to MARKET
-		`,
-		RunE: ccmd.updateMicroservice,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateMicroservice,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateOperationCmd.auto.go
+++ b/pkg/cmd/updateOperationCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateOperationCmd() *updateOperationCmd {
 		Example: `
 $ c8y operations update --id 12345 --status EXECUTING
 Update an operation
-		`,
-		RunE: ccmd.updateOperation,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateOperation,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateRetentionRuleCmd.auto.go
+++ b/pkg/cmd/updateRetentionRuleCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateRetentionRuleCmd() *updateRetentionRuleCmd {
 		Example: `
 $ c8y retentionRules get --id 12345
 Update a retention rule
-		`,
-		RunE: ccmd.updateRetentionRule,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateRetentionRule,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateTenantCmd.auto.go
+++ b/pkg/cmd/updateTenantCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateTenantCmd() *updateTenantCmd {
 		Example: `
 $ c8y tenants update --id "mycompany" --contactName "John Smith"
 Update a tenant by name (from the mangement tenant)
-		`,
-		RunE: ccmd.updateTenant,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateTenant,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateTenantOptionBulkCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionBulkCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateTenantOptionBulkCmd() *updateTenantOptionBulkCmd {
 		Example: `
 $ c8y tenantOptions updateBulk --category "c8y_cli_tests" --data "{\"option5\":0,\"option6\":1"}"
 Update multiple tenant options
-		`,
-		RunE: ccmd.updateTenantOptionBulk,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateTenantOptionBulk,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateTenantOptionCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateTenantOptionCmd() *updateTenantOptionCmd {
 		Example: `
 $ c8y tenantOptions update --category "c8y_cli_tests" --key "option4" --value "0"
 Update a tenant option
-		`,
-		RunE: ccmd.updateTenantOption,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateTenantOption,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateTenantOptionEditableCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionEditableCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateTenantOptionEditableCmd() *updateTenantOptionEditableCmd {
 		Example: `
 $ c8y tenantOptions updateEdit --category "c8y_cli_tests" --key "option8" --editable "true"
 Update editable property for an existing tenant option
-		`,
-		RunE: ccmd.updateTenantOptionEditable,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateTenantOptionEditable,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateUserCmd.auto.go
+++ b/pkg/cmd/updateUserCmd.auto.go
@@ -26,8 +26,9 @@ func newUpdateUserCmd() *updateUserCmd {
 		Example: `
 $ c8y users update --id "myuser" --firstName "Simon"
 Update a user
-		`,
-		RunE: ccmd.updateUser,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateUser,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/updateUserCurrentCmd.auto.go
+++ b/pkg/cmd/updateUserCurrentCmd.auto.go
@@ -27,8 +27,9 @@ func newUpdateUserCurrentCmd() *updateUserCurrentCmd {
 		Example: `
 $ c8y users updateCurrentUser --lastName "Smith"
 Update the current user's lastname
-		`,
-		RunE: ccmd.updateUserCurrent,
+        `,
+		PreRunE: validateUpdateMode,
+		RunE:    ccmd.updateUserCurrent,
 	}
 
 	cmd.SilenceUsage = true

--- a/pkg/cmd/validateMode.manual.go
+++ b/pkg/cmd/validateMode.manual.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func getValidationError(mode string, setting string) error {
+	return fmt.Errorf("%s mode is disabled. %s commands are disabled unless \"%s\" is set to 'true' in your session settings", mode, mode, setting)
+}
+
+func validateCreateMode(cmd *cobra.Command, args []string) error {
+	if !(globalModeEnableCreate || globalCIMode) {
+		return getValidationError("create", SettingsModeEnableCreate)
+	}
+	return nil
+}
+
+func validateUpdateMode(cmd *cobra.Command, args []string) error {
+	if !(globalModeEnableUpdate || globalCIMode) {
+		return getValidationError("update", SettingsModeEnableUpdate)
+	}
+	return nil
+}
+
+func validateDeleteMode(cmd *cobra.Command, args []string) error {
+	if !(globalModeEnableDelete || globalCIMode) {
+		return getValidationError("delete", SettingsModeEnableDelete)
+	}
+	return nil
+}

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -243,6 +243,15 @@
     }
 "@)
 
+    #
+    # Pre run validation (disable some commands without switch flags)
+    #
+    $PreRunFunction = switch ($Specification.method) {
+        "POST" { "validateCreateMode" }
+        "PUT" { "validateUpdateMode" }
+        "DELETE" { "validateDeleteMode" }
+        default { "nil" }
+    }
 
     #
     # Template
@@ -275,7 +284,8 @@ func new${NameCamel}Cmd() *${Name}Cmd {
 		Long:  ``$DescriptionLong``,
         Example: ``
 $($Examples -join "`n`n")
-		``,
+        ``,
+        PreRunE: $PreRunFunction,
 		RunE: ccmd.${Name},
     }
 

--- a/tools/PSc8y/Private/Set-EnvironmentVariablesFromSession.ps1
+++ b/tools/PSc8y/Private/Set-EnvironmentVariablesFromSession.ps1
@@ -17,6 +17,11 @@ None
 
     $Session = Get-Session
 
+    # reset any enabled side-effect commands
+    $env:C8Y_SETTINGS_MODE_ENABLECREATE = ""
+    $env:C8Y_SETTINGS_MODE_ENABLEUPDATE = ""
+    $env:C8Y_SETTINGS_MODE_ENABLEDELETE = ""
+
     if ($null -eq $Session)
     {
         Write-Verbose "Clearing the Cumulocity environment variables"

--- a/tools/PSc8y/Public-manual/Set-ClientConsoleSetting.ps1
+++ b/tools/PSc8y/Public-manual/Set-ClientConsoleSetting.ps1
@@ -12,6 +12,11 @@ When using -HideSensitive, the following information will be obfuscated when sho
 Set-ClientConsoleSetting -HideSensitive
 
 Hide any sensitive session information on the console. Settings like (tenant, username, password, base64 credentials)
+
+.EXAMPLE
+Set-ClientConsoleSetting -EnableCreateCommands -EnableUpdateCommands
+
+Enable all create and update commands until the session is changed
 #>
     [cmdletbinding()]
     Param(
@@ -20,6 +25,18 @@ Hide any sensitive session information on the console. Settings like (tenant, us
 
         # Show sensitive information (excepts clear-text passwords)
         [switch] $ShowSensitive,
+
+        # Enable create commands
+        [switch] $EnableCreateCommands,
+
+        # Enable update commands
+        [switch] $EnableUpdateCommands,
+
+        # Enable delete commands
+        [switch] $EnableDeleteCommands,
+
+        # Disable all create/update/delete commands
+        [switch] $DisableCommands,
 
         # Set the default paging size to use in collection queries
         [int] $DefaultPageSize
@@ -33,6 +50,28 @@ Hide any sensitive session information on the console. Settings like (tenant, us
     if ($HideSensitive) {
         Write-Host "Sensitive session information will be hidden" -ForegroundColor Gray
         $env:C8Y_LOGGER_HIDE_SENSITIVE = $true
+    }
+
+    if ($DisableCommands) {
+        Write-Host "Disableing create/update/delete commands" -ForegroundColor Gray
+        $env:C8Y_SETTINGS_MODE_ENABLECREATE = ""
+        $env:C8Y_SETTINGS_MODE_ENABLEUPDATE = ""
+        $env:C8Y_SETTINGS_MODE_ENABLEDELETE = ""
+    }
+
+    if ($EnableCreateCommands) {
+        Write-Host "Enabling create commands" -ForegroundColor Gray
+        $env:C8Y_SETTINGS_MODE_ENABLECREATE = $true
+    }
+
+    if ($EnableUpdateCommands) {
+        Write-Host "Enabling update commands" -ForegroundColor Gray
+        $env:C8Y_SETTINGS_MODE_ENABLEUPDATE = $true
+    }
+    
+    if ($EnableDeleteCommands) {
+        Write-Host "Enabling delete commands" -ForegroundColor Gray
+        $env:C8Y_SETTINGS_MODE_ENABLEDELETE = $true
     }
 
     if ($PSBoundParameters.ContainsKey("DefaultPageSize")) {

--- a/tools/PSc8y/Tests/DisableCommands.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/DisableCommands.manual.Tests.ps1
@@ -1,0 +1,68 @@
+. $PSScriptRoot/imports.ps1
+
+Describe -Name "Disable create/update/delete commands" {
+    BeforeEach {
+        $env:C8Y_SETTINGS_CI = ""
+        $env:C8Y_SETTINGS_MODE_ENABLECREATE = ""
+        $env:C8Y_SETTINGS_MODE_ENABLEUPDATE = ""
+        $env:C8Y_SETTINGS_MODE_ENABLEDELETE = ""
+
+        $items = New-Object System.Collections.ArrayList
+    }
+
+    It "Enables create commands" {
+
+        $null = New-TestDevice -WhatIf
+        $LASTEXITCODE | Should -Not -Be 0
+
+        Set-ClientConsoleSetting -EnableCreateCommands
+
+        $null = New-TestDevice -WhatIf
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It "Enables update commands" {
+        Set-ClientConsoleSetting -EnableCreateCommands
+
+        $device = New-TestDevice
+        $LASTEXITCODE | Should -Be 0
+        $null = $items.Add($device.id)
+
+        # updates should not work
+        $device | PSc8y\Update-Device -NewName "My New Name" -WhatIf
+        $LASTEXITCODE | Should -Not -Be 0
+
+        Set-ClientConsoleSetting -EnableUpdateCommands
+
+        # updates should work
+        $device | PSc8y\Update-Device -NewName "My New Name" -WhatIf
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It "Enables delete commands" {
+        Set-ClientConsoleSetting -EnableCreateCommands
+
+        $device = New-TestDevice
+        $LASTEXITCODE | Should -Be 0
+        $null = $items.Add($device.id)
+
+        # delete should not work
+        $device | PSc8y\Remove-Device -WhatIf
+        $LASTEXITCODE | Should -Not -Be 0
+
+        Set-ClientConsoleSetting -EnableDeleteCommands
+
+        # delete should work
+        $device | PSc8y\Remove-Device
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    AfterEach {
+        Set-ClientConsoleSetting -EnableDeleteCommands
+        foreach ($item in $items) {
+            if ($item) {
+                PSc8y\Remove-ManagedObject -Id $item
+            }
+        }
+    }
+}

--- a/tools/PSc8y/Tests/imports.ps1
+++ b/tools/PSc8y/Tests/imports.ps1
@@ -21,6 +21,7 @@ Import-Module "$PSScriptRoot/../dist/PSc8y/PSc8y.psd1" -Prefix "" -Force
 
 # Get credentials from the environment
 $env:C8Y_USE_ENVIRONMENT = "on"
+$env:C8Y_SETTINGS_CI = "true"
 
 # required in non-interactive mode, otherwise powershell throws errors (regardless of confirmation preference)
 $PSDefaultParameterValues = @{

--- a/tools/bash/c8y.plugin.zsh
+++ b/tools/bash/c8y.plugin.zsh
@@ -32,7 +32,7 @@ set-session () {
     # to support other 3rd party applicatsion (i.e. java c8y sdk apps)
     # which will read these variables
     session_info=$( cat "$C8Y_SESSION" )
-    if command -v jq; then
+    if [[ $(command -v jq) ]]; then
         export C8Y_HOST=$( echo $session_info | jq -r ".host" )
         export C8Y_TENANT=$( echo $session_info | jq -r ".tenant" )
         export C8Y_USER=$( echo $session_info | jq -r ".username" )

--- a/tools/bash/c8y.plugin.zsh
+++ b/tools/bash/c8y.plugin.zsh
@@ -39,6 +39,11 @@ set-session () {
         export C8Y_USERNAME=$( echo $session_info | jq -r ".username" )
         export C8Y_PASSWORD=$( echo $session_info | jq -r ".password" )
     fi
+
+    # reset any enabled side-effect commands
+    unset C8Y_SETTINGS_MODE_ENABLECREATE
+    unset C8Y_SETTINGS_MODE_ENABLEUPDATE
+    unset C8Y_SETTINGS_MODE_ENABLEDELETE
 }
 
 

--- a/tools/bash/c8y.profile.sh
+++ b/tools/bash/c8y.profile.sh
@@ -23,13 +23,13 @@ fi
 ########################################################################
 
 # -----------
-# set-session
+# executeTemplateCmd
 # -----------
 # Description: Switch Cumulocity session interactively
 # Usage:
-#   set-session
+#   executeTemplateCmd
 #
-set-session () {
+executeTemplateCmd () {
     if [ $# -gt 0 ]; then
         resp=$( c8y sessions list --sessionFilter "$1 $2 $3 $4 $5" )
     else
@@ -54,6 +54,11 @@ set-session () {
         export C8Y_USERNAME=$( echo $session_info | jq -r ".username" )
         export C8Y_PASSWORD=$( echo $session_info | jq -r ".password" )
     fi
+
+    # reset any enabled side-effect commands
+    unset C8Y_SETTINGS_MODE_ENABLECREATE
+    unset C8Y_SETTINGS_MODE_ENABLEUPDATE
+    unset C8Y_SETTINGS_MODE_ENABLEDELETE
 }
 
 # ----------

--- a/tools/bash/c8y.profile.sh
+++ b/tools/bash/c8y.profile.sh
@@ -47,7 +47,7 @@ executeTemplateCmd () {
     # to support other 3rd party applicatsion (i.e. java c8y sdk apps)
     # which will read these variables
     session_info=$( cat "$C8Y_SESSION" )
-    if command -v jq; then
+    if [[ $(command -v jq) ]]; then
         export C8Y_HOST=$( echo $session_info | jq -r ".host" )
         export C8Y_TENANT=$( echo $session_info | jq -r ".tenant" )
         export C8Y_USER=$( echo $session_info | jq -r ".username" )

--- a/tools/schema/session.schema.json
+++ b/tools/schema/session.schema.json
@@ -59,6 +59,22 @@
                 "template.path": {
                     "description": "Path / Folder where the templates are located. If the user gives a template name (without path), then a matching filename will be search for in this folder",
                     "type": "string"
+                },
+                "mode.enableCreate": {
+                    "description": "Enable/disable create commands",
+                    "type": "boolean"
+                },
+                "mode.enableUpdate": {
+                    "description": "Enable/disable update commands",
+                    "type": "boolean"
+                },
+                "mode.enableDelete": {
+                    "description": "Enable/disable delete commands",
+                    "type": "boolean"
+                },
+                "ci": {
+                    "description": "Enable CI/CD mode where all commands are enabled (create/update/delete)",
+                    "type": "boolean"
                 }
             }
         }


### PR DESCRIPTION
* Added support for disabling create/update/delete command individually to prevent accidental data loss. See the [session concept documentation](https://reubenmiller.github.io/go-c8y-cli/docs/concepts/sessions/) for full details.
    * create/update/delete command are disabled by default! They must be enabled otherwise the commands will return an error. Commands can be enabled/disabled from the session properties
    * commands can be temporarily enabled/disabled in the session via environment variables without persisting them in the session settings
    * CI mode which enables all commands via one environment variable