### PR TITLE
Feat/get session and processing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ No unreleased features
 * Get-Session uses a new c8y session get to retrieve information about the current session
 * Fixed bug when using the `-Session` on PUT and POST commands
 * Expand-Device supports piping of alarms, events, measurements and operations
+* Added `-ProcessingMode` parameter to all commands that use DELETE, PUT and POST requests.
+
+    ```powershell
+    New-ManagedObject -Name myobject -ProcessingMode TRANSIENT
+    New-ManagedObject -Name myobject -ProcessingMode QUIESCENT
+    New-ManagedObject -Name myobject -ProcessingMode PERSISTENT
+    New-ManagedObject -Name myobject -ProcessingMode CEP
+    ```
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,19 @@ No unreleased features
 
     }
     ```
+    * Added logout user command to invalidate current user token
+
+        **Bash/zsh**
+
+        ```sh
+        c8y users logout
+        ```
+
+        **PowerShell**
+
+        ```powershell
+        Invoke-UserLogout
+        ```
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,36 @@ No unreleased features
     New-ManagedObject -Name myobject -ProcessingMode CEP
     ```
 * `Set-session` automatically selects a session if only one matching session is found rather than prompting the user for the selection
+* `source` fragment is removed when being passed via file to the `Data` parameter in all create and update commands
+    ```json
+    // myevent.json
+    {
+        "source": {
+            "id": "99999",
+            "self": "https:/..../event/events/99999"
+        },
+        "type": "myExample1",
+
+    }
+    ```
+
+    When executing the following command:
+    ```powershell
+    PSc8y\New-Event -Device 12345 -Data myevent.json
+    ```
+
+    The `source` id fragment will be replaced entirely by the new source as specified by the `Device` parameter
+
+    ```json
+    // myevent.json
+    {
+        "source": {
+            "id": "12345",
+        },
+        "type": "myExample1",
+
+    }
+    ```
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ No unreleased features
     ```powershell
     Invoke-UserLogout
     ```
+* Fixed binary upload bugs with both `New-EventBinary` and `Update-EventBinary` which resulted in multipart form data being included in the binary information
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 No unreleased features
 
+* Get-Session uses a new c8y session get to retrieve information about the current session
+* Fixed bug when using the `-Session` on PUT and POST commands
+
 ## Released
 
 ### v1.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,19 +46,19 @@ No unreleased features
 
     }
     ```
-    * Added logout user command to invalidate current user token
+* Added logout user command to invalidate current user token
 
-        **Bash/zsh**
+    **Bash/zsh**
 
-        ```sh
-        c8y users logout
-        ```
+    ```sh
+    c8y users logout
+    ```
 
-        **PowerShell**
+    **PowerShell**
 
-        ```powershell
-        Invoke-UserLogout
-        ```
+    ```powershell
+    Invoke-UserLogout
+    ```
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ No unreleased features
 
 * Get-Session uses a new c8y session get to retrieve information about the current session
 * Fixed bug when using the `-Session` on PUT and POST commands
+* Expand-Device supports piping of alarms, events, measurements and operations
 
 ## Released
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 No unreleased features
 
-* Get-Session uses a new c8y session get to retrieve information about the current session
-* Fixed bug when using the `-Session` on PUT and POST commands
-* Expand-Device supports piping of alarms, events, measurements and operations
+* `Get-Session` uses a new c8y session get to retrieve information about the current session
+* Fixed bug when using the `-Session` on PUT and POST commands which resulted in an error being displayed eventhough the request would be successful
+* `Expand-Device` supports piping of alarms, events, measurements and operations
 * Added `-ProcessingMode` parameter to all commands that use DELETE, PUT and POST requests.
 
     ```powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ No unreleased features
     New-ManagedObject -Name myobject -ProcessingMode PERSISTENT
     New-ManagedObject -Name myobject -ProcessingMode CEP
     ```
+* `Set-session` automatically selects a session if only one matching session is found rather than prompting the user for the selection
 
 ## Released
 

--- a/README.md
+++ b/README.md
@@ -119,4 +119,7 @@ make test_powershell
 ```
 
 #### Running a test on a single
+
+```sh
 make TEST_FILE_FILTER=ClientRequest test_powershell
+```

--- a/api/spec/json/events.json
+++ b/api/spec/json/events.json
@@ -491,7 +491,7 @@
       "body": [
         {
           "name": "file",
-          "type": "file",
+          "type": "attachment",
           "required": true,
           "description": "File to be uploaded as a binary"
         }
@@ -514,7 +514,7 @@
             "description": "Update a binary related to an event",
             "beforeEach": [
               "$Device = New-TestDevice",
-              "$Event = New-TestEvent -Device $Device.id",
+              "$Event = New-TestEvent -Device $Device.id -WithBinary",
               "$TestFile = New-TestFile"
             ],
             "command": "Update-EventBinary -Id $Event.id -File $TestFile",
@@ -540,10 +540,16 @@
           "description": "Event id"
         }
       ],
+      "bodyTemplate": {
+        "type": "none"
+      },
+      "bodyContent": {
+        "type": "binary"
+      },
       "body": [
         {
           "name": "file",
-          "type": "file",
+          "type": "fileContents",
           "required": true,
           "description": "File to be uploaded as a binary"
         }

--- a/api/spec/json/measurements.json
+++ b/api/spec/json/measurements.json
@@ -59,14 +59,14 @@
         {
           "name": "csv",
           "type": "boolean",
-          "description": "Results will be displayed in csv format",
+          "description": "Results will be displayed in csv format. Note: -IncludeAll, is not supported when using using this parameter",
           "property": "Accept",
           "value": "text/csv"
         },
         {
           "name": "excel",
           "type": "boolean",
-          "description": "Results will be displayed in Excel format",
+          "description": "Results will be displayed in Excel format Note: -IncludeAll, is not supported when using using this parameter",
           "property": "Accept",
           "value": "application/vnd.ms-excel"
         },

--- a/api/spec/json/users.json
+++ b/api/spec/json/users.json
@@ -705,6 +705,32 @@
           "position": 99
         }
       ]
+    },
+    {
+      "name": "logout",
+      "description": "Log out the current user",
+      "descriptionLong": "Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL",
+      "method": "POST",
+      "path": "/user/logout",
+      "accept": "",
+      "alias": {
+        "go": "logout",
+        "powershell": "Invoke-UserLogout"
+      },
+      "examples": {
+        "powershell": [
+          {
+            "description": "Log out the current user",
+            "command": "Invoke-UserLogout"
+          }
+        ],
+        "go": [
+          {
+            "description": "Log out the current user",
+            "command": "c8y users logout"
+          }
+        ]
+      }
     }
   ]
 }

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -31,6 +31,8 @@
         "integer",
         "id",
         "file",
+        "fileContents",
+        "attachment",
         "datetime",
         "json",
         "json_custom",
@@ -351,6 +353,19 @@
               ]
             }
           },
+          "bodyContent": {
+            "type": "object",
+            "description": "Description of body content",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Body content type. Only used to identify binary contents",
+                "enum": [
+                  "binary"
+                ]
+              }
+            }
+          },
           "bodyTemplate": {
             "type": "object",
             "description": "Use a template when constructing the body of the http request. This can be used to force values, have defaults, or perform custom logic (depending on the template engine). At the moment on jsonnet is supported",
@@ -358,7 +373,7 @@
               "type": {
                 "type": "string",
                 "description": "Templating engine. Current only supports jsonnet",
-                "enum": ["jsonnet"]
+                "enum": ["jsonnet", "none"]
               },
               "applyLast": {
                 "type": "boolean",
@@ -370,9 +385,7 @@
               }
             },
             "required": [
-              "type",
-              "applyLast",
-              "template"
+              "type"
             ]
           },
           "bodyRequiredKeys": {

--- a/api/spec/yaml/events.yml
+++ b/api/spec/yaml/events.yml
@@ -361,7 +361,7 @@ endpoints:
 
     body:
       - name: file
-        type: file
+        type: attachment
         required: true
         description: File to be uploaded as a binary
 
@@ -380,7 +380,7 @@ endpoints:
         - description: Update a binary related to an event
           beforeEach:
             - $Device = New-TestDevice
-            - $Event = New-TestEvent -Device $Device.id
+            - $Event = New-TestEvent -Device $Device.id -WithBinary
             - $TestFile = New-TestFile
           command: Update-EventBinary -Id $Event.id -File $TestFile
           afterEach:
@@ -397,10 +397,13 @@ endpoints:
         required: true
         pipeline: true
         description: Event id
-
+    bodyTemplate:
+        type: none
+    bodyContent:
+        type: binary
     body:
       - name: file
-        type: file
+        type: fileContents
         required: true
         description: File to be uploaded as a binary
 

--- a/api/spec/yaml/measurements.yml
+++ b/api/spec/yaml/measurements.yml
@@ -46,13 +46,13 @@ endpoints:
     headerParameters:
       - name: csv
         type: boolean
-        description: Results will be displayed in csv format
+        description: 'Results will be displayed in csv format. Note: -IncludeAll, is not supported when using using this parameter'
         property: Accept
         value: text/csv
 
       - name: excel
         type: boolean
-        description: Results will be displayed in Excel format
+        description: 'Results will be displayed in Excel format Note: -IncludeAll, is not supported when using using this parameter'
         property: Accept
         value: application/vnd.ms-excel
 

--- a/api/spec/yaml/users.yml
+++ b/api/spec/yaml/users.yml
@@ -517,3 +517,20 @@ endpoints:
         type: tenant
         description: Tenant
         position: 99
+
+  - name: logout
+    description: Log out the current user
+    descriptionLong: Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL
+    method: POST
+    path: /user/logout
+    accept: ''
+    alias:
+        go: logout
+        powershell: Invoke-UserLogout
+    examples:
+      powershell:
+        - description: Log out the current user
+          command: Invoke-UserLogout
+      go:
+        - description: Log out the current user
+          command: c8y users logout

--- a/docs/_docs/concepts/sessions.md
+++ b/docs/_docs/concepts/sessions.md
@@ -31,6 +31,8 @@ New-Session
 
 A helper is provided to set the session interactively by providing the user a list of configured sessions. The user will be prompted to select one of the listed sessions.
 
+Note: On MacOS, you need to hold "option"+Arrow keys to navigate the list of sessions. Otherwise the VIM style "j" (down) and "k" (up) keys can be also used for navigation
+
 ##### Bash
 
 Assuming that you have already loaded the `c8y.profile.sh` helper.

--- a/docs/_docs/concepts/templates.md
+++ b/docs/_docs/concepts/templates.md
@@ -75,18 +75,21 @@ The following is an example of such a template:
 {
     name: "my device",
     type: var("type", "defaultType"),
+    var("fragment"): {},
     c8y_IsDevice: {},
 }
 ```
 
-The template can then be used when creating a managed object, and the `type` variable can be injected by using the `templateVars` parameter.
+The template can then be used when creating a managed object, and the `type` and `fragment` variables can be injected by using the `templateVars` parameter.
+
+Note: Multiple template variables can be provided, by using a comma separated list.
 
 **Bash/zsh**
 
 ```sh
 c8y inventory create \
     --template ./examples/templates/device.jsonnet \
-    --templateVars "type=myCustomType1" \
+    --templateVars "type=myCustomType1,fragment=myCustomObject" \
     --dry
 ```
 
@@ -95,7 +98,7 @@ c8y inventory create \
 ```sh
 New-ManagedObject `
     -Template ./examples/templates/measurement.jsonnet `
-    -TemplateVars "type=myCustomType1" `
+    -TemplateVars "type=myCustomType1,fragment=myCustomObject" `
     -WhatIf
 ```
 
@@ -107,6 +110,7 @@ These command would produce the following body which would be sent to Cumulocity
 {
     "name": "my device",
     "type": "myCustomType1",
+    "myCustomObject": {},
     "c8y_IsDevice": {}
 }
 ```

--- a/pkg/cmd/addDeviceToGroupCmd.auto.go
+++ b/pkg/cmd/addDeviceToGroupCmd.auto.go
@@ -38,6 +38,7 @@ Add multiple devices to a group
 
 	cmd.Flags().StringSlice("group", []string{""}, "Group (required)")
 	cmd.Flags().StringSlice("newChildDevice", []string{""}, "New device to be added to the group as an child asset (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -66,6 +67,11 @@ func (n *addDeviceToGroupCmd) addDeviceToGroup(cmd *cobra.Command, args []string
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/addGroupToGroupCmd.auto.go
+++ b/pkg/cmd/addGroupToGroupCmd.auto.go
@@ -38,6 +38,7 @@ Add multiple groups to a group
 
 	cmd.Flags().StringSlice("group", []string{""}, "Group (required)")
 	cmd.Flags().StringSlice("newChildGroup", []string{""}, "New child group to be added to the group as an child asset (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -66,6 +67,11 @@ func (n *addGroupToGroupCmd) addGroupToGroup(cmd *cobra.Command, args []string) 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/addRoleToGroupCmd.auto.go
+++ b/pkg/cmd/addRoleToGroupCmd.auto.go
@@ -36,6 +36,7 @@ Add a role to the admin group
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().StringSlice("group", []string{""}, "Group ID (required)")
 	cmd.Flags().StringSlice("role", []string{""}, "User role id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -64,6 +65,11 @@ func (n *addRoleToGroupCmd) addRoleToGroup(cmd *cobra.Command, args []string) er
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/addRoleToUserCmd.auto.go
+++ b/pkg/cmd/addRoleToUserCmd.auto.go
@@ -36,6 +36,7 @@ Add a role (ROLE_ALARM_READ) to a user
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().StringSlice("user", []string{""}, "User prefix or full username (required)")
 	cmd.Flags().StringSlice("role", []string{""}, "User role id")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("user")
@@ -63,6 +64,11 @@ func (n *addRoleToUserCmd) addRoleToUser(cmd *cobra.Command, args []string) erro
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/addUserToGroupCmd.auto.go
+++ b/pkg/cmd/addUserToGroupCmd.auto.go
@@ -36,6 +36,7 @@ List the users within a user group
 	cmd.Flags().StringSlice("group", []string{""}, "Group ID (required)")
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().StringSlice("user", []string{""}, "User id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -64,6 +65,11 @@ func (n *addUserToGroupCmd) addUserToGroup(cmd *cobra.Command, args []string) er
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/approveNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/approveNewDeviceRequestCmd.auto.go
@@ -35,6 +35,7 @@ Approve a new device request
 
 	cmd.Flags().String("id", "", "Device identifier (required)")
 	cmd.Flags().String("status", "ACCEPTED", "Status of registration")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -62,6 +63,11 @@ func (n *approveNewDeviceRequestCmd) approveNewDeviceRequest(cmd *cobra.Command,
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/constants.go
+++ b/pkg/cmd/constants.go
@@ -4,4 +4,5 @@ const (
 	FlagDataName                  = "data"
 	FlagDataTemplateName          = "template"
 	FlagDataTemplateVariablesName = "templateVars"
+	FlagProcessingModeName        = "processingMode"
 )

--- a/pkg/cmd/copyApplicationCmd.auto.go
+++ b/pkg/cmd/copyApplicationCmd.auto.go
@@ -39,6 +39,7 @@ Copy an existing application
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Application id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -66,6 +67,11 @@ func (n *copyApplicationCmd) copyApplication(cmd *cobra.Command, args []string) 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/createAgentCmd.auto.go
+++ b/pkg/cmd/createAgentCmd.auto.go
@@ -41,6 +41,7 @@ Create agent with custom properties
 	cmd.Flags().String("name", "", "Agent name (required)")
 	cmd.Flags().String("type", "", "Agent type")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("name")
@@ -68,6 +69,11 @@ func (n *createAgentCmd) createAgent(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/createDeviceCmd.auto.go
+++ b/pkg/cmd/createDeviceCmd.auto.go
@@ -40,6 +40,7 @@ Create device with custom properties
 	cmd.Flags().StringSlice("name", []string{""}, "Device name (required)")
 	cmd.Flags().String("type", "", "Device type")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("name")
@@ -67,6 +68,11 @@ func (n *createDeviceCmd) createDevice(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/createDeviceGroupCmd.auto.go
+++ b/pkg/cmd/createDeviceGroupCmd.auto.go
@@ -40,6 +40,7 @@ Create device group with custom properties
 	cmd.Flags().String("name", "", "Device group name (required)")
 	cmd.Flags().String("type", "", "Device group type (c8y_DeviceGroup (root folder) or c8y_DeviceSubGroup (sub folder)). Defaults to c8y_DeviceGroup")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("name")
@@ -67,6 +68,11 @@ func (n *createDeviceGroupCmd) createDeviceGroup(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/cumulocityProperties.go
+++ b/pkg/cmd/cumulocityProperties.go
@@ -24,6 +24,7 @@ func RemoveCumulocityProperties(data map[string]interface{}, removeID bool) map[
 	if removeID {
 		delete(data, "id")
 		delete(data, "owner")
+		delete(data, "source")
 	}
 	return data
 }

--- a/pkg/cmd/deleteAgentCmd.auto.go
+++ b/pkg/cmd/deleteAgentCmd.auto.go
@@ -36,6 +36,7 @@ Get agent by id
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Agent ID (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *deleteAgentCmd) deleteAgent(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/deleteAlarmCollectionCmd.auto.go
@@ -46,6 +46,7 @@ Remove alarms on the device which are active and created in the last 10 minutes
 	cmd.Flags().Bool("resolved", false, "When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.")
 	cmd.Flags().Bool("withSourceAssets", false, "When set to true also alarms for related source assets will be removed. When this parameter is provided also source must be defined.")
 	cmd.Flags().Bool("withSourceDevices", false, "When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -152,6 +153,11 @@ func (n *deleteAlarmCollectionCmd) deleteAlarmCollection(cmd *cobra.Command, arg
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteApplicationCmd.auto.go
+++ b/pkg/cmd/deleteApplicationCmd.auto.go
@@ -37,6 +37,7 @@ Delete an application by name
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Application id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *deleteApplicationCmd) deleteApplication(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteAssetFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteAssetFromGroupCmd.auto.go
@@ -36,6 +36,7 @@ Unassign a child device from its parent device
 	cmd.Flags().StringSlice("group", []string{""}, "Asset id (required)")
 	cmd.Flags().StringSlice("childDevice", []string{""}, "Child device")
 	cmd.Flags().StringSlice("childGroup", []string{""}, "Child device group")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -63,6 +64,11 @@ func (n *deleteAssetFromGroupCmd) deleteAssetFromGroup(cmd *cobra.Command, args 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteBinaryCmd.auto.go
+++ b/pkg/cmd/deleteBinaryCmd.auto.go
@@ -34,6 +34,7 @@ Delete a binary
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Inventory binary id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -61,6 +62,11 @@ func (n *deleteBinaryCmd) deleteBinary(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteDeviceCmd.auto.go
+++ b/pkg/cmd/deleteDeviceCmd.auto.go
@@ -36,6 +36,7 @@ Get device by id
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device ID (required)")
 	cmd.Flags().Bool("cascade", false, "Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -70,6 +71,11 @@ func (n *deleteDeviceCmd) deleteDevice(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteDeviceFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteDeviceFromGroupCmd.auto.go
@@ -35,6 +35,7 @@ Unassign a child device from its parent device
 
 	cmd.Flags().StringSlice("group", []string{""}, "Asset id (required)")
 	cmd.Flags().StringSlice("childDevice", []string{""}, "Child device (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -63,6 +64,11 @@ func (n *deleteDeviceFromGroupCmd) deleteDeviceFromGroup(cmd *cobra.Command, arg
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteDeviceGroupCmd.auto.go
+++ b/pkg/cmd/deleteDeviceGroupCmd.auto.go
@@ -36,6 +36,7 @@ Get device group by id
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device group ID (required)")
 	cmd.Flags().Bool("cascade", false, "Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -70,6 +71,11 @@ func (n *deleteDeviceGroupCmd) deleteDeviceGroup(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteEventBinaryCmd.auto.go
+++ b/pkg/cmd/deleteEventBinaryCmd.auto.go
@@ -35,6 +35,7 @@ Delete an binary attached to an event
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Event id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -62,6 +63,11 @@ func (n *deleteEventBinaryCmd) deleteEventBinary(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteEventCmd.auto.go
+++ b/pkg/cmd/deleteEventCmd.auto.go
@@ -34,6 +34,7 @@ Delete an event
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Event id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -61,6 +62,11 @@ func (n *deleteEventCmd) deleteEvent(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteEventCollectionCmd.auto.go
+++ b/pkg/cmd/deleteEventCollectionCmd.auto.go
@@ -42,6 +42,7 @@ Remove events from a device
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of event occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of event occurrence.")
 	cmd.Flags().Bool("revert", false, "Return the newest instead of the oldest events. Must be used with dateFrom and dateTo parameters")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -120,6 +121,11 @@ func (n *deleteEventCollectionCmd) deleteEventCollection(cmd *cobra.Command, arg
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteExternalIDCmd.auto.go
+++ b/pkg/cmd/deleteExternalIDCmd.auto.go
@@ -35,6 +35,7 @@ Delete external identity
 
 	cmd.Flags().String("type", "", "External identity type (required)")
 	cmd.Flags().String("name", "", "External identity id/name (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("type")
@@ -63,6 +64,11 @@ func (n *deleteExternalIDCmd) deleteExternalID(cmd *cobra.Command, args []string
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteGroupCmd.auto.go
+++ b/pkg/cmd/deleteGroupCmd.auto.go
@@ -35,6 +35,7 @@ Delete a user group
 
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().StringSlice("id", []string{""}, "Group id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -62,6 +63,11 @@ func (n *deleteGroupCmd) deleteGroup(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteManagedObjectChildAssetReferenceCmd.auto.go
+++ b/pkg/cmd/deleteManagedObjectChildAssetReferenceCmd.auto.go
@@ -36,6 +36,7 @@ Unassign a child device from its parent device
 	cmd.Flags().StringSlice("group", []string{""}, "Asset id (required)")
 	cmd.Flags().StringSlice("childDevice", []string{""}, "Child device")
 	cmd.Flags().StringSlice("childGroup", []string{""}, "Child device group")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -63,6 +64,11 @@ func (n *deleteManagedObjectChildAssetReferenceCmd) deleteManagedObjectChildAsse
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteManagedObjectChildDeviceReferenceCmd.auto.go
+++ b/pkg/cmd/deleteManagedObjectChildDeviceReferenceCmd.auto.go
@@ -35,6 +35,7 @@ Unassign a child device from its parent device
 
 	cmd.Flags().StringSlice("device", []string{""}, "ManagedObject id (required)")
 	cmd.Flags().StringSlice("childDevice", []string{""}, "Child device reference (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -63,6 +64,11 @@ func (n *deleteManagedObjectChildDeviceReferenceCmd) deleteManagedObjectChildDev
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteManagedObjectCmd.auto.go
+++ b/pkg/cmd/deleteManagedObjectCmd.auto.go
@@ -38,6 +38,7 @@ Delete a managed object
 
 	cmd.Flags().String("id", "", "ManagedObject id (required)")
 	cmd.Flags().Bool("cascade", false, "Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -72,6 +73,11 @@ func (n *deleteManagedObjectCmd) deleteManagedObject(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteMeasurementCmd.auto.go
+++ b/pkg/cmd/deleteMeasurementCmd.auto.go
@@ -34,6 +34,7 @@ Delete measurement
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Measurement id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -61,6 +62,11 @@ func (n *deleteMeasurementCmd) deleteMeasurement(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteMeasurementCollectionCmd.auto.go
+++ b/pkg/cmd/deleteMeasurementCollectionCmd.auto.go
@@ -38,6 +38,7 @@ Delete measurement collection for a device
 	cmd.Flags().String("fragmentType", "", "Fragment name from measurement (deprecated).")
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of measurement occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of measurement occurrence.")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -109,6 +110,11 @@ func (n *deleteMeasurementCollectionCmd) deleteMeasurementCollection(cmd *cobra.
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteMicroserviceCmd.auto.go
+++ b/pkg/cmd/deleteMicroserviceCmd.auto.go
@@ -37,6 +37,7 @@ Delete a microservice by name
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Microservice id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *deleteMicroserviceCmd) deleteMicroservice(cmd *cobra.Command, args []st
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteNewDeviceRequestCmd.auto.go
+++ b/pkg/cmd/deleteNewDeviceRequestCmd.auto.go
@@ -34,6 +34,7 @@ Delete a new device request
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "New Device Request ID (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -61,6 +62,11 @@ func (n *deleteNewDeviceRequestCmd) deleteNewDeviceRequest(cmd *cobra.Command, a
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteOperationCollectionCmd.auto.go
+++ b/pkg/cmd/deleteOperationCollectionCmd.auto.go
@@ -39,6 +39,7 @@ Remove all pending operations for a given device
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of operation.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of operation.")
 	cmd.Flags().String("status", "", "Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING.")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -120,6 +121,11 @@ func (n *deleteOperationCollectionCmd) deleteOperationCollection(cmd *cobra.Comm
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteRetentionRuleCmd.auto.go
+++ b/pkg/cmd/deleteRetentionRuleCmd.auto.go
@@ -35,6 +35,7 @@ Delete a retention rule
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Retention rule id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -62,6 +63,11 @@ func (n *deleteRetentionRuleCmd) deleteRetentionRule(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteRoleFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteRoleFromGroupCmd.auto.go
@@ -36,6 +36,7 @@ Remove a role from the given user
 	cmd.Flags().StringSlice("group", []string{""}, "Group id (required)")
 	cmd.Flags().StringSlice("role", []string{""}, "Role name, e.g. ROLE_TENANT_MANAGEMENT_ADMIN (required)")
 	cmd.Flags().String("tenant", "", "Tenant")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -64,6 +65,11 @@ func (n *deleteRoleFromGroupCmd) deleteRoleFromGroup(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteRoleFromUserCmd.auto.go
+++ b/pkg/cmd/deleteRoleFromUserCmd.auto.go
@@ -36,6 +36,7 @@ Remove a role from the given user
 	cmd.Flags().StringSlice("user", []string{""}, "User (required)")
 	cmd.Flags().StringSlice("role", []string{""}, "Role name (required)")
 	cmd.Flags().String("tenant", "", "Tenant")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("user")
@@ -64,6 +65,11 @@ func (n *deleteRoleFromUserCmd) deleteRoleFromUser(cmd *cobra.Command, args []st
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteTenantCmd.auto.go
+++ b/pkg/cmd/deleteTenantCmd.auto.go
@@ -34,6 +34,7 @@ Delete a tenant by name (from the mangement tenant)
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Tenant id")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -60,6 +61,11 @@ func (n *deleteTenantCmd) deleteTenant(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteTenantOptionCmd.auto.go
+++ b/pkg/cmd/deleteTenantOptionCmd.auto.go
@@ -35,6 +35,7 @@ Get a tenant option
 
 	cmd.Flags().String("category", "", "Tenant Option category (required)")
 	cmd.Flags().String("key", "", "Tenant Option key (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("category")
@@ -63,6 +64,11 @@ func (n *deleteTenantOptionCmd) deleteTenantOption(cmd *cobra.Command, args []st
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteUserCmd.auto.go
+++ b/pkg/cmd/deleteUserCmd.auto.go
@@ -37,6 +37,7 @@ Delete a user
 
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().String("id", "", "User id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *deleteUserCmd) deleteUser(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/deleteUserFromGroupCmd.auto.go
+++ b/pkg/cmd/deleteUserFromGroupCmd.auto.go
@@ -36,6 +36,7 @@ List the users within a user group
 	cmd.Flags().StringSlice("group", []string{""}, "Group ID (required)")
 	cmd.Flags().StringSlice("user", []string{""}, "User id/username (required)")
 	cmd.Flags().String("tenant", "", "Tenant")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -64,6 +65,11 @@ func (n *deleteUserFromGroupCmd) deleteUserFromGroup(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/disableApplicationFromTenantCmd.auto.go
+++ b/pkg/cmd/disableApplicationFromTenantCmd.auto.go
@@ -35,6 +35,7 @@ Disable an application of a tenant by name
 
 	cmd.Flags().String("tenant", "", "Tenant id. Defaults to current tenant (based on credentials)")
 	cmd.Flags().String("application", "", "Application id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("application")
@@ -62,6 +63,11 @@ func (n *disableApplicationFromTenantCmd) disableApplicationFromTenant(cmd *cobr
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/disableMicroserviceCmd.auto.go
+++ b/pkg/cmd/disableMicroserviceCmd.auto.go
@@ -39,6 +39,7 @@ Disable (unsubscribe) to a microservice
 
 	cmd.Flags().String("id", "", "Microservice id (required)")
 	cmd.Flags().String("tenant", "", "Tenant id")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -66,6 +67,11 @@ func (n *disableMicroserviceCmd) disableMicroservice(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/enableApplicationOnTenantCmd.auto.go
+++ b/pkg/cmd/enableApplicationOnTenantCmd.auto.go
@@ -35,6 +35,7 @@ Enable an application of a tenant by name
 
 	cmd.Flags().String("tenant", "", "Tenant id. Defaults to current tenant (based on credentials)")
 	cmd.Flags().String("application", "", "Application id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("application")
@@ -62,6 +63,11 @@ func (n *enableApplicationOnTenantCmd) enableApplicationOnTenant(cmd *cobra.Comm
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/enableMicroserviceCmd.auto.go
+++ b/pkg/cmd/enableMicroserviceCmd.auto.go
@@ -39,6 +39,7 @@ Enable (subscribe) to a microservice
 
 	cmd.Flags().String("tenant", "", "Tenant id")
 	cmd.Flags().String("id", "", "Microservice id (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -66,6 +67,11 @@ func (n *enableMicroserviceCmd) enableMicroservice(cmd *cobra.Command, args []st
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/genericRestCmd.go
+++ b/pkg/cmd/genericRestCmd.go
@@ -155,7 +155,7 @@ func (n *getGenericRestCmd) getGenericRest(cmd *cobra.Command, args []string) er
 		// get file info
 		if cmd.Flags().Changed("file") {
 			req.FormData = make(map[string]io.Reader)
-			getFileFlag(cmd, "file", req.FormData)
+			getFileFlag(cmd, "file", true, req.FormData)
 		}
 	}
 

--- a/pkg/cmd/getMeasurementCollectionCmd.auto.go
+++ b/pkg/cmd/getMeasurementCollectionCmd.auto.go
@@ -41,8 +41,8 @@ Get a list of measurements
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of measurement occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of measurement occurrence.")
 	cmd.Flags().Bool("revert", false, "Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters")
-	cmd.Flags().Bool("csv", false, "Results will be displayed in csv format")
-	cmd.Flags().Bool("excel", false, "Results will be displayed in Excel format")
+	cmd.Flags().Bool("csv", false, "Results will be displayed in csv format. Note: -IncludeAll, is not supported when using using this parameter")
+	cmd.Flags().Bool("excel", false, "Results will be displayed in Excel format Note: -IncludeAll, is not supported when using using this parameter")
 	cmd.Flags().String("unit", "", "Every measurement fragment which contains 'unit' property will be transformed to use required system of units.")
 
 	// Required flags

--- a/pkg/cmd/getSessionCmd.manual.go
+++ b/pkg/cmd/getSessionCmd.manual.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/prompt"
+	"github.com/spf13/cobra"
+	"github.com/tidwall/pretty"
+)
+
+// CumulocitySessionDetails public details about the current session
+type CumulocitySessionDetails struct {
+	CumulocitySession
+
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+type getSessionCmd struct {
+	OutputJSON bool
+	prompter   *prompt.Prompt
+	*baseCmd
+}
+
+func newGetSessionCmd() *getSessionCmd {
+	ccmd := &getSessionCmd{}
+	ccmd.prompter = prompt.NewPrompt(Logger)
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get session information",
+		Long:  `Get session information`,
+		Example: `
+Get the details about the current session
+$ c8y sessions get
+
+Get the details about the current session which is specified via the --session argument
+$ c8y sessions get --session mycustomsession
+		`,
+		RunE: ccmd.getSession,
+	}
+
+	cmd.Flags().BoolVar(&ccmd.OutputJSON, "json", false, "Output passphrase in json")
+	cmd.SilenceUsage = true
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *getSessionCmd) getSession(cmd *cobra.Command, args []string) error {
+
+	session := CumulocitySessionDetails{
+		Path: cliConfig.GetSessionFilePath(),
+		Name: cliConfig.GetName(),
+		CumulocitySession: CumulocitySession{
+			Host:            cliConfig.GetHost(),
+			Tenant:          cliConfig.GetTenant(),
+			Username:        cliConfig.GetUsername(),
+			Description:     cliConfig.GetDescription(),
+			UseTenantPrefix: cliConfig.Persistent.GetBool("useTenantPrefix"),
+		},
+	}
+
+	if session.CumulocitySession.Host == "" {
+		return newUserError("no session is loaded")
+	}
+
+	b, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
+
+	outputEnding := "\n"
+
+	if globalFlagPrettyPrint {
+		fmt.Printf("%s%s", pretty.Pretty(bytes.TrimSpace(b)), outputEnding)
+	} else {
+		fmt.Printf("%s%s", bytes.TrimSpace(b), outputEnding)
+	}
+	return nil
+}

--- a/pkg/cmd/inventoryFlags.go
+++ b/pkg/cmd/inventoryFlags.go
@@ -62,6 +62,10 @@ func addTemplateFlag(cmd *cobra.Command) {
 	cmd.Flags().String(FlagDataTemplateVariablesName, "", "Body template variables")
 }
 
+func addProcessingModeFlag(cmd *cobra.Command) {
+	cmd.Flags().String(FlagProcessingModeName, "", "Processing mode")
+}
+
 // resolveTemplatePath resolves a template path
 func resolveTemplatePath(name string) (string, error) {
 	return matchFilePath(globalFlagTemplatePath, name, ".jsonnet", "ignore")
@@ -204,7 +208,7 @@ func getFormDataObjectFlag(cmd *cobra.Command, flagName string, data map[string]
 	return nil
 }
 
-func getFileFlag(cmd *cobra.Command, flagName string, formData map[string]io.Reader) error {
+func getFileFlag(cmd *cobra.Command, flagName string, includeMeta bool, formData map[string]io.Reader) error {
 	if formData == nil {
 		formData = make(map[string]io.Reader)
 	}
@@ -238,12 +242,13 @@ func getFileFlag(cmd *cobra.Command, flagName string, formData map[string]io.Rea
 			objectInfo["type"] = mimeType
 		}
 
-		if v, err := json.Marshal(objectInfo); err == nil {
-			formData["object"] = bytes.NewReader(v)
-		} else {
-			return errors.New("failed to create object form-data property")
+		if includeMeta {
+			if v, err := json.Marshal(objectInfo); err == nil {
+				formData["object"] = bytes.NewReader(v)
+			} else {
+				return errors.New("failed to create object form-data property")
+			}
 		}
-
 	}
 	return nil
 }

--- a/pkg/cmd/inventoryFlags.go
+++ b/pkg/cmd/inventoryFlags.go
@@ -208,6 +208,12 @@ func getFormDataObjectFlag(cmd *cobra.Command, flagName string, data map[string]
 	return nil
 }
 
+func getFileContentsFlag(cmd *cobra.Command, flagName string, body *mapbuilder.MapBuilder) {
+	if value, err := cmd.Flags().GetString(flagName); err == nil {
+		body.SetFile(value)
+	}
+}
+
 func getFileFlag(cmd *cobra.Command, flagName string, includeMeta bool, formData map[string]io.Reader) error {
 	if formData == nil {
 		formData = make(map[string]io.Reader)

--- a/pkg/cmd/listSessionCmd.manual.go
+++ b/pkg/cmd/listSessionCmd.manual.go
@@ -178,7 +178,17 @@ func (n *listSessionCmd) listSession(cmd *cobra.Command, args []string) error {
 		Searcher:          searcher,
 	}
 
-	idx, result, err := prompt.Run()
+	var idx int
+	var result string
+
+	if len(filteredSessions) == 1 {
+		Logger.Info("Only 1 session found. Selecting it automatically")
+		idx = 0
+		result = filteredSessions[0].Path
+		err = nil
+	} else {
+		idx, result, err = prompt.Run()
+	}
 
 	if err != nil {
 		fmt.Printf("Prompt failed %v\n", err)

--- a/pkg/cmd/logoutCmd.auto.go
+++ b/pkg/cmd/logoutCmd.auto.go
@@ -1,0 +1,92 @@
+// Code generated from specification version 1.0.0: DO NOT EDIT
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type logoutCmd struct {
+	*baseCmd
+}
+
+func newLogoutCmd() *logoutCmd {
+	ccmd := &logoutCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Log out the current user",
+		Long:  `Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL`,
+		Example: `
+$ c8y users logout
+Log out the current user
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.logout,
+	}
+
+	cmd.SilenceUsage = true
+
+	addProcessingModeFlag(cmd)
+
+	// Required flags
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *logoutCmd) logout(cmd *cobra.Command, args []string) error {
+
+	commonOptions, err := getCommonOptions(cmd)
+	if err != nil {
+		return newUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+	}
+
+	// query parameters
+	queryValue := url.QueryEscape("")
+	query := url.Values{}
+	queryValue, err = url.QueryUnescape(query.Encode())
+
+	if err != nil {
+		return newSystemError("Invalid query parameter")
+	}
+
+	// headers
+	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
+
+	// form data
+	formData := make(map[string]io.Reader)
+
+	// body
+	body := mapbuilder.NewMapBuilder()
+
+	// path parameters
+	pathParameters := make(map[string]string)
+
+	path := replacePathParameters("/user/logout", pathParameters)
+
+	req := c8y.RequestOptions{
+		Method:       "POST",
+		Path:         path,
+		Query:        queryValue,
+		Body:         body.GetMap(),
+		FormData:     formData,
+		Header:       headers,
+		IgnoreAccept: false,
+		DryRun:       globalFlagDryRun,
+	}
+
+	return processRequestAndResponse([]c8y.RequestOptions{req}, commonOptions)
+}

--- a/pkg/cmd/newAlarmCmd.auto.go
+++ b/pkg/cmd/newAlarmCmd.auto.go
@@ -40,6 +40,7 @@ Create a new alarm for device
 	cmd.Flags().String("severity", "", "The severity of the alarm: CRITICAL, MAJOR, MINOR or WARNING. Must be upper-case.")
 	cmd.Flags().String("status", "", "The status of the alarm: ACTIVE, ACKNOWLEDGED or CLEARED. If status was not appeared, new alarm will have status ACTIVE. Must be upper-case.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -67,6 +68,11 @@ func (n *newAlarmCmd) newAlarm(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newApplicationBinaryCmd.auto.go
+++ b/pkg/cmd/newApplicationBinaryCmd.auto.go
@@ -40,6 +40,7 @@ Upload application microservice binary
 
 	cmd.Flags().String("id", "", "Application id (required)")
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -68,6 +69,11 @@ func (n *newApplicationBinaryCmd) newApplicationBinary(cmd *cobra.Command, args 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)
@@ -75,7 +81,7 @@ func (n *newApplicationBinaryCmd) newApplicationBinary(cmd *cobra.Command, args 
 	// body
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
-	getFileFlag(cmd, "file", formData)
+	getFileFlag(cmd, "file", true, formData)
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}

--- a/pkg/cmd/newApplicationCmd.auto.go
+++ b/pkg/cmd/newApplicationCmd.auto.go
@@ -43,6 +43,7 @@ Create a new hosted application
 	cmd.Flags().String("resourcesUsername", "", "authorization username to access resourcesUrl")
 	cmd.Flags().String("resourcesPassword", "", "authorization password to access resourcesUrl")
 	cmd.Flags().String("externalUrl", "", "URL to the external application. Required when application type is EXTERNAL")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("name")
@@ -72,6 +73,11 @@ func (n *newApplicationCmd) newApplication(cmd *cobra.Command, args []string) er
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newAuditCmd.auto.go
+++ b/pkg/cmd/newAuditCmd.auto.go
@@ -42,6 +42,7 @@ Create an audit record for a custom managed object update
 	cmd.Flags().String("user", "", "The user responsible for the audited action.")
 	cmd.Flags().String("application", "", "The application used to carry out the audited action.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("type")
@@ -73,6 +74,11 @@ func (n *newAuditCmd) newAudit(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newBinaryCmd.auto.go
+++ b/pkg/cmd/newBinaryCmd.auto.go
@@ -38,6 +38,7 @@ Upload a config file and make it globally accessible for all users
 
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("file")
@@ -65,6 +66,11 @@ func (n *newBinaryCmd) newBinary(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)
@@ -72,7 +78,7 @@ func (n *newBinaryCmd) newBinary(cmd *cobra.Command, args []string) error {
 	// body
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
-	getFileFlag(cmd, "file", formData)
+	getFileFlag(cmd, "file", true, formData)
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}

--- a/pkg/cmd/newEventBinaryCmd.auto.go
+++ b/pkg/cmd/newEventBinaryCmd.auto.go
@@ -35,6 +35,7 @@ Add a binary to an event
 
 	cmd.Flags().String("id", "", "Event id (required)")
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *newEventBinaryCmd) newEventBinary(cmd *cobra.Command, args []string) er
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)
@@ -70,7 +76,7 @@ func (n *newEventBinaryCmd) newEventBinary(cmd *cobra.Command, args []string) er
 	// body
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
-	getFileFlag(cmd, "file", formData)
+	getFileFlag(cmd, "file", false, formData)
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}

--- a/pkg/cmd/newEventCmd.auto.go
+++ b/pkg/cmd/newEventCmd.auto.go
@@ -38,6 +38,7 @@ Create a new event for a device
 	cmd.Flags().String("type", "", "Identifies the type of this event.")
 	cmd.Flags().String("text", "", "Text description of the event.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -65,6 +66,11 @@ func (n *newEventCmd) newEvent(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newExternalIDCmd.auto.go
+++ b/pkg/cmd/newExternalIDCmd.auto.go
@@ -36,6 +36,7 @@ Create external identity
 	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject linked to the external ID. (required)")
 	cmd.Flags().String("type", "", "The type of the external identifier as string, e.g. 'com_cumulocity_model_idtype_SerialNumber'. (required)")
 	cmd.Flags().String("name", "", "The identifier used in the external system that Cumulocity interfaces with. (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -65,6 +66,11 @@ func (n *newExternalIDCmd) newExternalID(cmd *cobra.Command, args []string) erro
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newGroupCmd.auto.go
+++ b/pkg/cmd/newGroupCmd.auto.go
@@ -35,6 +35,7 @@ Create a user group
 
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().String("name", "", "Group name")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -61,6 +62,11 @@ func (n *newGroupCmd) newGroup(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildAssetCmd.auto.go
@@ -36,6 +36,7 @@ Create group heirachy (parent group -> child group)
 	cmd.Flags().StringSlice("group", []string{""}, "Group (required)")
 	cmd.Flags().StringSlice("newChildDevice", []string{""}, "New child device to be added to the group as an asset")
 	cmd.Flags().StringSlice("newChildGroup", []string{""}, "New child device group to be added to the group as an asset")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("group")
@@ -63,6 +64,11 @@ func (n *newManagedObjectChildAssetCmd) newManagedObjectChildAsset(cmd *cobra.Co
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
+++ b/pkg/cmd/newManagedObjectChildDeviceCmd.auto.go
@@ -35,6 +35,7 @@ Assign a device as a child device to an existing device
 
 	cmd.Flags().StringSlice("device", []string{""}, "Device. (required)")
 	cmd.Flags().StringSlice("newChild", []string{""}, "New child device (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -63,6 +64,11 @@ func (n *newManagedObjectChildDeviceCmd) newManagedObjectChildDevice(cmd *cobra.
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newManagedObjectCmd.auto.go
+++ b/pkg/cmd/newManagedObjectCmd.auto.go
@@ -36,6 +36,7 @@ Create a managed object
 	cmd.Flags().String("name", "", "name")
 	cmd.Flags().String("type", "", "type")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -62,6 +63,11 @@ func (n *newManagedObjectCmd) newManagedObject(cmd *cobra.Command, args []string
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newMeasurementCmd.auto.go
+++ b/pkg/cmd/newMeasurementCmd.auto.go
@@ -37,6 +37,7 @@ Create measurement
 	cmd.Flags().String("time", "0s", "Time of the measurement. Defaults to current timestamp.")
 	cmd.Flags().String("type", "", "The most specific type of this entire measurement.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -64,6 +65,11 @@ func (n *newMeasurementCmd) newMeasurement(cmd *cobra.Command, args []string) er
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newMicroserviceBinaryCmd.auto.go
+++ b/pkg/cmd/newMicroserviceBinaryCmd.auto.go
@@ -40,6 +40,7 @@ Upload microservice binary
 
 	cmd.Flags().String("id", "", "Microservice id (required)")
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -68,6 +69,11 @@ func (n *newMicroserviceBinaryCmd) newMicroserviceBinary(cmd *cobra.Command, arg
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)
@@ -75,7 +81,7 @@ func (n *newMicroserviceBinaryCmd) newMicroserviceBinary(cmd *cobra.Command, arg
 	// body
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
-	getFileFlag(cmd, "file", formData)
+	getFileFlag(cmd, "file", true, formData)
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}

--- a/pkg/cmd/newOperationCmd.auto.go
+++ b/pkg/cmd/newOperationCmd.auto.go
@@ -36,6 +36,7 @@ Create operation for a device
 	cmd.Flags().StringSlice("device", []string{""}, "Identifies the target device on which this operation should be performed. (required)")
 	cmd.Flags().String("description", "", "Text description of the operation.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -63,6 +64,11 @@ func (n *newOperationCmd) newOperation(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newRetentionRuleCmd.auto.go
+++ b/pkg/cmd/newRetentionRuleCmd.auto.go
@@ -40,6 +40,7 @@ Create a retention rule
 	cmd.Flags().String("source", "", "RetentionRule will be applied to documents with source.")
 	cmd.Flags().Int("maximumAge", 0, "Maximum age of document in days. (required)")
 	cmd.Flags().Bool("editable", false, "Whether the rule is editable. Can be updated only by management tenant.")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("dataType")
@@ -68,6 +69,11 @@ func (n *newRetentionRuleCmd) newRetentionRule(cmd *cobra.Command, args []string
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newTenantCmd.auto.go
+++ b/pkg/cmd/newTenantCmd.auto.go
@@ -41,6 +41,7 @@ Create a new tenant (from the management tenant)
 	cmd.Flags().String("contactPhone", "", "An international contact phone number")
 	cmd.Flags().String("tenantId", "", "The tenant ID. This should be left bank unless you know what you are doing. Will be auto-generated if not present.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("company")
@@ -69,6 +70,11 @@ func (n *newTenantCmd) newTenant(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newTenantOptionCmd.auto.go
+++ b/pkg/cmd/newTenantOptionCmd.auto.go
@@ -36,6 +36,7 @@ Create a tenant option
 	cmd.Flags().String("category", "", "Category of option (required)")
 	cmd.Flags().String("key", "", "Key of option (required)")
 	cmd.Flags().String("value", "", "Value of option (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("category")
@@ -65,6 +66,11 @@ func (n *newTenantOptionCmd) newTenantOption(cmd *cobra.Command, args []string) 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/newUserCmd.auto.go
+++ b/pkg/cmd/newUserCmd.auto.go
@@ -43,6 +43,7 @@ Create a user
 	cmd.Flags().String("password", "", "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed")
 	cmd.Flags().Bool("sendPasswordResetEmail", false, "User activation status (true/false)")
 	cmd.Flags().String("customProperties", "", "Custom properties to be added to the user")
+	addProcessingModeFlag(cmd)
 	addTemplateFlag(cmd)
 
 	// Required flags
@@ -70,6 +71,11 @@ func (n *newUserCmd) newUser(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/registerNewDeviceCmd.auto.go
+++ b/pkg/cmd/registerNewDeviceCmd.auto.go
@@ -34,6 +34,7 @@ Register a new device request
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Device identifier. Max: 1000 characters. E.g. IMEI (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -61,6 +62,11 @@ func (n *registerNewDeviceCmd) registerNewDevice(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/requestDeviceCredentialsCmd.auto.go
+++ b/pkg/cmd/requestDeviceCredentialsCmd.auto.go
@@ -34,6 +34,7 @@ Request credentials for a new device
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Device identifier. Max: 1000 characters. E.g. IMEI (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -61,6 +62,11 @@ func (n *requestDeviceCredentialsCmd) requestDeviceCredentials(cmd *cobra.Comman
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/resetUserPasswordCmd.auto.go
+++ b/pkg/cmd/resetUserPasswordCmd.auto.go
@@ -36,6 +36,7 @@ Update a user
 	cmd.Flags().StringSlice("id", []string{""}, "User id (required)")
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().String("newPassword", "", "New user password. Min: 6, max: 32 characters. Only Latin1 chars allowed")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *resetUserPasswordCmd) resetUserPassword(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -69,10 +69,12 @@ func (c *c8yCmd) createCumulocityClient() {
 	}
 
 	// Try reading session from file
-	if _, readErr := ReadConfigFiles(viper.GetViper()); readErr != nil {
+	if sessionFilePath, readErr := ReadConfigFiles(viper.GetViper()); readErr != nil {
 		Logger.Printf("Error reading config file. %s", readErr)
 		// Fallback to reading session from environment variables
 		// client = c8y.NewClientFromEnvironment(httpClient, true)
+	} else {
+		cliConfig.SetSessionFilePath(sessionFilePath)
 	}
 	client = c8y.NewClient(
 		httpClient,

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -458,7 +458,9 @@ func ReadConfigFiles(v *viper.Viper) (path string, err error) {
 			sessionName = globalFlagSessionFile
 		}
 
-		v.SetConfigName(sessionName)
+		if sessionName != "" {
+			v.SetConfigName(sessionName)
+		}
 	}
 
 	err = v.MergeInConfig()

--- a/pkg/cmd/sessionsRootCmd.manual.go
+++ b/pkg/cmd/sessionsRootCmd.manual.go
@@ -19,6 +19,7 @@ func newSessionsRootCmd() *sessionsCmd {
 
 	// Subcommands
 	cmd.AddCommand(newNewSessionCmd().getCommand())
+	cmd.AddCommand(newGetSessionCmd().getCommand())
 	cmd.AddCommand(newEncryptTextCmd().getCommand())
 	cmd.AddCommand(newDecryptTextCmd().getCommand())
 	cmd.AddCommand(newCheckSessionPassphraseCmd().getCommand())

--- a/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
+++ b/pkg/cmd/setDeviceRequiredAvailabilityCmd.auto.go
@@ -35,6 +35,7 @@ Set the required availability of a device by name to 10 minutes
 
 	cmd.Flags().StringSlice("device", []string{""}, "Device ID (required)")
 	cmd.Flags().Int("interval", 0, "Interval in minutes (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("device")
@@ -63,6 +64,11 @@ func (n *setDeviceRequiredAvailabilityCmd) setDeviceRequiredAvailability(cmd *co
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateAgentCmd.auto.go
+++ b/pkg/cmd/updateAgentCmd.auto.go
@@ -36,6 +36,7 @@ Update agent by id
 	cmd.Flags().StringSlice("id", []string{""}, "Agent ID (required)")
 	cmd.Flags().String("newName", "", "Agent name")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *updateAgentCmd) updateAgent(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateAlarmCmd.auto.go
+++ b/pkg/cmd/updateAlarmCmd.auto.go
@@ -41,6 +41,7 @@ Update severity of an existing alarm to CRITICAL
 	cmd.Flags().String("severity", "", "Alarm severity, for example CRITICAL, MAJOR, MINOR or WARNING.")
 	cmd.Flags().String("text", "", "Text description of the alarm.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -68,6 +69,11 @@ func (n *updateAlarmCmd) updateAlarm(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateAlarmCollectionCmd.auto.go
+++ b/pkg/cmd/updateAlarmCollectionCmd.auto.go
@@ -40,6 +40,7 @@ Update the status of all active alarms on a device to ACKNOWLEDGED
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of alarm occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of alarm occurrence.")
 	cmd.Flags().String("newStatus", "", "New status to be applied to all of the matching alarms (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("newStatus")
@@ -119,6 +120,11 @@ func (n *updateAlarmCollectionCmd) updateAlarmCollection(cmd *cobra.Command, arg
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateApplicationCmd.auto.go
+++ b/pkg/cmd/updateApplicationCmd.auto.go
@@ -43,6 +43,7 @@ Update application availability to MARKET
 	cmd.Flags().String("resourcesUsername", "", "authorization username to access resourcesUrl")
 	cmd.Flags().String("resourcesPassword", "", "authorization password to access resourcesUrl")
 	cmd.Flags().String("externalUrl", "", "URL to the external application")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -70,6 +71,11 @@ func (n *updateApplicationCmd) updateApplication(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateBinaryCmd.auto.go
+++ b/pkg/cmd/updateBinaryCmd.auto.go
@@ -36,6 +36,7 @@ Update an existing binary file
 
 	cmd.Flags().String("id", "", "Inventory binary id (required)")
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *updateBinaryCmd) updateBinary(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateBinaryCmd.auto.go
+++ b/pkg/cmd/updateBinaryCmd.auto.go
@@ -77,7 +77,7 @@ func (n *updateBinaryCmd) updateBinary(cmd *cobra.Command, args []string) error 
 	// body
 	body := mapbuilder.NewMapBuilder()
 	body.SetMap(getDataFlag(cmd))
-	getFileFlag(cmd, "file", formData)
+	getFileFlag(cmd, "file", true, formData)
 	if err := setDataTemplateFromFlags(cmd, body); err != nil {
 		return newUserError("Template error. ", err)
 	}

--- a/pkg/cmd/updateCurrentApplicationCmd.auto.go
+++ b/pkg/cmd/updateCurrentApplicationCmd.auto.go
@@ -42,6 +42,7 @@ Update custom properties of the current application (requires using application 
 	cmd.Flags().String("resourcesUsername", "", "authorization username to access resourcesUrl")
 	cmd.Flags().String("resourcesPassword", "", "authorization password to access resourcesUrl")
 	cmd.Flags().String("externalUrl", "", "URL to the external application")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -68,6 +69,11 @@ func (n *updateCurrentApplicationCmd) updateCurrentApplication(cmd *cobra.Comman
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateDataBrokerCmd.auto.go
+++ b/pkg/cmd/updateDataBrokerCmd.auto.go
@@ -36,6 +36,7 @@ Change the status of a specific data broker connector by given connector id
 	cmd.Flags().String("id", "", "Data broker connector id (required)")
 	cmd.Flags().String("status", "", "DataBroker status [SUSPENDED]. (required)")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *updateDataBrokerCmd) updateDataBroker(cmd *cobra.Command, args []string
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateDeviceCmd.auto.go
+++ b/pkg/cmd/updateDeviceCmd.auto.go
@@ -36,6 +36,7 @@ Update device by id
 	cmd.Flags().StringSlice("id", []string{""}, "Device ID (required)")
 	cmd.Flags().String("newName", "", "Device name")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *updateDeviceCmd) updateDevice(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateDeviceGroupCmd.auto.go
+++ b/pkg/cmd/updateDeviceGroupCmd.auto.go
@@ -37,6 +37,7 @@ Update device group by id
 	cmd.Flags().StringSlice("id", []string{""}, "Device group ID (required)")
 	cmd.Flags().String("name", "", "Device group name")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *updateDeviceGroupCmd) updateDeviceGroup(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateEventBinaryCmd.auto.go
+++ b/pkg/cmd/updateEventBinaryCmd.auto.go
@@ -76,14 +76,7 @@ func (n *updateEventBinaryCmd) updateEventBinary(cmd *cobra.Command, args []stri
 
 	// body
 	body := mapbuilder.NewMapBuilder()
-	body.SetMap(getDataFlag(cmd))
-	getFileFlag(cmd, "file", formData)
-	if err := setDataTemplateFromFlags(cmd, body); err != nil {
-		return newUserError("Template error. ", err)
-	}
-	if err := body.Validate(); err != nil {
-		return newUserError("Body validation error. ", err)
-	}
+	getFileContentsFlag(cmd, "file", body)
 
 	// path parameters
 	pathParameters := make(map[string]string)
@@ -101,7 +94,7 @@ func (n *updateEventBinaryCmd) updateEventBinary(cmd *cobra.Command, args []stri
 		Method:       "PUT",
 		Path:         path,
 		Query:        queryValue,
-		Body:         body.GetMap(),
+		Body:         body.GetFileContents(),
 		FormData:     formData,
 		Header:       headers,
 		IgnoreAccept: false,

--- a/pkg/cmd/updateEventBinaryCmd.auto.go
+++ b/pkg/cmd/updateEventBinaryCmd.auto.go
@@ -36,6 +36,7 @@ Update a binary related to an event
 
 	cmd.Flags().String("id", "", "Event id (required)")
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -64,6 +65,11 @@ func (n *updateEventBinaryCmd) updateEventBinary(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateEventCmd.auto.go
+++ b/pkg/cmd/updateEventCmd.auto.go
@@ -39,6 +39,7 @@ Update custom properties of an existing event
 	cmd.Flags().String("id", "", "Event id (required)")
 	cmd.Flags().String("text", "", "Text description of the event.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -66,6 +67,11 @@ func (n *updateEventCmd) updateEvent(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateGroupCmd.auto.go
+++ b/pkg/cmd/updateGroupCmd.auto.go
@@ -36,6 +36,7 @@ Update a user group
 	cmd.Flags().String("tenant", "", "Tenant")
 	cmd.Flags().StringSlice("id", []string{""}, "Group id (required)")
 	cmd.Flags().String("name", "", "name")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *updateGroupCmd) updateGroup(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateManagedObjectCmd.auto.go
+++ b/pkg/cmd/updateManagedObjectCmd.auto.go
@@ -36,6 +36,7 @@ Update a managed object
 	cmd.Flags().String("id", "", "ManagedObject id (required)")
 	cmd.Flags().String("newName", "", "name")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -63,6 +64,11 @@ func (n *updateManagedObjectCmd) updateManagedObject(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateMicroserviceCmd.auto.go
+++ b/pkg/cmd/updateMicroserviceCmd.auto.go
@@ -40,6 +40,7 @@ Update microservice availability to MARKET
 	cmd.Flags().String("availability", "", "Access level for other tenants. Possible values are : MARKET, PRIVATE (default)")
 	cmd.Flags().String("contextPath", "", "contextPath of the hosted application")
 	cmd.Flags().String("resourcesUrl", "", "URL to microservice base directory hosted on an external server")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -67,6 +68,11 @@ func (n *updateMicroserviceCmd) updateMicroservice(cmd *cobra.Command, args []st
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateOperationCmd.auto.go
+++ b/pkg/cmd/updateOperationCmd.auto.go
@@ -38,6 +38,7 @@ Update an operation
 	cmd.Flags().String("status", "", "Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING. (required)")
 	cmd.Flags().String("failureReason", "", "Reason for the failure. Use when setting status to FAILED")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -66,6 +67,11 @@ func (n *updateOperationCmd) updateOperation(cmd *cobra.Command, args []string) 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateRetentionRuleCmd.auto.go
+++ b/pkg/cmd/updateRetentionRuleCmd.auto.go
@@ -42,6 +42,7 @@ Update a retention rule
 	cmd.Flags().Int("maximumAge", 0, "Maximum age of document in days.")
 	cmd.Flags().Bool("editable", false, "Whether the rule is editable. Can be updated only by management tenant.")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -70,6 +71,11 @@ func (n *updateRetentionRuleCmd) updateRetentionRule(cmd *cobra.Command, args []
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateTenantCmd.auto.go
+++ b/pkg/cmd/updateTenantCmd.auto.go
@@ -41,6 +41,7 @@ Update a tenant by name (from the mangement tenant)
 	cmd.Flags().String("contactName", "", "A contact name, for example an administrator, of the tenant")
 	cmd.Flags().String("contactPhone", "", "An international contact phone number")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("domain")
@@ -68,6 +69,11 @@ func (n *updateTenantCmd) updateTenant(cmd *cobra.Command, args []string) error 
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateTenantOptionBulkCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionBulkCmd.auto.go
@@ -35,6 +35,7 @@ Update multiple tenant options
 
 	cmd.Flags().String("category", "", "Tenant Option category (required)")
 	addDataFlag(cmd)
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("category")
@@ -63,6 +64,11 @@ func (n *updateTenantOptionBulkCmd) updateTenantOptionBulk(cmd *cobra.Command, a
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateTenantOptionCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionCmd.auto.go
@@ -36,6 +36,7 @@ Update a tenant option
 	cmd.Flags().String("category", "", "Tenant Option category (required)")
 	cmd.Flags().String("key", "", "Tenant Option key (required)")
 	cmd.Flags().String("value", "", "New value (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("category")
@@ -65,6 +66,11 @@ func (n *updateTenantOptionCmd) updateTenantOption(cmd *cobra.Command, args []st
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateTenantOptionEditableCmd.auto.go
+++ b/pkg/cmd/updateTenantOptionEditableCmd.auto.go
@@ -37,6 +37,7 @@ Update editable property for an existing tenant option
 	cmd.Flags().String("category", "", "Tenant Option category (required)")
 	cmd.Flags().String("key", "", "Tenant Option key (required)")
 	cmd.Flags().String("editable", "", "Whether the tenant option should be editable or not (required)")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("category")
@@ -66,6 +67,11 @@ func (n *updateTenantOptionEditableCmd) updateTenantOptionEditable(cmd *cobra.Co
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateUserCmd.auto.go
+++ b/pkg/cmd/updateUserCmd.auto.go
@@ -43,6 +43,7 @@ Update a user
 	cmd.Flags().String("password", "", "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed")
 	cmd.Flags().Bool("sendPasswordResetEmail", false, "User activation status (true/false)")
 	cmd.Flags().String("customProperties", "", "Custom properties to be added to the user")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 	cmd.MarkFlagRequired("id")
@@ -70,6 +71,11 @@ func (n *updateUserCmd) updateUser(cmd *cobra.Command, args []string) error {
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/updateUserCurrentCmd.auto.go
+++ b/pkg/cmd/updateUserCurrentCmd.auto.go
@@ -40,6 +40,7 @@ Update the current user's lastname
 	cmd.Flags().String("email", "", "User email address")
 	cmd.Flags().String("enabled", "", "User activation status (true/false)")
 	cmd.Flags().String("password", "", "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed")
+	addProcessingModeFlag(cmd)
 
 	// Required flags
 
@@ -66,6 +67,11 @@ func (n *updateUserCurrentCmd) updateUserCurrent(cmd *cobra.Command, args []stri
 
 	// headers
 	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
 
 	// form data
 	formData := make(map[string]io.Reader)

--- a/pkg/cmd/usersRootCmd.go
+++ b/pkg/cmd/usersRootCmd.go
@@ -30,6 +30,7 @@ func newUsersRootCmd() *usersCmd {
 	cmd.AddCommand(newUpdateUserCmd().getCommand())
 	cmd.AddCommand(newResetUserPasswordCmd().getCommand())
 	cmd.AddCommand(newGetUserMembershipCollectionCmd().getCommand())
+	cmd.AddCommand(newLogoutCmd().getCommand())
 
 	ccmd.baseCmd = newBaseCmd(cmd)
 

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -30,6 +30,9 @@ type CliConfiguration struct {
 	// Persistent settings (stored to file)
 	Persistent *viper.Viper
 
+	// Session file path
+	path string
+
 	// SecureData accessor to encrypt/decrypt data
 	SecureData *encrypt.SecureData
 
@@ -108,6 +111,26 @@ func (c *CliConfiguration) GetUsername() string {
 		return v
 	}
 	return os.Getenv("C8Y_USER")
+}
+
+// SetSessionFilePath sets the session's file path
+func (c *CliConfiguration) SetSessionFilePath(v string) {
+	c.path = v
+}
+
+// GetSessionFilePath returns the session file path
+func (c *CliConfiguration) GetSessionFilePath() string {
+	return c.path
+}
+
+// GetName returns the name of the current session
+func (c *CliConfiguration) GetName() string {
+	return c.viper.GetString("name")
+}
+
+// GetDescription returns the name description of the current session
+func (c *CliConfiguration) GetDescription() string {
+	return c.viper.GetString("name")
 }
 
 // GetTenant returns the Cumulocity tenant id

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -112,6 +112,7 @@ func NewMapBuilderFromJSON(data string) (*MapBuilder, error) {
 // MapBuilder creates body builder
 type MapBuilder struct {
 	body map[string]interface{}
+	file string
 
 	templateVariables map[string]interface{}
 	requiredKeys      []string
@@ -221,9 +222,30 @@ func (b *MapBuilder) SetMap(body map[string]interface{}) {
 	b.body = body
 }
 
+// SetFile sets the body to the contents of the file path
+func (b *MapBuilder) SetFile(path string) {
+	b.file = path
+}
+
 // GetMap returns the body as a map[string]interface{}
 func (b MapBuilder) GetMap() map[string]interface{} {
 	return b.body
+}
+
+func (b MapBuilder) GetFileContents() *os.File {
+	file, err := os.Open(b.file)
+	if err != nil {
+		log.Printf("failed to open file. %s", err)
+		return nil
+	}
+	return file
+}
+
+func (b MapBuilder) GetBody() (interface{}, error) {
+	if b.file != "" {
+		return os.Open(b.file)
+	}
+	return b.GetMap(), nil
 }
 
 // GetMap returns the body as a map[string]interface{}

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -91,8 +91,14 @@
     #
     $RESTBodyBuilder = New-Object System.Text.StringBuilder
     $RESTFormDataBuilder = New-Object System.Text.StringBuilder
+    $GetBodyContents = "body.GetMap()"
+    
     if ($Specification.body) {
-        $null = $RESTBodyBuilder.AppendLine('body.SetMap(getDataFlag(cmd))')
+        if ($Specification.bodyContent.type -ne 'binary') {
+            $null = $RESTBodyBuilder.AppendLine('body.SetMap(getDataFlag(cmd))')
+        } else {
+            $GetBodyContents = "body.GetFileContents()"
+        }
 
         foreach ($iArg in (Remove-SkippedParameters $Specification.body)) {
             $code = New-C8yApiGoGetValueFromFlag -Parameters $iArg -SetterType "body"
@@ -136,6 +142,9 @@
 "@.TrimStart()
                     $null = $RESTBodyBuilder.AppendLine($BodyErrCheck)
                 }
+                "none" {
+                    # Do nothing
+                }
                 default {
                     Write-Warning ("Unsupported templating type [{0}]" -f $Specification.bodyTemplate.type)
                 }
@@ -145,13 +154,14 @@
         #
         # Add support for user defined templates to control body
         #
-        $BodyUserTemplateCode = @"
+        if ($Specification.bodyTemplate.type -ne "none") {
+            $BodyUserTemplateCode = @"
         if err := setDataTemplateFromFlags(cmd, body); err != nil {
             return newUserError("Template error. ", err)
         }
 "@.TrimStart()
-        $null = $RESTBodyBuilder.AppendLine($BodyUserTemplateCode)
-
+            $null = $RESTBodyBuilder.AppendLine($BodyUserTemplateCode)
+        }
         
         if ($Specification.bodyValidation) {
             switch ($Specification.bodyValidation.type) {
@@ -174,12 +184,14 @@
         #
         # Validate body
         #
-        $BodyValidateionCode = @"
+        if ($Specification.bodyContent.type -ne 'binary') {
+            $BodyValidateionCode = @"
         if err := body.Validate(); err != nil {
             return newUserError("Body validation error. ", err)
         }
 "@.TrimStart()
-        $null = $RESTBodyBuilder.AppendLine($BodyValidateionCode)
+            $null = $RESTBodyBuilder.AppendLine($BodyValidateionCode)
+        }
         
     }
 
@@ -370,7 +382,7 @@ func (n *${Name}Cmd) ${Name}(cmd *cobra.Command, args []string) error {
         Method:       "${RESTMethod}",
         Path:         path,
         Query:        queryValue,
-        Body:         body.GetMap(),
+        Body:         $GetBodyContents,
         FormData:     formData,
         Header:       headers,
         IgnoreAccept: false,
@@ -674,6 +686,18 @@ Function Get-C8yGoArgs {
         }
 
         "attachment" {
+            $SetFlag = if ($UseOption) {
+                'cmd.Flags().StringP("{0}", "{1}", "{2}", "{3}")' -f $Name, $OptionName, $Default, $Description
+            } else {
+                'cmd.Flags().String("{0}", "{1}", "{2}")' -f $Name, $Default, $Description
+            }
+
+            @{
+                SetFlag = $SetFlag
+            }
+        }
+
+        "fileContents" {
             $SetFlag = if ($UseOption) {
                 'cmd.Flags().StringP("{0}", "{1}", "{2}", "{3}")' -f $Name, $OptionName, $Default, $Description
             } else {

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -1,4 +1,4 @@
-Function New-C8yApiGoCommand {
+﻿Function New-C8yApiGoCommand {
     [cmdletbinding()]
     Param(
         [Parameter(
@@ -662,6 +662,18 @@ Function Get-C8yGoArgs {
         }
 
         "file" {
+            $SetFlag = if ($UseOption) {
+                'cmd.Flags().StringP("{0}", "{1}", "{2}", "{3}")' -f $Name, $OptionName, $Default, $Description
+            } else {
+                'cmd.Flags().String("{0}", "{1}", "{2}")' -f $Name, $Default, $Description
+            }
+
+            @{
+                SetFlag = $SetFlag
+            }
+        }
+
+        "attachment" {
             $SetFlag = if ($UseOption) {
                 'cmd.Flags().StringP("{0}", "{1}", "{2}", "{3}")' -f $Name, $OptionName, $Default, $Description
             } else {

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -38,6 +38,7 @@
         "boolean" = @{}
         "datetime" = @{}
         "file" = @{}
+        "attachment" = @{}
         "id" = @{}
         "integer" = @{}
         "json_custom" = @{}
@@ -48,12 +49,20 @@
         "tenant" = @{}
     }
 
-    # file (used in multipart/form-data uploads). It rights to the formData object instead of the body
+    # file (used in multipart/form-data uploads). It writes to the formData object instead of the body
     $Setters."file"."query" = "query.Add(`"${queryParam}`", `"true`")"
     $Setters."file"."path" = "pathParameters[`"${queryParam}`"] = `"true`""
-    $Setters."file"."body" = "getFileFlag(cmd, `"${prop}`", formData)"
+    $Setters."file"."body" = "getFileFlag(cmd, `"${prop}`", true, formData)"
     $Definitions."file" = @"
     $($Setters."file".$SetterType)
+"@
+
+    # attachment (used in multipart/form-data uploads), without extra details
+    $Setters."attachment"."query" = "query.Add(`"${queryParam}`", `"true`")"
+    $Setters."attachment"."path" = "pathParameters[`"${queryParam}`"] = `"true`""
+    $Setters."attachment"."body" = "getFileFlag(cmd, `"${prop}`", false, formData)"
+    $Definitions."attachment" = @"
+    $($Setters."attachment".$SetterType)
 "@
 
     # Boolean

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -38,6 +38,7 @@
         "boolean" = @{}
         "datetime" = @{}
         "file" = @{}
+        "fileContents" = @{}
         "attachment" = @{}
         "id" = @{}
         "integer" = @{}
@@ -55,6 +56,12 @@
     $Setters."file"."body" = "getFileFlag(cmd, `"${prop}`", true, formData)"
     $Definitions."file" = @"
     $($Setters."file".$SetterType)
+"@
+
+    # fileContents. File contents will be added to body
+    $Setters."fileContents"."body" = "getFileContentsFlag(cmd, `"${prop}`", body)"
+    $Definitions."fileContents" = @"
+    $($Setters."fileContents".$SetterType)
 "@
 
     # attachment (used in multipart/form-data uploads), without extra details

--- a/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
+++ b/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
@@ -237,6 +237,25 @@
     }
 
     #
+    # Processing Mode
+    #
+    if ($Specification.method -match "DELETE|PUT|POST") {
+        $ProcessingModeParam = New-Object System.Text.StringBuilder
+        $null = $ProcessingModeParam.AppendLine('        # Cumulocity processing mode')
+        $null = $ProcessingModeParam.AppendLine('        [Parameter()]')
+        $null = $ProcessingModeParam.AppendLine('        [AllowNull()]')
+        $null = $ProcessingModeParam.AppendLine('        [AllowEmptyString()]')
+        $null = $ProcessingModeParam.AppendLine('        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]')
+        $null = $ProcessingModeParam.AppendLine('        [string]')
+        $null = $ProcessingModeParam.Append('        $ProcessingMode')
+        $null = $CmdletParameters.Add($ProcessingModeParam)
+
+        $null = $BeginParameterBuilder.AppendLine('        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {')
+        $null = $BeginParameterBuilder.AppendLine('            $Parameters["ProcessingMode"] = $ProcessingMode')
+        $null = $BeginParameterBuilder.AppendLine('        }')
+    }
+
+    #
     # Add common parameters
     #
     if ($ResultType -match "collection") {

--- a/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
+++ b/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
@@ -251,7 +251,7 @@
         $null = $CmdletParameters.Add($ProcessingModeParam)
 
         $null = $BeginParameterBuilder.AppendLine('        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {')
-        $null = $BeginParameterBuilder.AppendLine('            $Parameters["ProcessingMode"] = $ProcessingMode')
+        $null = $BeginParameterBuilder.AppendLine('            $Parameters["processingMode"] = $ProcessingMode')
         $null = $BeginParameterBuilder.AppendLine('        }')
     }
 

--- a/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
+++ b/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
@@ -245,7 +245,7 @@
         $null = $ProcessingModeParam.AppendLine('        [Parameter()]')
         $null = $ProcessingModeParam.AppendLine('        [AllowNull()]')
         $null = $ProcessingModeParam.AppendLine('        [AllowEmptyString()]')
-        $null = $ProcessingModeParam.AppendLine('        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]')
+        $null = $ProcessingModeParam.AppendLine('        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]')
         $null = $ProcessingModeParam.AppendLine('        [string]')
         $null = $ProcessingModeParam.Append('        $ProcessingMode')
         $null = $CmdletParameters.Add($ProcessingModeParam)

--- a/scripts/build-powershell/New-C8yPowershellArguments.ps1
+++ b/scripts/build-powershell/New-C8yPowershellArguments.ps1
@@ -66,6 +66,7 @@
         "dateto" { "string" }
         "directory" { "string" }
         "file" { "string" }
+        "fileContents" { "string" }
         "attachment" { "string" }
         "id" { "object" }
         "integer" { "long" }

--- a/scripts/build-powershell/New-C8yPowershellArguments.ps1
+++ b/scripts/build-powershell/New-C8yPowershellArguments.ps1
@@ -66,6 +66,7 @@
         "dateto" { "string" }
         "directory" { "string" }
         "file" { "string" }
+        "attachment" { "string" }
         "id" { "object" }
         "integer" { "long" }
         "json" { "object" }

--- a/tools/PSc8y/PSc8y.psd1
+++ b/tools/PSc8y/PSc8y.psd1
@@ -172,6 +172,7 @@ FunctionsToExport = @(
 	'Get-UserByName',
 	'Get-UserCollection',
 	'Get-UserMembershipCollection',
+	'Invoke-UserLogout',
 	'New-Agent',
 	'New-Alarm',
 	'New-Application',

--- a/tools/PSc8y/Private/Set-EnvironmentVariablesFromSession.ps1
+++ b/tools/PSc8y/Private/Set-EnvironmentVariablesFromSession.ps1
@@ -15,7 +15,7 @@ None
     [cmdletbinding()]
     Param()
 
-    $Session = Get-Session
+    $Session = Get-Session -ErrorAction SilentlyContinue
 
     # reset any enabled side-effect commands
     $env:C8Y_SETTINGS_MODE_ENABLECREATE = ""

--- a/tools/PSc8y/Public-manual/Clear-Session.ps1
+++ b/tools/PSc8y/Public-manual/Clear-Session.ps1
@@ -18,5 +18,6 @@ None
     Param()
     Write-Verbose "Clearing cumulocity session"
     $env:C8Y_SESSION = ""
+    $env:C8Y_HOST = ""
     Set-EnvironmentVariablesFromSession -WarningAction SilentlyContinue
 }

--- a/tools/PSc8y/Public-manual/Expand-Device.ps1
+++ b/tools/PSc8y/Public-manual/Expand-Device.ps1
@@ -41,7 +41,19 @@ Get all the device object (with app in their name). Note the Expand cmdlet won't
     Process {
         [array] $AllDevices = foreach ($iDevice in $InputObject)
         {
-            if ($iDevice.id) {
+            if ($iDevice.deviceId) {
+                # operation
+                [PSCustomObject]@{
+                    id = $iDevice.deviceId
+                    name = $iDevice.deviceName
+                }
+            } elseif ($iDevice.source.id) {
+                # alarms/events/measurements etc.
+                [PSCustomObject]@{
+                    id = $iDevice.source.id
+                    name = $iDevice.source.name
+                }
+            } elseif ($iDevice.id) {
                 $iDevice
             } else {
                 if ($iDevice -match "^\d+$") {

--- a/tools/PSc8y/Public-manual/Get-C8ySessionProperty.ps1
+++ b/tools/PSc8y/Public-manual/Get-C8ySessionProperty.ps1
@@ -27,17 +27,13 @@ string
         [string] $Name
     )
 
-    $Values = @{
+    $Values = [PSCustomObject]@{
         host = $env:C8Y_HOST
         tenant = $env:C8Y_TENANT
     }
 
     # Is calling cmdlet using the session variable?
-    $SessionFile = (Get-PSCallStack).InvocationInfo.BoundParameters.Session
-
-    if ($SessionFile) {
-        $Values = Get-Content -LiteralPath $SessionFile | ConvertFrom-Json
-    }
-
-    $Values[$Name]
+    $Session = (Get-PSCallStack).InvocationInfo.BoundParameters.Session
+    $Values = Get-Session -Session:$Session
+    $Values | Select-Object -ExpandProperty $Name
 }

--- a/tools/PSc8y/Public-manual/Invoke-Template.ps1
+++ b/tools/PSc8y/Public-manual/Invoke-Template.ps1
@@ -16,6 +16,11 @@ Function Invoke-Template {
     
     Execute a jsonnet template
 
+    .EXAMPLE
+    PS> Invoke-Template -Template ./template.jsonnet -TemplateVars "name=input,type=mytype"
+    
+    Execute a jsonnet template which has multiple template variables (using a comma separated string)
+
     .OUTPUTS
     String
     

--- a/tools/PSc8y/Public-manual/New-TestAgent.ps1
+++ b/tools/PSc8y/Public-manual/New-TestAgent.ps1
@@ -33,6 +33,14 @@ Create 10 test agents all with unique names
         )]
         [string] $Name = "testagent",
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -56,6 +64,7 @@ Create 10 test agents all with unique names
         $TestAgent = PSc8y\New-ManagedObject `
             -Name $AgentName `
             -Data $Data `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestAlarm.ps1
+++ b/tools/PSc8y/Public-manual/New-TestAlarm.ps1
@@ -32,6 +32,14 @@ Create an alarm on the existing device "myExistingDevice"
         )]
         [object] $Device,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -65,6 +73,7 @@ Create an alarm on the existing device "myExistingDevice"
                 -Type "c8y_ci_TestAlarm" `
                 -Severity MAJOR `
                 -Text "Test CI Alarm" `
+                -ProcessingMode:$ProcessingMode `
                 -Template:$Template `
                 -TemplateVars:$TemplateVars `
                 -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestDevice.ps1
+++ b/tools/PSc8y/Public-manual/New-TestDevice.ps1
@@ -41,6 +41,14 @@ Create 10 test devices (with agent functionality) all with unique names
         # Add agent fragment to the device
         [switch] $AsAgent,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -65,6 +73,7 @@ Create 10 test devices (with agent functionality) all with unique names
         $TestDevice = PSc8y\New-ManagedObject `
             -Name $DeviceName `
             -Data $Data `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestDeviceGroup.ps1
+++ b/tools/PSc8y/Public-manual/New-TestDeviceGroup.ps1
@@ -34,6 +34,14 @@ Create 10 test device groups all with unique names
         [ValidateSet("Group", "SubGroup")]
         [string] $Type = "Group",
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -68,6 +76,7 @@ Create 10 test device groups all with unique names
         PSc8y\New-ManagedObject `
             -Name $GroupName `
             -Data $Data `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestEvent.ps1
+++ b/tools/PSc8y/Public-manual/New-TestEvent.ps1
@@ -35,6 +35,14 @@ Create an event on the existing device "myExistingDevice"
         # Add a dummy file to the event
         [switch] $WithBinary,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -67,6 +75,7 @@ Create an event on the existing device "myExistingDevice"
             -Time "1970-01-01" `
             -Type "c8y_ci_TestEvent" `
             -Text "Test CI Event" `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestEvent.ps1
+++ b/tools/PSc8y/Public-manual/New-TestEvent.ps1
@@ -39,7 +39,7 @@ Create an event on the existing device "myExistingDevice"
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public-manual/New-TestGroup.ps1
+++ b/tools/PSc8y/Public-manual/New-TestGroup.ps1
@@ -25,6 +25,14 @@ Create a new user group with the prefix "mygroup". A random postfix will be adde
         )]
         [string] $Name = "testgroup",
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -43,6 +51,7 @@ Create a new user group with the prefix "mygroup". A random postfix will be adde
         $GroupName = New-RandomString -Prefix "${Name}_"
         $TestGroup = PSc8y\New-Group `
             -Name $GroupName `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestMeasurement.ps1
+++ b/tools/PSc8y/Public-manual/New-TestMeasurement.ps1
@@ -47,6 +47,14 @@ Create a measurement on the existing device "myExistingDevice"
         # Unit. i.e. °C, m/s
         [string] $Unit = "°C",
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -80,6 +88,7 @@ Create a measurement on the existing device "myExistingDevice"
                     }
                 }
             } `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/New-TestOperation.ps1
+++ b/tools/PSc8y/Public-manual/New-TestOperation.ps1
@@ -32,6 +32,14 @@ Create an operation on the existing device "myExistingDevice"
         )]
         [object] $Device,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -67,6 +75,7 @@ Create an operation on the existing device "myExistingDevice"
                     parameters = @{ }
                 }
             } `
+            -ProcessingMode:$ProcessingMode `
             -Template:$Template `
             -TemplateVars:$TemplateVars `
             -Force:$Force

--- a/tools/PSc8y/Public-manual/Set-Session.ps1
+++ b/tools/PSc8y/Public-manual/Set-Session.ps1
@@ -114,6 +114,9 @@ String
             return
         }
 
+        # Clear session before seting the new one
+        PSc8y\Clear-Session
+
         Write-Verbose "Setting new session: $Path"
         $env:C8Y_SESSION = Resolve-Path $Path
 

--- a/tools/PSc8y/Public-manual/Set-Session.ps1
+++ b/tools/PSc8y/Public-manual/Set-Session.ps1
@@ -17,6 +17,9 @@ terms will be includes in the results. The search is applied to the following fi
 * tenant
 * username
 
+.NOTES
+On MacOS, you need to hold "control"+Arrow keys to navigate the list of sessions. Otherwise the VIM style "j" (down) and "k" (up) keys can be also used for navigation
+
 .EXAMPLE
 Set-Session
 

--- a/tools/PSc8y/Public/Add-AssetToGroup.ps1
+++ b/tools/PSc8y/Public/Add-AssetToGroup.ps1
@@ -38,6 +38,14 @@ Create group heirachy (parent group -> child group)
         [object[]]
         $NewChildGroup,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -86,6 +94,9 @@ Create group heirachy (parent group -> child group)
         }
         if ($PSBoundParameters.ContainsKey("NewChildGroup")) {
             $Parameters["newChildGroup"] = $NewChildGroup
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Add-AssetToGroup.ps1
+++ b/tools/PSc8y/Public/Add-AssetToGroup.ps1
@@ -42,7 +42,7 @@ Create group heirachy (parent group -> child group)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-ChildDeviceToDevice.ps1
+++ b/tools/PSc8y/Public/Add-ChildDeviceToDevice.ps1
@@ -38,6 +38,14 @@ Assign a device as a child device to an existing device (using pipeline)
         [object[]]
         $NewChild,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -83,6 +91,9 @@ Assign a device as a child device to an existing device (using pipeline)
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Device")) {
             $Parameters["device"] = $Device
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Add-ChildDeviceToDevice.ps1
+++ b/tools/PSc8y/Public/Add-ChildDeviceToDevice.ps1
@@ -42,7 +42,7 @@ Assign a device as a child device to an existing device (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-ChildGroupToGroup.ps1
+++ b/tools/PSc8y/Public/Add-ChildGroupToGroup.ps1
@@ -40,6 +40,14 @@ to filter for a collection of devices and assign the results to a single group.
         [object[]]
         $NewChildGroup,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -85,6 +93,9 @@ to filter for a collection of devices and assign the results to a single group.
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Group")) {
             $Parameters["group"] = $Group
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Add-ChildGroupToGroup.ps1
+++ b/tools/PSc8y/Public/Add-ChildGroupToGroup.ps1
@@ -44,7 +44,7 @@ to filter for a collection of devices and assign the results to a single group.
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-DeviceToGroup.ps1
+++ b/tools/PSc8y/Public/Add-DeviceToGroup.ps1
@@ -40,6 +40,14 @@ to filter for a collection of devices and assign the results to a single group.
         [object[]]
         $NewChildDevice,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -85,6 +93,9 @@ to filter for a collection of devices and assign the results to a single group.
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Group")) {
             $Parameters["group"] = $Group
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Add-DeviceToGroup.ps1
+++ b/tools/PSc8y/Public/Add-DeviceToGroup.ps1
@@ -44,7 +44,7 @@ to filter for a collection of devices and assign the results to a single group.
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-RoleToGroup.ps1
+++ b/tools/PSc8y/Public/Add-RoleToGroup.ps1
@@ -47,7 +47,7 @@ Add a role to a group using wildcards (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-RoleToGroup.ps1
+++ b/tools/PSc8y/Public/Add-RoleToGroup.ps1
@@ -43,6 +43,14 @@ Add a role to a group using wildcards (using pipeline)
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -91,6 +99,9 @@ Add a role to a group using wildcards (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Add-RoleToUser.ps1
+++ b/tools/PSc8y/Public/Add-RoleToUser.ps1
@@ -51,7 +51,7 @@ Add a role to a user using wildcards (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-RoleToUser.ps1
+++ b/tools/PSc8y/Public/Add-RoleToUser.ps1
@@ -47,6 +47,14 @@ Add a role to a user using wildcards (using pipeline)
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -95,6 +103,9 @@ Add a role to a user using wildcards (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Add-UserToGroup.ps1
+++ b/tools/PSc8y/Public/Add-UserToGroup.ps1
@@ -42,7 +42,7 @@ Add a user to a user group
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Add-UserToGroup.ps1
+++ b/tools/PSc8y/Public/Add-UserToGroup.ps1
@@ -38,6 +38,14 @@ Add a user to a user group
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -86,6 +94,9 @@ Add a user to a user group
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Approve-DeviceRequest.ps1
+++ b/tools/PSc8y/Public/Approve-DeviceRequest.ps1
@@ -38,7 +38,7 @@ Approve a new device request
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Approve-DeviceRequest.ps1
+++ b/tools/PSc8y/Public/Approve-DeviceRequest.ps1
@@ -34,6 +34,14 @@ Approve a new device request
         [string]
         $Status,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -82,6 +90,9 @@ Approve a new device request
         }
         if ($PSBoundParameters.ContainsKey("Status")) {
             $Parameters["status"] = $Status
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Copy-Application.ps1
+++ b/tools/PSc8y/Public/Copy-Application.ps1
@@ -37,7 +37,7 @@ Copy an existing application
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Copy-Application.ps1
+++ b/tools/PSc8y/Public/Copy-Application.ps1
@@ -33,6 +33,14 @@ Copy an existing application
         [object[]]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -76,6 +84,9 @@ Copy an existing application
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template
         }

--- a/tools/PSc8y/Public/Disable-Application.ps1
+++ b/tools/PSc8y/Public/Disable-Application.ps1
@@ -33,6 +33,14 @@ Disable an application of a tenant
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -68,6 +76,9 @@ Disable an application of a tenant
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Disable-Application.ps1
+++ b/tools/PSc8y/Public/Disable-Application.ps1
@@ -37,7 +37,7 @@ Disable an application of a tenant
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Disable-Microservice.ps1
+++ b/tools/PSc8y/Public/Disable-Microservice.ps1
@@ -38,7 +38,7 @@ Disable (unsubscribe) to a microservice
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Disable-Microservice.ps1
+++ b/tools/PSc8y/Public/Disable-Microservice.ps1
@@ -34,6 +34,14 @@ Disable (unsubscribe) to a microservice
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +77,9 @@ Disable (unsubscribe) to a microservice
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Enable-Application.ps1
+++ b/tools/PSc8y/Public/Enable-Application.ps1
@@ -37,7 +37,7 @@ Enable an application of a tenant
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Enable-Application.ps1
+++ b/tools/PSc8y/Public/Enable-Application.ps1
@@ -33,6 +33,14 @@ Enable an application of a tenant
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -78,6 +86,9 @@ Enable an application of a tenant
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Enable-Microservice.ps1
+++ b/tools/PSc8y/Public/Enable-Microservice.ps1
@@ -34,6 +34,14 @@ Enable (subscribe) to a microservice
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -79,6 +87,9 @@ Enable (subscribe) to a microservice
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Enable-Microservice.ps1
+++ b/tools/PSc8y/Public/Enable-Microservice.ps1
@@ -38,7 +38,7 @@ Enable (subscribe) to a microservice
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Get-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Get-MeasurementCollection.ps1
@@ -72,12 +72,12 @@ Get measurements from a device (using pipeline)
         [switch]
         $Revert,
 
-        # Results will be displayed in csv format
+        # Results will be displayed in csv format. Note: -IncludeAll, is not supported when using using this parameter
         [Parameter()]
         [switch]
         $Csv,
 
-        # Results will be displayed in Excel format
+        # Results will be displayed in Excel format Note: -IncludeAll, is not supported when using using this parameter
         [Parameter()]
         [switch]
         $Excel,

--- a/tools/PSc8y/Public/Invoke-UserLogout.ps1
+++ b/tools/PSc8y/Public/Invoke-UserLogout.ps1
@@ -1,0 +1,123 @@
+﻿# Code generated from specification version 1.0.0: DO NOT EDIT
+Function Invoke-UserLogout {
+<#
+.SYNOPSIS
+Log out the current user
+
+.DESCRIPTION
+Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL
+
+.EXAMPLE
+PS> Invoke-UserLogout
+
+Log out the current user
+
+
+#>
+    [cmdletbinding(SupportsShouldProcess = $true,
+                   PositionalBinding=$true,
+                   HelpUri='',
+                   ConfirmImpact = 'High')]
+    [Alias()]
+    [OutputType([object])]
+    Param(
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
+        [string]
+        $ProcessingMode,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
+        # Show the full (raw) response from Cumulocity including pagination information
+        [Parameter()]
+        [switch]
+        $Raw,
+
+        # Write the response to file
+        [Parameter()]
+        [string]
+        $OutputFile,
+
+        # Ignore any proxy settings when running the cmdlet
+        [Parameter()]
+        [switch]
+        $NoProxy,
+
+        # Specifiy alternative Cumulocity session to use when running the cmdlet
+        [Parameter()]
+        [string]
+        $Session,
+
+        # TimeoutSec timeout in seconds before a request will be aborted
+        [Parameter()]
+        [double]
+        $TimeoutSec,
+
+        # Don't prompt for confirmation
+        [Parameter()]
+        [switch]
+        $Force
+    )
+
+    Begin {
+        $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
+        }
+        if ($PSBoundParameters.ContainsKey("OutputFile")) {
+            $Parameters["outputFile"] = $OutputFile
+        }
+        if ($PSBoundParameters.ContainsKey("NoProxy")) {
+            $Parameters["noProxy"] = $NoProxy
+        }
+        if ($PSBoundParameters.ContainsKey("Session")) {
+            $Parameters["session"] = $Session
+        }
+        if ($PSBoundParameters.ContainsKey("TimeoutSec")) {
+            $Parameters["timeout"] = $TimeoutSec * 1000
+        }
+
+    }
+
+    Process {
+        foreach ($item in @("")) {
+
+            if (!$Force -and
+                !$WhatIfPreference -and
+                !$PSCmdlet.ShouldProcess(
+                    (PSc8y\Get-C8ySessionProperty -Name "tenant"),
+                    (Format-ConfirmationMessage -Name $PSCmdlet.MyInvocation.InvocationName -InputObject $item)
+                )) {
+                continue
+            }
+
+            Invoke-ClientCommand `
+                -Noun "users" `
+                -Verb "logout" `
+                -Parameters $Parameters `
+                -Type "" `
+                -ItemType "" `
+                -ResultProperty "" `
+                -Raw:$Raw
+        }
+    }
+
+    End {}
+}

--- a/tools/PSc8y/Public/New-Agent.ps1
+++ b/tools/PSc8y/Public/New-Agent.ps1
@@ -43,6 +43,14 @@ Create agent with custom properties
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -94,6 +102,9 @@ Create agent with custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Agent.ps1
+++ b/tools/PSc8y/Public/New-Agent.ps1
@@ -47,7 +47,7 @@ Create agent with custom properties
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-Alarm.ps1
+++ b/tools/PSc8y/Public/New-Alarm.ps1
@@ -69,7 +69,7 @@ Create a new alarm for device (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-Alarm.ps1
+++ b/tools/PSc8y/Public/New-Alarm.ps1
@@ -65,6 +65,14 @@ Create a new alarm for device (using pipeline)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -125,6 +133,9 @@ Create a new alarm for device (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Application.ps1
+++ b/tools/PSc8y/Public/New-Application.ps1
@@ -73,6 +73,14 @@ Create a new hosted application
         [string]
         $ExternalUrl,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -145,6 +153,9 @@ Create a new hosted application
         }
         if ($PSBoundParameters.ContainsKey("ExternalUrl")) {
             $Parameters["externalUrl"] = $ExternalUrl
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Application.ps1
+++ b/tools/PSc8y/Public/New-Application.ps1
@@ -77,7 +77,7 @@ Create a new hosted application
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-ApplicationBinary.ps1
+++ b/tools/PSc8y/Public/New-ApplicationBinary.ps1
@@ -42,7 +42,7 @@ Upload application microservice binary
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-ApplicationBinary.ps1
+++ b/tools/PSc8y/Public/New-ApplicationBinary.ps1
@@ -38,6 +38,14 @@ Upload application microservice binary
         [string]
         $File,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -83,6 +91,9 @@ Upload application microservice binary
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-AuditRecord.ps1
+++ b/tools/PSc8y/Public/New-AuditRecord.ps1
@@ -71,7 +71,7 @@ Create an audit record for a custom managed object update
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-AuditRecord.ps1
+++ b/tools/PSc8y/Public/New-AuditRecord.ps1
@@ -67,6 +67,14 @@ Create an audit record for a custom managed object update
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -136,6 +144,9 @@ Create an audit record for a custom managed object update
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Binary.ps1
+++ b/tools/PSc8y/Public/New-Binary.ps1
@@ -40,7 +40,7 @@ Upload a config file and make it globally accessible for all users
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-Binary.ps1
+++ b/tools/PSc8y/Public/New-Binary.ps1
@@ -36,6 +36,14 @@ Upload a config file and make it globally accessible for all users
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -84,6 +92,9 @@ Upload a config file and make it globally accessible for all users
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Device.ps1
+++ b/tools/PSc8y/Public/New-Device.ps1
@@ -44,6 +44,14 @@ Create device with custom properties
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -92,6 +100,9 @@ Create device with custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Device.ps1
+++ b/tools/PSc8y/Public/New-Device.ps1
@@ -48,7 +48,7 @@ Create device with custom properties
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/New-DeviceGroup.ps1
@@ -47,7 +47,7 @@ Create device group with custom properties
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/New-DeviceGroup.ps1
@@ -43,6 +43,14 @@ Create device group with custom properties
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -94,6 +102,9 @@ Create device group with custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Event.ps1
+++ b/tools/PSc8y/Public/New-Event.ps1
@@ -53,6 +53,14 @@ Create a new event for a device (using pipeline)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -107,6 +115,9 @@ Create a new event for a device (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Event.ps1
+++ b/tools/PSc8y/Public/New-Event.ps1
@@ -57,7 +57,7 @@ Create a new event for a device (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-EventBinary.ps1
+++ b/tools/PSc8y/Public/New-EventBinary.ps1
@@ -37,7 +37,7 @@ Add a binary to an event
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-EventBinary.ps1
+++ b/tools/PSc8y/Public/New-EventBinary.ps1
@@ -33,6 +33,14 @@ Add a binary to an event
         [string]
         $File,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -78,6 +86,9 @@ Add a binary to an event
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-ExternalId.ps1
+++ b/tools/PSc8y/Public/New-ExternalId.ps1
@@ -43,6 +43,14 @@ Create external identity (using pipeline)
         [string]
         $Name,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -91,6 +99,9 @@ Create external identity (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Name")) {
             $Parameters["name"] = $Name
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-ExternalId.ps1
+++ b/tools/PSc8y/Public/New-ExternalId.ps1
@@ -47,7 +47,7 @@ Create external identity (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-Group.ps1
+++ b/tools/PSc8y/Public/New-Group.ps1
@@ -31,6 +31,14 @@ Create a user group
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -79,6 +87,9 @@ Create a user group
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Group.ps1
+++ b/tools/PSc8y/Public/New-Group.ps1
@@ -35,7 +35,7 @@ Create a user group
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-ManagedObject.ps1
+++ b/tools/PSc8y/Public/New-ManagedObject.ps1
@@ -36,6 +36,14 @@ Create a managed object
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -87,6 +95,9 @@ Create a managed object
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-ManagedObject.ps1
+++ b/tools/PSc8y/Public/New-ManagedObject.ps1
@@ -40,7 +40,7 @@ Create a managed object
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-Measurement.ps1
+++ b/tools/PSc8y/Public/New-Measurement.ps1
@@ -43,6 +43,14 @@ Create measurement
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -94,6 +102,9 @@ Create measurement
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Measurement.ps1
+++ b/tools/PSc8y/Public/New-Measurement.ps1
@@ -47,7 +47,7 @@ Create measurement
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-MicroserviceBinary.ps1
+++ b/tools/PSc8y/Public/New-MicroserviceBinary.ps1
@@ -38,6 +38,14 @@ Upload microservice binary
         [string]
         $File,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -83,6 +91,9 @@ Upload microservice binary
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-MicroserviceBinary.ps1
+++ b/tools/PSc8y/Public/New-MicroserviceBinary.ps1
@@ -42,7 +42,7 @@ Upload microservice binary
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-Operation.ps1
+++ b/tools/PSc8y/Public/New-Operation.ps1
@@ -43,6 +43,14 @@ Create operation for a device (using pipeline)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -91,6 +99,9 @@ Create operation for a device (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Operation.ps1
+++ b/tools/PSc8y/Public/New-Operation.ps1
@@ -47,7 +47,7 @@ Create operation for a device (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-RetentionRule.ps1
+++ b/tools/PSc8y/Public/New-RetentionRule.ps1
@@ -57,7 +57,7 @@ Create a retention rule to delete all alarms after 180 days
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-RetentionRule.ps1
+++ b/tools/PSc8y/Public/New-RetentionRule.ps1
@@ -53,6 +53,14 @@ Create a retention rule to delete all alarms after 180 days
         [switch]
         $Editable,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -113,6 +121,9 @@ Create a retention rule to delete all alarms after 180 days
         }
         if ($PSBoundParameters.ContainsKey("Editable")) {
             $Parameters["editable"] = $Editable
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Tenant.ps1
+++ b/tools/PSc8y/Public/New-Tenant.ps1
@@ -61,6 +61,14 @@ Create a new tenant (from the management tenant)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -127,6 +135,9 @@ Create a new tenant (from the management tenant)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-Tenant.ps1
+++ b/tools/PSc8y/Public/New-Tenant.ps1
@@ -65,7 +65,7 @@ Create a new tenant (from the management tenant)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-TenantOption.ps1
+++ b/tools/PSc8y/Public/New-TenantOption.ps1
@@ -36,6 +36,14 @@ Create a tenant option
         [string]
         $Value,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -87,6 +95,9 @@ Create a tenant option
         }
         if ($PSBoundParameters.ContainsKey("Value")) {
             $Parameters["value"] = $Value
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-TenantOption.ps1
+++ b/tools/PSc8y/Public/New-TenantOption.ps1
@@ -40,7 +40,7 @@ Create a tenant option
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/New-User.ps1
+++ b/tools/PSc8y/Public/New-User.ps1
@@ -72,6 +72,14 @@ Create a user
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -144,6 +152,9 @@ Create a user
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/New-User.ps1
+++ b/tools/PSc8y/Public/New-User.ps1
@@ -76,7 +76,7 @@ Create a user
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Register-Device.ps1
+++ b/tools/PSc8y/Public/Register-Device.ps1
@@ -28,6 +28,14 @@ Register a new device
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -73,6 +81,9 @@ Register a new device
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Id")) {
             $Parameters["id"] = $Id
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Register-Device.ps1
+++ b/tools/PSc8y/Public/Register-Device.ps1
@@ -32,7 +32,7 @@ Register a new device
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Agent.ps1
+++ b/tools/PSc8y/Public/Remove-Agent.ps1
@@ -35,6 +35,14 @@ Remove agent by name
         [object[]]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -68,6 +76,9 @@ Remove agent by name
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-Agent.ps1
+++ b/tools/PSc8y/Public/Remove-Agent.ps1
@@ -39,7 +39,7 @@ Remove agent by name
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Remove-AlarmCollection.ps1
@@ -84,6 +84,14 @@ Remove alarms on the device which are active and created in the last 10 minutes 
         [switch]
         $WithSourceDevices,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -143,6 +151,9 @@ Remove alarms on the device which are active and created in the last 10 minutes 
         }
         if ($PSBoundParameters.ContainsKey("WithSourceDevices")) {
             $Parameters["withSourceDevices"] = $WithSourceDevices
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Remove-AlarmCollection.ps1
@@ -88,7 +88,7 @@ Remove alarms on the device which are active and created in the last 10 minutes 
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Application.ps1
+++ b/tools/PSc8y/Public/Remove-Application.ps1
@@ -37,7 +37,7 @@ Delete an application by name
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Application.ps1
+++ b/tools/PSc8y/Public/Remove-Application.ps1
@@ -33,6 +33,14 @@ Delete an application by name
         [object[]]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -66,6 +74,9 @@ Delete an application by name
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-AssetFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-AssetFromGroup.ps1
@@ -42,7 +42,7 @@ Unassign a child device from its parent asset
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-AssetFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-AssetFromGroup.ps1
@@ -38,6 +38,14 @@ Unassign a child device from its parent asset
         [object[]]
         $ChildGroup,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -76,6 +84,9 @@ Unassign a child device from its parent asset
         }
         if ($PSBoundParameters.ContainsKey("ChildGroup")) {
             $Parameters["childGroup"] = $ChildGroup
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-Binary.ps1
+++ b/tools/PSc8y/Public/Remove-Binary.ps1
@@ -28,6 +28,14 @@ Delete a binary
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -61,6 +69,9 @@ Delete a binary
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-Binary.ps1
+++ b/tools/PSc8y/Public/Remove-Binary.ps1
@@ -32,7 +32,7 @@ Delete a binary
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-ChildDeviceFromDevice.ps1
+++ b/tools/PSc8y/Public/Remove-ChildDeviceFromDevice.ps1
@@ -37,7 +37,7 @@ Unassign a child device from its parent device
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-ChildDeviceFromDevice.ps1
+++ b/tools/PSc8y/Public/Remove-ChildDeviceFromDevice.ps1
@@ -33,6 +33,14 @@ Unassign a child device from its parent device
         [object[]]
         $ChildDevice,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -68,6 +76,9 @@ Unassign a child device from its parent device
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("ChildDevice")) {
             $Parameters["childDevice"] = $ChildDevice
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-Device.ps1
+++ b/tools/PSc8y/Public/Remove-Device.ps1
@@ -43,7 +43,7 @@ Remove device by name
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Device.ps1
+++ b/tools/PSc8y/Public/Remove-Device.ps1
@@ -39,6 +39,14 @@ Remove device by name
         [switch]
         $Cascade,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -74,6 +82,9 @@ Remove device by name
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Cascade")) {
             $Parameters["cascade"] = $Cascade
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-DeviceFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-DeviceFromGroup.ps1
@@ -33,6 +33,14 @@ Unassign a child device from its parent asset
         [object[]]
         $ChildDevice,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -68,6 +76,9 @@ Unassign a child device from its parent asset
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("ChildDevice")) {
             $Parameters["childDevice"] = $ChildDevice
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-DeviceFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-DeviceFromGroup.ps1
@@ -37,7 +37,7 @@ Unassign a child device from its parent asset
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/Remove-DeviceGroup.ps1
@@ -43,7 +43,7 @@ Remove device group by name
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/Remove-DeviceGroup.ps1
@@ -39,6 +39,14 @@ Remove device group by name
         [switch]
         $Cascade,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -74,6 +82,9 @@ Remove device group by name
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Cascade")) {
             $Parameters["cascade"] = $Cascade
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-DeviceRequest.ps1
+++ b/tools/PSc8y/Public/Remove-DeviceRequest.ps1
@@ -28,6 +28,14 @@ Delete a new device request
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -61,6 +69,9 @@ Delete a new device request
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-DeviceRequest.ps1
+++ b/tools/PSc8y/Public/Remove-DeviceRequest.ps1
@@ -32,7 +32,7 @@ Delete a new device request
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Event.ps1
+++ b/tools/PSc8y/Public/Remove-Event.ps1
@@ -32,7 +32,7 @@ Delete an event
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Event.ps1
+++ b/tools/PSc8y/Public/Remove-Event.ps1
@@ -28,6 +28,14 @@ Delete an event
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -61,6 +69,9 @@ Delete an event
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-EventBinary.ps1
+++ b/tools/PSc8y/Public/Remove-EventBinary.ps1
@@ -29,6 +29,14 @@ Delete an binary attached to an event
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -62,6 +70,9 @@ Delete an binary attached to an event
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-EventBinary.ps1
+++ b/tools/PSc8y/Public/Remove-EventBinary.ps1
@@ -33,7 +33,7 @@ Delete an binary attached to an event
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-EventCollection.ps1
+++ b/tools/PSc8y/Public/Remove-EventCollection.ps1
@@ -60,7 +60,7 @@ Remove events from a device
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-EventCollection.ps1
+++ b/tools/PSc8y/Public/Remove-EventCollection.ps1
@@ -56,6 +56,14 @@ Remove events from a device
         [switch]
         $Revert,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -106,6 +114,9 @@ Remove events from a device
         }
         if ($PSBoundParameters.ContainsKey("Revert")) {
             $Parameters["revert"] = $Revert
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-ExternalId.ps1
+++ b/tools/PSc8y/Public/Remove-ExternalId.ps1
@@ -35,7 +35,7 @@ Delete external identity
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-ExternalId.ps1
+++ b/tools/PSc8y/Public/Remove-ExternalId.ps1
@@ -31,6 +31,14 @@ Delete external identity
         [string]
         $Name,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +77,9 @@ Delete external identity
         }
         if ($PSBoundParameters.ContainsKey("Name")) {
             $Parameters["name"] = $Name
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-Group.ps1
+++ b/tools/PSc8y/Public/Remove-Group.ps1
@@ -42,7 +42,7 @@ Delete a user group (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Group.ps1
+++ b/tools/PSc8y/Public/Remove-Group.ps1
@@ -38,6 +38,14 @@ Delete a user group (using pipeline)
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -73,6 +81,9 @@ Delete a user group (using pipeline)
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Remove-ManagedObject.ps1
@@ -47,7 +47,7 @@ Delete a managed object and all child devices
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Remove-ManagedObject.ps1
@@ -43,6 +43,14 @@ Delete a managed object and all child devices
         [switch]
         $Cascade,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -78,6 +86,9 @@ Delete a managed object and all child devices
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Cascade")) {
             $Parameters["cascade"] = $Cascade
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-Measurement.ps1
+++ b/tools/PSc8y/Public/Remove-Measurement.ps1
@@ -32,7 +32,7 @@ Delete measurement
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Measurement.ps1
+++ b/tools/PSc8y/Public/Remove-Measurement.ps1
@@ -28,6 +28,14 @@ Delete measurement
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -61,6 +69,9 @@ Delete measurement
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
@@ -47,6 +47,14 @@ Delete measurement collection for a device
         [string]
         $DateTo,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -91,6 +99,9 @@ Delete measurement collection for a device
         }
         if ($PSBoundParameters.ContainsKey("DateTo")) {
             $Parameters["dateTo"] = $DateTo
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
@@ -51,7 +51,7 @@ Delete measurement collection for a device
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Microservice.ps1
+++ b/tools/PSc8y/Public/Remove-Microservice.ps1
@@ -37,7 +37,7 @@ Delete a microservice by name
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Microservice.ps1
+++ b/tools/PSc8y/Public/Remove-Microservice.ps1
@@ -33,6 +33,14 @@ Delete a microservice by name
         [object[]]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -66,6 +74,9 @@ Delete a microservice by name
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-OperationCollection.ps1
+++ b/tools/PSc8y/Public/Remove-OperationCollection.ps1
@@ -53,7 +53,7 @@ Remove all pending operations for a given device
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-OperationCollection.ps1
+++ b/tools/PSc8y/Public/Remove-OperationCollection.ps1
@@ -49,6 +49,14 @@ Remove all pending operations for a given device
         [string]
         $Status,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -93,6 +101,9 @@ Remove all pending operations for a given device
         }
         if ($PSBoundParameters.ContainsKey("Status")) {
             $Parameters["status"] = $Status
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-RetentionRule.ps1
+++ b/tools/PSc8y/Public/Remove-RetentionRule.ps1
@@ -34,6 +34,14 @@ Delete a retention rule (using pipeline)
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -67,6 +75,9 @@ Delete a retention rule (using pipeline)
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-RetentionRule.ps1
+++ b/tools/PSc8y/Public/Remove-RetentionRule.ps1
@@ -38,7 +38,7 @@ Delete a retention rule (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-RoleFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-RoleFromGroup.ps1
@@ -36,6 +36,14 @@ Remove a role from the given user group
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +85,9 @@ Remove a role from the given user group
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-RoleFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-RoleFromGroup.ps1
@@ -40,7 +40,7 @@ Remove a role from the given user group
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-RoleFromUser.ps1
+++ b/tools/PSc8y/Public/Remove-RoleFromUser.ps1
@@ -40,7 +40,7 @@ Remove a role from the given user
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-RoleFromUser.ps1
+++ b/tools/PSc8y/Public/Remove-RoleFromUser.ps1
@@ -36,6 +36,14 @@ Remove a role from the given user
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +85,9 @@ Remove a role from the given user
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-Tenant.ps1
+++ b/tools/PSc8y/Public/Remove-Tenant.ps1
@@ -31,7 +31,7 @@ Delete a tenant by name (from the mangement tenant)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-Tenant.ps1
+++ b/tools/PSc8y/Public/Remove-Tenant.ps1
@@ -27,6 +27,14 @@ Delete a tenant by name (from the mangement tenant)
         [object]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -60,6 +68,9 @@ Delete a tenant by name (from the mangement tenant)
 
     Begin {
         $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile
         }

--- a/tools/PSc8y/Public/Remove-TenantOption.ps1
+++ b/tools/PSc8y/Public/Remove-TenantOption.ps1
@@ -35,7 +35,7 @@ Delete a tenant option
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-TenantOption.ps1
+++ b/tools/PSc8y/Public/Remove-TenantOption.ps1
@@ -31,6 +31,14 @@ Delete a tenant option
         [string]
         $Key,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -69,6 +77,9 @@ Delete a tenant option
         }
         if ($PSBoundParameters.ContainsKey("Key")) {
             $Parameters["key"] = $Key
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-User.ps1
+++ b/tools/PSc8y/Public/Remove-User.ps1
@@ -35,6 +35,14 @@ Delete a user
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -70,6 +78,9 @@ Delete a user
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Remove-User.ps1
+++ b/tools/PSc8y/Public/Remove-User.ps1
@@ -39,7 +39,7 @@ Delete a user
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-UserFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-UserFromGroup.ps1
@@ -40,7 +40,7 @@ Add a user to a user group
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Remove-UserFromGroup.ps1
+++ b/tools/PSc8y/Public/Remove-UserFromGroup.ps1
@@ -36,6 +36,14 @@ Add a user to a user group
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Show the full (raw) response from Cumulocity including pagination information
         [Parameter()]
         [switch]
@@ -77,6 +85,9 @@ Add a user to a user group
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("OutputFile")) {
             $Parameters["outputFile"] = $OutputFile

--- a/tools/PSc8y/Public/Request-DeviceCredentials.ps1
+++ b/tools/PSc8y/Public/Request-DeviceCredentials.ps1
@@ -28,6 +28,14 @@ Request credentials for a new device
         [string]
         $Id,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -73,6 +81,9 @@ Request credentials for a new device
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Id")) {
             $Parameters["id"] = $Id
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Request-DeviceCredentials.ps1
+++ b/tools/PSc8y/Public/Request-DeviceCredentials.ps1
@@ -32,7 +32,7 @@ Request credentials for a new device
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Reset-UserPassword.ps1
+++ b/tools/PSc8y/Public/Reset-UserPassword.ps1
@@ -43,6 +43,14 @@ Resets a user's password by generating a new password
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -91,6 +99,9 @@ Resets a user's password by generating a new password
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Reset-UserPassword.ps1
+++ b/tools/PSc8y/Public/Reset-UserPassword.ps1
@@ -47,7 +47,7 @@ Resets a user's password by generating a new password
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Set-DeviceRequiredAvailability.ps1
+++ b/tools/PSc8y/Public/Set-DeviceRequiredAvailability.ps1
@@ -42,7 +42,7 @@ Set the required availability of a device (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Set-DeviceRequiredAvailability.ps1
+++ b/tools/PSc8y/Public/Set-DeviceRequiredAvailability.ps1
@@ -38,6 +38,14 @@ Set the required availability of a device (using pipeline)
         [long]
         $Interval,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -83,6 +91,9 @@ Set the required availability of a device (using pipeline)
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("Interval")) {
             $Parameters["interval"] = $Interval
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Agent.ps1
+++ b/tools/PSc8y/Public/Update-Agent.ps1
@@ -48,6 +48,14 @@ Update agent custom properties
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -96,6 +104,9 @@ Update agent custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Agent.ps1
+++ b/tools/PSc8y/Public/Update-Agent.ps1
@@ -52,7 +52,7 @@ Update agent custom properties
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Alarm.ps1
+++ b/tools/PSc8y/Public/Update-Alarm.ps1
@@ -64,7 +64,7 @@ Update severity of an existing alarm to CRITICAL
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Alarm.ps1
+++ b/tools/PSc8y/Public/Update-Alarm.ps1
@@ -60,6 +60,14 @@ Update severity of an existing alarm to CRITICAL
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -114,6 +122,9 @@ Update severity of an existing alarm to CRITICAL
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Update-AlarmCollection.ps1
@@ -69,7 +69,7 @@ Update the status of all active alarms on a device to ACKNOWLEDGED (using pipeli
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Update-AlarmCollection.ps1
@@ -65,6 +65,14 @@ Update the status of all active alarms on a device to ACKNOWLEDGED (using pipeli
         [string]
         $NewStatus,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -125,6 +133,9 @@ Update the status of all active alarms on a device to ACKNOWLEDGED (using pipeli
         }
         if ($PSBoundParameters.ContainsKey("NewStatus")) {
             $Parameters["newStatus"] = $NewStatus
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Application.ps1
+++ b/tools/PSc8y/Public/Update-Application.ps1
@@ -74,6 +74,14 @@ Update application availability to MARKET
         [string]
         $ExternalUrl,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -143,6 +151,9 @@ Update application availability to MARKET
         }
         if ($PSBoundParameters.ContainsKey("ExternalUrl")) {
             $Parameters["externalUrl"] = $ExternalUrl
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Application.ps1
+++ b/tools/PSc8y/Public/Update-Application.ps1
@@ -78,7 +78,7 @@ Update application availability to MARKET
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Binary.ps1
+++ b/tools/PSc8y/Public/Update-Binary.ps1
@@ -34,6 +34,14 @@ Update an existing binary file
         [string]
         $File,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -79,6 +87,9 @@ Update an existing binary file
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Binary.ps1
+++ b/tools/PSc8y/Public/Update-Binary.ps1
@@ -38,7 +38,7 @@ Update an existing binary file
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-CurrentApplication.ps1
+++ b/tools/PSc8y/Public/Update-CurrentApplication.ps1
@@ -71,7 +71,7 @@ Update custom properties of the current application (requires using application 
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-CurrentApplication.ps1
+++ b/tools/PSc8y/Public/Update-CurrentApplication.ps1
@@ -67,6 +67,14 @@ Update custom properties of the current application (requires using application 
         [string]
         $ExternalUrl,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -136,6 +144,9 @@ Update custom properties of the current application (requires using application 
         }
         if ($PSBoundParameters.ContainsKey("ExternalUrl")) {
             $Parameters["externalUrl"] = $ExternalUrl
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-CurrentUser.ps1
+++ b/tools/PSc8y/Public/Update-CurrentUser.ps1
@@ -53,6 +53,14 @@ Update the current user's lastname
         [string]
         $Password,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -113,6 +121,9 @@ Update the current user's lastname
         }
         if ($PSBoundParameters.ContainsKey("Password")) {
             $Parameters["password"] = $Password
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-CurrentUser.ps1
+++ b/tools/PSc8y/Public/Update-CurrentUser.ps1
@@ -57,7 +57,7 @@ Update the current user's lastname
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-DataBrokerConnector.ps1
+++ b/tools/PSc8y/Public/Update-DataBrokerConnector.ps1
@@ -39,6 +39,14 @@ Change the status of a specific data broker connector by given connector id
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -87,6 +95,9 @@ Change the status of a specific data broker connector by given connector id
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-DataBrokerConnector.ps1
+++ b/tools/PSc8y/Public/Update-DataBrokerConnector.ps1
@@ -43,7 +43,7 @@ Change the status of a specific data broker connector by given connector id
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Device.ps1
+++ b/tools/PSc8y/Public/Update-Device.ps1
@@ -52,7 +52,7 @@ Update device custom properties
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Device.ps1
+++ b/tools/PSc8y/Public/Update-Device.ps1
@@ -48,6 +48,14 @@ Update device custom properties
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -96,6 +104,9 @@ Update device custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/Update-DeviceGroup.ps1
@@ -49,6 +49,14 @@ Update device group custom properties
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -97,6 +105,9 @@ Update device group custom properties
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/Update-DeviceGroup.ps1
@@ -53,7 +53,7 @@ Update device group custom properties
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Event.ps1
+++ b/tools/PSc8y/Public/Update-Event.ps1
@@ -52,7 +52,7 @@ Update custom properties of an existing event (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Event.ps1
+++ b/tools/PSc8y/Public/Update-Event.ps1
@@ -48,6 +48,14 @@ Update custom properties of an existing event (using pipeline)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -96,6 +104,9 @@ Update custom properties of an existing event (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-EventBinary.ps1
+++ b/tools/PSc8y/Public/Update-EventBinary.ps1
@@ -34,6 +34,14 @@ Update a binary related to an event
         [string]
         $File,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -79,6 +87,9 @@ Update a binary related to an event
         $Parameters = @{}
         if ($PSBoundParameters.ContainsKey("File")) {
             $Parameters["file"] = $File
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-EventBinary.ps1
+++ b/tools/PSc8y/Public/Update-EventBinary.ps1
@@ -38,7 +38,7 @@ Update a binary related to an event
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Group.ps1
+++ b/tools/PSc8y/Public/Update-Group.ps1
@@ -47,7 +47,7 @@ Update a user group (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Group.ps1
+++ b/tools/PSc8y/Public/Update-Group.ps1
@@ -43,6 +43,14 @@ Update a user group (using pipeline)
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -91,6 +99,9 @@ Update a user group (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Update-ManagedObject.ps1
@@ -47,7 +47,7 @@ Update a managed object (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Update-ManagedObject.ps1
@@ -43,6 +43,14 @@ Update a managed object (using pipeline)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -91,6 +99,9 @@ Update a managed object (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Microservice.ps1
+++ b/tools/PSc8y/Public/Update-Microservice.ps1
@@ -59,7 +59,7 @@ Update microservice availability to MARKET
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-Microservice.ps1
+++ b/tools/PSc8y/Public/Update-Microservice.ps1
@@ -55,6 +55,14 @@ Update microservice availability to MARKET
         [string]
         $ResourcesUrl,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -112,6 +120,9 @@ Update microservice availability to MARKET
         }
         if ($PSBoundParameters.ContainsKey("ResourcesUrl")) {
             $Parameters["resourcesUrl"] = $ResourcesUrl
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Operation.ps1
+++ b/tools/PSc8y/Public/Update-Operation.ps1
@@ -50,6 +50,14 @@ Update multiple operations
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -101,6 +109,9 @@ Update multiple operations
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Operation.ps1
+++ b/tools/PSc8y/Public/Update-Operation.ps1
@@ -54,7 +54,7 @@ Update multiple operations
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-RetentionRule.ps1
+++ b/tools/PSc8y/Public/Update-RetentionRule.ps1
@@ -74,7 +74,7 @@ Update a retention rule (using pipeline)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-RetentionRule.ps1
+++ b/tools/PSc8y/Public/Update-RetentionRule.ps1
@@ -70,6 +70,14 @@ Update a retention rule (using pipeline)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -133,6 +141,9 @@ Update a retention rule (using pipeline)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Tenant.ps1
+++ b/tools/PSc8y/Public/Update-Tenant.ps1
@@ -62,6 +62,14 @@ Update a tenant by name (from the mangement tenant)
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -125,6 +133,9 @@ Update a tenant by name (from the mangement tenant)
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-Tenant.ps1
+++ b/tools/PSc8y/Public/Update-Tenant.ps1
@@ -66,7 +66,7 @@ Update a tenant by name (from the mangement tenant)
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-TenantOption.ps1
+++ b/tools/PSc8y/Public/Update-TenantOption.ps1
@@ -36,6 +36,14 @@ Update a tenant option
         [string]
         $Value,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -87,6 +95,9 @@ Update a tenant option
         }
         if ($PSBoundParameters.ContainsKey("Value")) {
             $Parameters["value"] = $Value
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-TenantOption.ps1
+++ b/tools/PSc8y/Public/Update-TenantOption.ps1
@@ -40,7 +40,7 @@ Update a tenant option
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-TenantOptionBulk.ps1
+++ b/tools/PSc8y/Public/Update-TenantOptionBulk.ps1
@@ -35,7 +35,7 @@ Update multiple tenant options
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-TenantOptionBulk.ps1
+++ b/tools/PSc8y/Public/Update-TenantOptionBulk.ps1
@@ -31,6 +31,14 @@ Update multiple tenant options
         [object]
         $Data,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -79,6 +87,9 @@ Update multiple tenant options
         }
         if ($PSBoundParameters.ContainsKey("Data")) {
             $Parameters["data"] = ConvertTo-JsonArgument $Data
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-TenantOptionEditable.ps1
+++ b/tools/PSc8y/Public/Update-TenantOptionEditable.ps1
@@ -42,7 +42,7 @@ Update editable property for an existing tenant option
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-TenantOptionEditable.ps1
+++ b/tools/PSc8y/Public/Update-TenantOptionEditable.ps1
@@ -38,6 +38,14 @@ Update editable property for an existing tenant option
         [string]
         $Editable,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -89,6 +97,9 @@ Update editable property for an existing tenant option
         }
         if ($PSBoundParameters.ContainsKey("Editable")) {
             $Parameters["editable"] = $Editable
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Public/Update-User.ps1
+++ b/tools/PSc8y/Public/Update-User.ps1
@@ -78,7 +78,7 @@ Update a user
         [Parameter()]
         [AllowNull()]
         [AllowEmptyString()]
-        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
         [string]
         $ProcessingMode,
 

--- a/tools/PSc8y/Public/Update-User.ps1
+++ b/tools/PSc8y/Public/Update-User.ps1
@@ -74,6 +74,14 @@ Update a user
         [object]
         $Tenant,
 
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")]
+        [string]
+        $ProcessingMode,
+
         # Template (jsonnet) file to use to create the request body.
         [Parameter()]
         [string]
@@ -143,6 +151,9 @@ Update a user
         }
         if ($PSBoundParameters.ContainsKey("Tenant")) {
             $Parameters["tenant"] = $Tenant
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
         }
         if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
             $Parameters["template"] = $Template

--- a/tools/PSc8y/Tests/Expand-Device.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Expand-Device.manual.Tests.ps1
@@ -2,7 +2,7 @@
 
 Describe -Name "Expand-Device" {
     BeforeAll {
-        $Device = PSc8y\New-TestDevice
+        $Device = PSc8y\New-TestAgent
     }
 
     It "Expand device (with object)" {
@@ -37,6 +37,18 @@ Describe -Name "Expand-Device" {
 
     It "Expand device from Get-DeviceCollection" {
         $Result = Get-DeviceCollection $Device.name | PSc8y\Expand-Device
+        $Result.id | Should -BeExactly $Device.id
+    }
+
+    It "Expand device from operation" {
+        $operation = PSc8y\New-TestOperation -Device $Device.id
+        $Result = $operation | PSc8y\Expand-Device
+        $Result.id | Should -BeExactly $Device.id
+    }
+
+    It "Expand device from operation" {
+        $measurement = PSc8y\New-TestMeasurement -Device $Device.id
+        $Result = $measurement | PSc8y\Expand-Device
         $Result.id | Should -BeExactly $Device.id
     }
 

--- a/tools/PSc8y/Tests/Invoke-UserLogout.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Invoke-UserLogout.auto.Tests.ps1
@@ -1,0 +1,18 @@
+﻿. $PSScriptRoot/imports.ps1
+
+Describe -Name "Invoke-UserLogout" {
+    BeforeEach {
+
+    }
+
+    It "Log out the current user" {
+        $Response = PSc8y\Invoke-UserLogout
+        $LASTEXITCODE | Should -Be 0
+    }
+
+
+    AfterEach {
+
+    }
+}
+

--- a/tools/PSc8y/Tests/New-ManagedObject.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/New-ManagedObject.manual.Tests.ps1
@@ -76,6 +76,13 @@ Describe -Name "New-ManagedObject" {
         $Response | Should -BeNullOrEmpty
     }
 
+    It "Managed object allow setting the processing mode" {
+        foreach ($mode in @("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP")) {
+            $WhatIfMessage = $($null = PSc8y\New-ManagedObject -Data @{} -ProcessingMode $mode -WhatIf) 6>&1
+            $WhatIfMessage -match "X-Cumulocity-Processing-Mode:\s+$mode" | Should -HaveCount 1
+        }
+    }
+
     AfterEach {
         Get-ManagedObjectCollection -Type $type -PageSize 100 | Select-Object | Remove-ManagedObject
 

--- a/tools/PSc8y/Tests/Update-EventBinary.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Update-EventBinary.auto.Tests.ps1
@@ -3,7 +3,7 @@
 Describe -Name "Update-EventBinary" {
     BeforeEach {
         $Device = New-TestDevice
-        $Event = New-TestEvent -Device $Device.id
+        $Event = New-TestEvent -Device $Device.id -WithBinary
         $TestFile = New-TestFile
 
     }

--- a/tools/PSc8y/Tests/Update-EventBinary.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Update-EventBinary.manual.Tests.ps1
@@ -1,0 +1,31 @@
+. $PSScriptRoot/imports.ps1
+
+Describe -Name "Update-EventBinary" {
+    BeforeEach {
+        $Device = New-TestDevice
+        $Event = New-TestEvent -Device $Device.id
+        $TestFile = New-TestFile
+    }
+
+    It "Create and update a binary attached to an event" {
+        $ExpectedText1 = "my test file`nsecond line"
+        $ExpectedText1 | Out-File $TestFile
+        PSc8y\New-EventBinary -Id $Event.id -File $TestFile
+        $BinaryContents = (PSc8y\Get-EventBinary -Id $Event.id) -join "`n"
+        $BinaryContents | Should -BeExactly $ExpectedText1
+
+        $ExpectedText2 = "adjusted text äöüß"
+        $ExpectedText2 | Out-File $TestFile
+        $BinaryContents = PSc8y\Update-EventBinary -Id $Event.id -File $TestFile
+        $BinaryContents = (PSc8y\Get-EventBinary -Id $Event.id) -join "`n"
+        $BinaryContents | Should -BeExactly $ExpectedText2
+    }
+
+
+    AfterEach {
+        Remove-Item $TestFile
+        Remove-ManagedObject -Id $Device.id
+
+    }
+}
+

--- a/tools/PSc8y/completion.definitions.ps1
+++ b/tools/PSc8y/completion.definitions.ps1
@@ -1,0 +1,396 @@
+<# 
+.SYNOPSIS
+Provides argument completions for dynamic data by querying Cumulocity for the values
+#>
+$RoleCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-RoleCollection -PageSize 100 `
+    | Select-Object -ExpandProperty id `
+    | Where-Object { $_ -like "$searchFor*" } `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_,
+            $_,
+            'ParameterValue',
+            "$_"
+        )
+    }
+}
+
+$TenantCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-TenantCollection -PageSize 100 -WarningAction SilentlyContinue `
+    | Where-Object { $_.id -like "$searchFor*" } `
+    | ForEach-Object {
+        $id = $_.id
+        $details = ("{0} ({1})" -f $_.id, ($_.domain -split "\.")[0])
+        [System.Management.Automation.CompletionResult]::new(
+            $id,
+            $details,
+            'ParameterValue',
+            $id
+        )
+    }
+}
+
+$ApplicationCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-ApplicationCollection -PageSize 100 -WarningAction SilentlyContinue `
+    | Where-Object { $_.id -like "$searchFor*" -or $_.name -like "$searchFor*" } `
+    | ForEach-Object {
+        $value = $_.name
+        $details = ("{0} ({1})" -f $_.id, $_.name)
+        [System.Management.Automation.CompletionResult]::new(
+            $value,
+            $details,
+            'ParameterValue',
+            $value
+        )
+    }
+}
+
+$MicroserviceCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-ApplicationCollection -PageSize 100 -WarningAction SilentlyContinue `
+    | Where-Object { $_.type -eq "MICROSERVICE" } `
+    | Where-Object { $_.id -like "$searchFor*" -or $_.name -like "$searchFor*" } `
+    | ForEach-Object {
+        $details = ("{0} ({1})" -f $_.id, $_.name)
+        [System.Management.Automation.CompletionResult]::new(
+            $_.id,
+            $details,
+            'ParameterValue',
+            $_.id
+        )
+    }
+}
+
+$UserGroupCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-GroupCollection -PageSize 100 -WarningAction SilentlyContinue `
+    | Where-Object { $_.id -like "$searchFor*" -or $_.name -like "$searchFor*" } `
+    | ForEach-Object {
+        $value = $_.name
+        $details = ("{0} ({1})" -f $_.id, $_.name)
+        [System.Management.Automation.CompletionResult]::new(
+            $_.id,
+            $details,
+            'ParameterValue',
+            $_.id
+        )
+    }
+}
+
+$TenantOptionCategoryCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-TenantOptionCollection -PageSize 100 -WarningAction SilentlyContinue `
+    | Where-Object { $_.category -like "$searchFor*" } `
+    | Select-Object -Unique -ExpandProperty category `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_,
+            $_,
+            'ParameterValue',
+            $_
+        )
+    }
+}
+
+$TenantOptionKeyCompleter = {
+    param ($commandName, $parameterName, $wordToComplete, $ast, $fakeBoundParameters)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    $options = Get-TenantOptionForCategory -Category $fakeBoundParameters["category"] -PageSize 100 -WarningAction SilentlyContinue
+    
+    if ($options -is [hashtable]) {
+        $keys = $options.keys
+    } else {
+        $keys = $options.psobject.Properties.Name
+    }
+    
+    $keys `
+    | Where-Object { $_ -like "$searchFor*" } `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_,
+            $_,
+            'ParameterValue',
+            $_
+        )
+    }
+}
+
+$UserCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-UserCollection -PageSize 1000 -WarningAction SilentlyContinue `
+    | Where-Object { $_.id -like "$searchFor*" -or $_.email -like "$searchFor*" } `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_.id,
+            $_.id,
+            'ParameterValue',
+            $_.id
+        )
+    }
+}
+
+$DeviceGroupCompleter = {
+    param ($commandName, $parameterName, $wordToComplete)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    Get-DeviceGroupCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue `
+    | Where-Object { $_.name -like "$searchFor*" } `
+    | Sort-Object { $_.name } `
+    | ForEach-Object {
+        $details = ("{0} ({1})" -f $_.name, $_.id)
+        [System.Management.Automation.CompletionResult]::new(
+            $_.id,
+            $details,
+            'ParameterValue',
+            $details
+        )
+    }
+}
+
+$MeasurementFragmentTypeCompleter = {
+    param ($commandName, $parameterName, $wordToComplete, $ast, $fakeBoundParameters)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    if (!$fakeBoundParameters.ContainsKey("Device")) {
+        return
+    }
+
+    $device = $fakeBoundParameters["Device"]
+
+    Get-SupportedMeasurements -Device:$device -WarningAction SilentlyContinue `
+    | Where-Object { $_ -like "$searchFor*" } `
+    | Sort-Object { $_ } `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_,
+            $_,
+            'ParameterValue',
+            $_
+        )
+    }
+}
+
+$MeasurementSeriesCompleter = {
+    param ($commandName, $parameterName, $wordToComplete, $ast, $fakeBoundParameters)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    if (!$fakeBoundParameters.ContainsKey("Device")) {
+        return
+    }
+
+    $device = $fakeBoundParameters["Device"]
+    $valueFragmentType = $fakeBoundParameters["valueFragmentType"]
+    
+    Get-SupportedSeries -Device:$device -WarningAction SilentlyContinue `
+    | Where-Object { $_ -like "$valueFragmentType.*" } `
+    | Where-Object { $_ -like "*.$searchFor*" } `
+    | ForEach-Object { "$_".Split(".")[-1] } `
+    | Sort-Object { $_ } `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_,
+            $_,
+            'ParameterValue',
+            $_
+        )
+    }
+}
+
+$MeasurementFullSeriesCompleter = {
+    param ($commandName, $parameterName, $wordToComplete, $ast, $fakeBoundParameters)
+    if ($wordToComplete -is [array]) {
+        $searchFor = $wordToComplete | Select-Object -Last 1
+    } else {
+        $searchFor = $wordToComplete
+    }
+
+    if (!$fakeBoundParameters.ContainsKey("Device")) {
+        return
+    }
+
+    $device = $fakeBoundParameters["Device"]
+    
+    Get-SupportedSeries -Device:$device -WarningAction SilentlyContinue `
+    | Where-Object { $_ -like "$searchFor*" } `
+    | Sort-Object { $_ } `
+    | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new(
+            $_,
+            $_,
+            'ParameterValue',
+            $_
+        )
+    }
+}
+
+# Tenant options
+Register-ArgumentCompleter -CommandName Update-TenantOption -ParameterName category -ScriptBlock $TenantOptionCategoryCompleter
+Register-ArgumentCompleter -CommandName Update-TenantOption -ParameterName key -ScriptBlock $TenantOptionKeyCompleter
+Register-ArgumentCompleter -CommandName Remove-TenantOption -ParameterName category -ScriptBlock $TenantOptionCategoryCompleter
+Register-ArgumentCompleter -CommandName Remove-TenantOption -ParameterName key -ScriptBlock $TenantOptionKeyCompleter
+Register-ArgumentCompleter -CommandName Update-TenantOptionEditable -ParameterName category -ScriptBlock $TenantOptionCategoryCompleter
+Register-ArgumentCompleter -CommandName Update-TenantOptionEditable -ParameterName key -ScriptBlock $TenantOptionKeyCompleter
+
+# User Group
+Register-ArgumentCompleter -CommandName Get-Group -ParameterName Id -ScriptBlock $UserGroupCompleter
+Register-ArgumentCompleter -CommandName Update-Group -ParameterName Id -ScriptBlock $UserGroupCompleter
+Register-ArgumentCompleter -CommandName Remove-Group -ParameterName Id -ScriptBlock $UserGroupCompleter
+
+# Service User (microservice)
+Register-ArgumentCompleter -CommandName New-ServiceUser -ParameterName Roles -ScriptBlock $RoleCompleter
+
+# Application
+Register-ArgumentCompleter -CommandName Get-Application -ParameterName Id -ScriptBlock $ApplicationCompleter
+Register-ArgumentCompleter -CommandName Update-Application -ParameterName Id -ScriptBlock $ApplicationCompleter
+Register-ArgumentCompleter -CommandName Remove-Application -ParameterName Id -ScriptBlock $ApplicationCompleter
+
+# Microservice
+Register-ArgumentCompleter -CommandName Get-Microservice -ParameterName Id -ScriptBlock $MicroserviceCompleter
+Register-ArgumentCompleter -CommandName Update-Microservice -ParameterName Id -ScriptBlock $MicroserviceCompleter
+Register-ArgumentCompleter -CommandName Remove-Microservice -ParameterName Id -ScriptBlock $MicroserviceCompleter
+
+# tenant
+Register-ArgumentCompleter -CommandName Get-Tenant -ParameterName Id -ScriptBlock $TenantCompleter
+Register-ArgumentCompleter -CommandName Update-Tenant -ParameterName Id -ScriptBlock $TenantCompleter
+Register-ArgumentCompleter -CommandName Remove-Tenant -ParameterName Id -ScriptBlock $TenantCompleter
+
+# user
+Register-ArgumentCompleter -CommandName Get-User -ParameterName Id -ScriptBlock $UserCompleter
+Register-ArgumentCompleter -CommandName Update-User -ParameterName Id -ScriptBlock $UserCompleter
+Register-ArgumentCompleter -CommandName Remove-User -ParameterName Id -ScriptBlock $UserCompleter
+
+# device group
+Register-ArgumentCompleter -CommandName Get-DeviceGroup -ParameterName Id -ScriptBlock $DeviceGroupCompleter
+Register-ArgumentCompleter -CommandName Update-DeviceGroup -ParameterName Id -ScriptBlock $DeviceGroupCompleter
+Register-ArgumentCompleter -CommandName Remove-DeviceGroup -ParameterName Id -ScriptBlock $DeviceGroupCompleter
+
+# measurement
+Register-ArgumentCompleter -CommandName Get-MeasurementCollection -ParameterName valueFragmentType -ScriptBlock $MeasurementFragmentTypeCompleter
+Register-ArgumentCompleter -CommandName Get-MeasurementCollection -ParameterName valueFragmentSeries -ScriptBlock $MeasurementSeriesCompleter
+Register-ArgumentCompleter -CommandName Get-MeasurementSeries -ParameterName Series -ScriptBlock $MeasurementFullSeriesCompleter
+
+
+# User group
+Register-ArgumentCompleter -CommandName Add-UserToGroup -ParameterName User -ScriptBlock $UserCompleter
+Register-ArgumentCompleter -CommandName Add-UserToGroup -ParameterName Group -ScriptBlock $UserGroupCompleter
+
+# Add Role to Group
+Register-ArgumentCompleter -CommandName Add-RoleToGroup -ParameterName Group -ScriptBlock $UserGroupCompleter
+Register-ArgumentCompleter -CommandName Add-RoleToGroup -ParameterName Role -ScriptBlock $RoleCompleter
+
+# Add Role to User
+Register-ArgumentCompleter -CommandName Add-RoleToUser -ParameterName User -ScriptBlock $UserCompleter
+Register-ArgumentCompleter -CommandName Add-RoleToUser -ParameterName Role -ScriptBlock $RoleCompleter
+
+Register-ArgumentCompleter -CommandName Get-GroupMembershipCollection -ParameterName Id -ScriptBlock $UserGroupCompleter
+
+$ModuleName = "PSc8y"
+
+Function Register-C8yArgumentCompletion {
+    [cmdletbinding()]
+    Param(
+        [string] $Module,
+        [string] $ArgumentName,
+        [scriptblock] $Completer
+    )
+
+    if (!(Get-Command -Name Register-ArgumentCompleter -ErrorAction SilentlyContinue)) {
+        Write-Warning "Register-ArgumentCompleter is required to use this function"
+        return
+    }
+
+    $commands = Get-Command -Module $Module -CommandType "Function" `
+        | Where-Object {
+            $null -ne $_.Parameters -and $_.Parameters.ContainsKey($ArgumentName)
+        }
+    Register-ArgumentCompleter -CommandName $commands -ParameterName $ArgumentName -ScriptBlock $Completer
+}
+
+Function Get-c8yCommand {
+    [cmdletbinding()]
+    Param(
+        [string] $Module,
+        [string] $IncludeCommand,
+        [string] $ExcludeCommand,
+        [string] $ParameterName
+    )
+
+    Get-Command -Module $Module -CommandType "Function" `
+        | Where-Object {          
+            ([string]::IsNullOrWhiteSpace($IncludeCommand) -or $_.Name -like $IncludeCommand) `
+                -and ([string]::IsNullOrWhiteSpace($ExcludeCommand) -or $_.Name -notlike $ExcludeCommand) `
+                -and ($null -ne $_.Parameters) `
+                -and ($_.Parameters.ContainsKey($ParameterName))
+        }
+}
+
+# Tenant/s parameters
+Register-C8yArgumentCompletion -Module $ModuleName -ArgumentName "Tenant" -Completer $TenantCompleter
+Register-C8yArgumentCompletion -Module $ModuleName -ArgumentName "Tenants" -Completer $TenantCompleter
+
+Register-C8yArgumentCompletion -Module $ModuleName -ArgumentName "User" -Completer $TenantCompleter
+Register-C8yArgumentCompletion -Module $ModuleName -ArgumentName "Role" -Completer $RoleCompleter
+Register-C8yArgumentCompletion -Module $ModuleName -ArgumentName "Roles" -Completer $RoleCompleter

--- a/tools/bash/c8y.plugin.zsh
+++ b/tools/bash/c8y.plugin.zsh
@@ -47,6 +47,9 @@ set-session () {
         return
     fi
 
+    # clear session before settings new one as stale env variables can cause problems
+    clear-session
+
     export C8Y_SESSION=$resp
 
     # Check encryption passphrase

--- a/tools/bash/c8y.plugin.zsh
+++ b/tools/bash/c8y.plugin.zsh
@@ -82,6 +82,24 @@ set-session () {
     unset C8Y_SETTINGS_MODE_ENABLEDELETE
 }
 
+# -----------
+# clear-session
+# -----------
+# Description: Clear all cumulocity session variables
+# Usage:
+#   clear-session
+#
+clear-session () {
+    unset C8Y_HOST
+    unset C8Y_TENANT
+    unset C8Y_USER
+    unset C8Y_USERNAME
+    unset C8Y_PASSWORD
+    unset C8Y_SESSION
+    unset C8Y_SETTINGS_MODE_ENABLECREATE
+    unset C8Y_SETTINGS_MODE_ENABLEUPDATE
+    unset C8Y_SETTINGS_MODE_ENABLEDELETE
+}
 
 # ----------
 # c8y-update

--- a/tools/bash/c8y.profile.sh
+++ b/tools/bash/c8y.profile.sh
@@ -62,6 +62,9 @@ set-session () {
         return
     fi
 
+    # clear session before settings new one as stale env variables can cause problems
+    clear-session
+
     export C8Y_SESSION=$resp
 
     # Check encryption passphrase

--- a/tools/bash/c8y.profile.sh
+++ b/tools/bash/c8y.profile.sh
@@ -97,6 +97,25 @@ set-session () {
     unset C8Y_SETTINGS_MODE_ENABLEDELETE
 }
 
+# -----------
+# clear-session
+# -----------
+# Description: Clear all cumulocity session variables
+# Usage:
+#   clear-session
+#
+clear-session () {
+    unset C8Y_HOST
+    unset C8Y_TENANT
+    unset C8Y_USER
+    unset C8Y_USERNAME
+    unset C8Y_PASSWORD
+    unset C8Y_SESSION
+    unset C8Y_SETTINGS_MODE_ENABLECREATE
+    unset C8Y_SETTINGS_MODE_ENABLEUPDATE
+    unset C8Y_SETTINGS_MODE_ENABLEDELETE
+}
+
 # ----------
 # c8y-update
 # ----------

--- a/tools/schema/session.schema.json
+++ b/tools/schema/session.schema.json
@@ -6,6 +6,10 @@
             "type": "integer",
             "minimum": 1,
             "maximum": 2000
+        },
+        "cookieProperty": {
+            "type": "string",
+            "description": "Cookies value in the form of key=value"
         }
     },
     "properties":{
@@ -35,8 +39,28 @@
             "type": "object",
             "properties": {
                 "cookies": {
-                    "description": "List of cookies which should be added to each outgoing request",
-                    "type": "array",
+                    "description": "Cookies which should be added to each outgoing request. Cookies are ordered sorted by their index/key",
+                    "type": "object",
+                    "properties": {
+                        "0": {
+                            "$ref": "#/definitions/cookieProperty"
+                        },
+                        "1": {
+                            "$ref": "#/definitions/cookieProperty"
+                        },
+                        "2": {
+                            "$ref": "#/definitions/cookieProperty"
+                        },
+                        "3": {
+                            "$ref": "#/definitions/cookieProperty"
+                        },
+                        "4": {
+                            "$ref": "#/definitions/cookieProperty"
+                        },
+                        "5": {
+                            "$ref": "#/definitions/cookieProperty"
+                        }
+                    },
                     "items": {
                         "type": "string"
                     }


### PR DESCRIPTION
* `Get-Session` uses a new c8y session get to retrieve information about the current session
* Fixed bug when using the `-Session` on PUT and POST commands which resulted in an error being displayed eventhough the request would be successful
* `Expand-Device` supports piping of alarms, events, measurements and operations
* Added `-ProcessingMode` parameter to all commands that use DELETE, PUT and POST requests.

    ```powershell
    New-ManagedObject -Name myobject -ProcessingMode TRANSIENT
    New-ManagedObject -Name myobject -ProcessingMode QUIESCENT
    New-ManagedObject -Name myobject -ProcessingMode PERSISTENT
    New-ManagedObject -Name myobject -ProcessingMode CEP
    ```
* `Set-session` automatically selects a session if only one matching session is found rather than prompting the user for the selection
* `source` fragment is removed when being passed via file to the `Data` parameter in all create and update commands
    ```json
    // myevent.json
    {
        "source": {
            "id": "99999",
            "self": "https:/..../event/events/99999"
        },
        "type": "myExample1",

    }
    ```

    When executing the following command:
    ```powershell
    PSc8y\New-Event -Device 12345 -Data myevent.json
    ```

    The `source` id fragment will be replaced entirely by the new source as specified by the `Device` parameter

    ```json
    // myevent.json
    {
        "source": {
            "id": "12345",
        },
        "type": "myExample1",

    }
    ```
    * Added logout user command to invalidate current user token

        **Bash/zsh**

        ```sh
        c8y users logout
        ```

        **PowerShell**

        ```powershell
        Invoke-UserLogout
        ```