### PR TITLE
reducing unnecessary api calls to server

### DIFF
--- a/pkg/cmd/agentFetcher.manual.go
+++ b/pkg/cmd/agentFetcher.manual.go
@@ -89,7 +89,7 @@ func getFormattedAgentSlice(cmd *cobra.Command, args []string, name string) ([]s
 
 	values = ParseValues(append(values, args...))
 
-	formattedValues, err := lookupEntity(f, values, true)
+	formattedValues, err := lookupEntity(f, values, false)
 
 	if err != nil {
 		Logger.Warningf("Failed to fetch entities. %s", err)

--- a/pkg/cmd/applicationFetcher.go
+++ b/pkg/cmd/applicationFetcher.go
@@ -100,7 +100,7 @@ func getApplicationSlice(cmd *cobra.Command, args []string, name string) ([]stri
 
 	// values = ParseValues(append(values, args...))
 
-	formattedValues, err := lookupEntity(f, values, true)
+	formattedValues, err := lookupEntity(f, values, false)
 
 	if err != nil {
 		Logger.Errorf("Failed to fetch entities. %s", err)

--- a/pkg/cmd/deviceFetcher.go
+++ b/pkg/cmd/deviceFetcher.go
@@ -86,7 +86,7 @@ func getFormattedDeviceSlice(cmd *cobra.Command, args []string, name string) ([]
 
 	values = ParseValues(append(values, args...))
 
-	formattedValues, err := lookupEntity(f, values, true)
+	formattedValues, err := lookupEntity(f, values, false)
 
 	if err != nil {
 		Logger.Errorf("Failed to fetch entities. %s", err)

--- a/pkg/cmd/deviceGroupFetcher.go
+++ b/pkg/cmd/deviceGroupFetcher.go
@@ -88,7 +88,7 @@ func getFormattedDeviceGroupSlice(cmd *cobra.Command, args []string, name string
 
 	values = ParseValues(append(values, args...))
 
-	formattedValues, err := lookupEntity(f, values, true)
+	formattedValues, err := lookupEntity(f, values, false)
 
 	if err != nil {
 		Logger.Warningf("Failed to fetch entities. %s", err)

--- a/pkg/cmd/userGroupFetcher.go
+++ b/pkg/cmd/userGroupFetcher.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/reubenmiller/go-c8y-cli/pkg/matcher"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
 )
 
@@ -92,7 +92,7 @@ func getFormattedGroupSlice(cmd *cobra.Command, args []string, name string) ([]s
 
 	values = ParseValues(append(values, args...))
 
-	formattedValues, err := lookupEntity(f, values, true)
+	formattedValues, err := lookupEntity(f, values, false)
 
 	if err != nil {
 		Logger.Warningf("Failed to fetch entities. %s", err)

--- a/tools/PSc8y/Public-manual/Expand-Application.ps1
+++ b/tools/PSc8y/Public-manual/Expand-Application.ps1
@@ -42,6 +42,13 @@ Expand applications that match a name of "*" and have a type of "MICROSERVICE"
         [object[]] $InputObject
     )
 
+    Begin {
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
     Process {
         [array] $AllApplications = foreach ($iApp in $InputObject)
         {

--- a/tools/PSc8y/Public-manual/Expand-Device.ps1
+++ b/tools/PSc8y/Public-manual/Expand-Device.ps1
@@ -8,7 +8,37 @@ The list of devices will be expanded to include the full device representation b
 the data from Cumulocity.
 
 .NOTES
+If the function calling the Expand-Device has a "Force" parameter and it is set to True, then Expand-Device will not fetch the device managed object
+from the server. Instead it will return an object with only the id and name set (and the name will be set to [id={}]). This is to save the
+number of calls to the server as usually the ID is the item you need to use in subsequent calls.
+
 If the given object is already an device object, then it is added with no additional lookup
+
+The following cases describe when the managed object is fetched from the server and when not.
+
+Cases when the managed object IS fetched from the server
+* Calling function does not have -Force on its function, and the user does not use it. OR
+* OR User provides input a string which does not only contain digits
+* OR User sets the -Fetch parameter on Expand-Device
+
+Cases when the managed object IS NOT fetched from the server
+* User passes an ID like object to Expand-Device
+* AND -Force is not used on the calling function
+* AND user does not use -Fetch when calling Expand-Device
+
+
+.OUTPUTS
+# Without fetch
+[pscustomobject]@{
+    id = "1234"
+    name = "[id=1234]"
+}
+
+# With fetch
+[pscustomobject]@{
+    id = "1234"
+    name = "mydevice"
+}
 
 .PARAMETER InputObject
 List of ids, names or device objects
@@ -23,6 +53,15 @@ Get-DeviceCollection *test* | Expand-Device
 
 Get all the device object (with app in their name). Note the Expand cmdlet won't do much here except for returning the input objects.
 
+.EXAMPLE
+Get-DeviceCollection *test* | Expand-Device
+
+Get all the device object (with app in their name). Note the Expand cmdlet won't do much here except for returning the input objects.
+
+.EXAMPLE
+"12345", "mydevice" | Expand-Device -Fetch
+
+Expand the devices and always fetch device managed object if an object is not provided via the pipeline
 
 #>
     [cmdletbinding(
@@ -35,10 +74,32 @@ Get all the device object (with app in their name). Note the Expand cmdlet won't
             ValueFromPipeline=$true,
             Position=0
         )]
-        [object[]] $InputObject
+        [object[]] $InputObject,
+
+        # Fetch the full managed object if only the id or name is provided.
+        [switch] $Fetch
     )
 
+    Begin {
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
     Process {
+        $FetchFullDevice = $Fetch
+        $callstack = Get-PSCallStack | Select-Object -Skip 1 -First 1
+        if ($null -ne $callstack.InvocationInfo.MyCommand.Parameters -and $null -ne $callstack.InvocationInfo.BoundParameters) {
+            $CanPromptUser = $callstack.InvocationInfo.MyCommand.Parameters.ContainsKey("Force")
+            $ForceEnabled = (($callstack.InvocationInfo.BoundParameters["Force"] -eq $true) -or ($ConfirmPreference -match "None"))
+
+            if (!$Fetch) {
+                $FetchFullDevice = $CanPromptUser -and !$ForceEnabled
+            }
+        }
+        
+
         [array] $AllDevices = foreach ($iDevice in $InputObject)
         {
             if ($iDevice.deviceId) {
@@ -66,7 +127,15 @@ Get all the device object (with app in their name). Note the Expand cmdlet won't
                             name = "name of $iDevice"
                         }
                     } else {
-                        Get-ManagedObject -Id $iDevice -WhatIf:$false
+                        if ($FetchFullDevice) {
+                            Get-ManagedObject -Id $iDevice -WhatIf:$false
+                        } else {
+                            [PSCustomObject]@{
+                                id = $iDevice
+                                # Dummy value
+                                name = "[id=$iDevice]"
+                            }
+                        }
                     }
                 } else {
                     Get-DeviceCollection -Name $iDevice -WhatIf:$false

--- a/tools/PSc8y/Public-manual/Expand-Microservice.ps1
+++ b/tools/PSc8y/Public-manual/Expand-Microservice.ps1
@@ -33,6 +33,13 @@ Get all the microservice object (with app in their name). Note the Expand cmdlet
         [object[]] $InputObject
     )
 
+    Begin {
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
     Process {
         [array] $AllMicroservices = foreach ($iApp in $InputObject)
         {

--- a/tools/PSc8y/Public-manual/Expand-Tenant.ps1
+++ b/tools/PSc8y/Public-manual/Expand-Tenant.ps1
@@ -31,6 +31,13 @@ Get all the tenant object (with app in their name). Note the Expand cmdlet won't
         [object[]] $InputObject
     )
 
+    Begin {
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
     Process {
         [array] $AllTenants = foreach ($iTenant in $InputObject)
         {

--- a/tools/PSc8y/Public-manual/Expand-User.ps1
+++ b/tools/PSc8y/Public-manual/Expand-User.ps1
@@ -31,6 +31,13 @@ Get all the user object (with app in their name). Note the Expand cmdlet won't d
         [object[]] $InputObject
     )
 
+    Begin {
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
     Process {
         [array] $AllUsers = foreach ($iUser in $InputObject)
         {

--- a/tools/PSc8y/Tests/Device-Lookup.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Device-Lookup.manual.Tests.ps1
@@ -1,0 +1,64 @@
+. $PSScriptRoot/imports.ps1
+
+Describe -Name "Device lookup up manual tests" {
+    BeforeEach {
+        $Device = PSc8y\New-TestDevice
+        $Group = PSc8y\New-TestDeviceGroup
+
+    }
+
+    It "Add a device to a group using ids should only result in 1 API call (and Force=True)" {
+        $VerboseMessages = $( $Response = PSc8y\Add-DeviceToGroup -Group $Group.id -NewChildDevice $Device.id -Verbose -Force ) 4>&1
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 1
+    }
+
+    It "Add a device to a group using names should only cause 1 lookup per name" {
+        $VerboseMessages = $( $Response = PSc8y\Add-DeviceToGroup -Group $Group.name -NewChildDevice $Device.name -Verbose -Force ) 4>&1
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 3 -Because "2 GETs to get device ids and 1 POST to create the child link"
+    }
+
+    It "Should not do name unnecessary name lookups if the confirmation preference is set to None" {
+        $ConfirmBackup = $ConfirmPreference
+        $ConfirmPreference = "None"
+        $VerboseMessages = $( $Response = PSc8y\Update-Device -Id $Device.id -NewName "mytestname" -Verbose ) 4>&1
+        $ConfirmPreference = $ConfirmBackup
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 1
+    }
+
+    It "Should not do name unnecessary name lookups if the Force parameter is used" {
+        $VerboseMessages = $( $Response = PSc8y\Update-Device -Id $Device.id -NewName "mytestname" -Verbose -Force ) 4>&1
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 1
+    }
+
+    It "Should only use 1 api call when looking up managed object by an ID" {
+        $VerboseMessages = $( $Response = PSc8y\Get-Device -Id $Device.id -Verbose ) 4>&1
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 1
+    }
+
+    AfterEach {
+        PSc8y\Remove-ManagedObject -Id $Device.id
+        PSc8y\Remove-ManagedObject -Id $Group.id
+
+    }
+}
+

--- a/tools/PSc8y/Tests/Expand-Device.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Expand-Device.manual.Tests.ps1
@@ -52,6 +52,71 @@ Describe -Name "Expand-Device" {
         $Result.id | Should -BeExactly $Device.id
     }
 
+    It "Expand device called from a function with force" {
+        Function Update-MyObject {
+            [cmdletbinding()]
+            Param(
+                [Parameter(
+                    Mandatory = $true,
+                    Position = 0,
+                    ValueFromPipeline = $true,
+                    ValueFromPipelineByPropertyName = $true
+                )]
+                [object[]] $Device,
+                [switch] $Force
+            )
+
+            foreach ($iDevice in (PSc8y\Expand-Device $Device)) {
+                $iDevice
+            }
+        }
+        # Passing id to an object
+        $VerboseMessages = $( $Results = $Device.id | Update-MyObject -Force -Verbose ) 4>&1
+        $Results.id | Should -Be $Device.id
+        $Results.name | Should -Not -Be $Device.name
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 0
+
+        # Passing an object
+        $VerboseMessages = $( $Results = $Device | Update-MyObject -Force -Verbose ) 4>&1
+        $Results.id | Should -Be $Device.id
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 0
+    }
+    
+    It "Expand device called from a function using expand object" {
+        Function Update-MyObject {
+            [cmdletbinding()]
+            Param(
+                [Parameter(
+                    Mandatory = $true,
+                    Position = 0,
+                    ValueFromPipeline = $true,
+                    ValueFromPipelineByPropertyName = $true
+                )]
+                [object[]] $Device,
+                [switch] $Force
+            )
+
+            foreach ($iDevice in (PSc8y\Expand-Device $Device -Fetch)) {
+                $iDevice
+            }
+        }
+        # Passing id to an object
+        $VerboseMessages = $( $Results = $Device.id | Update-MyObject -Verbose ) 4>&1
+        $Results.id | Should -Be $Device.id
+        $Results.name | Should -Be $Device.name
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 1
+
+        # Passing an object (no fetch should be done)
+        $VerboseMessages = $( $Results = $Device | Update-MyObject -Force -Verbose ) 4>&1
+        $Results.id | Should -Be $Device.id
+        $Results.name | Should -Be $Device.name
+        [array] $APICalls = $VerboseMessages -like "*Sending request*"
+        $APICalls | Should -HaveCount 0
+    }
+
     AfterAll {
         Remove-ManagedObject -Id $Device.id
     }


### PR DESCRIPTION
### Breaking Changes

* `Expand-Device` no longer fetches the device managed object when given the id when being called from a function that does not makes use of a "Force" parameter. If you would like the old functionality, then add the new "-Fetch" parameter when calling `Expand-Device`.

    By default if Expand-Device is called from an interactive function, then the managed object will be looked up in order to provide helpful information to the user in the confirmation prompt. Additionally users writing modules, can force fetching of the device when given an id by using the new `-Fetch` parameter.

    The change enable a significant reduction in API calls as shown below in the following examples:

    **Comparison of total API calls per command to previous PSc8y version**

    Previous version: PSc8y=1.9.1

    The following examples show how many api calls are made to Cumulocity.

    ```sh
    # API calls: 1 x GET    (previously 3 x GET!)
    Get-Device 1234

    # API calls: 2 x GET    (previously 5 x GET!)
    Get-Device 1234 | Get-Device

    # API calls: 1 x GET and 1 x PUT    (prevously 4 x GET and 1 x PUT)
    Get-Device 1234 | Update-Device

    # API calls: 1 x POST   (prevously 3 x GET and 1 x POST)
    Add-DeviceToGroup -Group 11111 -NewChildDevice 222222 -ProcessingMode QUIESCENT -Force
    ```

    **Expand-Device Usage**
    Expand-Device was created in order to normalize the input of devices given by the user. Since PSc8y accepts devices either by id, name, object or piped objects, it can make it difficult to handle each of the input types in each function.

    ```powershell
    # file: my-script.ps1
    Param(
        [Parameter(
            Mandatory = $true,
            Position = 0,
            ValueFromPipeline = $true,
            ValueFromPipelineByPropertyName = $true
        )]
        [object[]] $Device = ""
    )

    foreach ($iDevice in (PSc8y\Expand-Device $Device)) {
        Write-Host ("Dummy api call with device id: /inventory/managedObject/{0}" -f $iDevice.id)
    }
    ```

    By writing it like this the user can call the function in the following ways with the same code.

    ```powershell
    # Pass array item
    ./my-script.ps1 -Device 12345

    # array of items mixing ids with names
    ./my-script.ps1 -Device "myDevicename", 1234

    # using pipelines from other PSc8y cmdlets
    Get-DeviceCollection | ./my-script.ps1

    # By hashtable with id property (using positional argument)
    ./my-script.ps1 @{id="12345"}, @{id="6789"}
    ```

    Now let's say that you wanted to add some logic which required the full device managed object from the server, and not just the id and name fields. This can be achieved by adding the `-Fetch` parameter to the `Expand-Device` cmdlet call.

    The differences in the output can be shown in the small example

    ```powershell
    # This will not fetch the device (as the device already exists)
    PS> 1234 | Expand-Device

    id   name
    ---- ----
    1234 [id=1234]
    ```

    Agent but using `-Fetch`.

    ```powershell
    # Using -Fetch will return the whole device managed object from Cumulocity (1 x GET request)
    PS> 1234 | Expand-Device -Fetch

    additionParents : @{references=System.Object[]; self=https://example.cumulocity.com/inventory/managedObjects/1234/additionParents}
    assetParents    : @{references=System.Object[]; self=https://example.cumulocity.com/inventory/managedObjects/1234/assetParents}
    c8y_IsDevice    : 
    childAdditions  : @{references=System.Object[]; self=https://example.cumulocity.com/inventory/managedObjects/1234/childAdditions}
    childAssets     : @{references=System.Object[]; self=https://example.cumulocity.com/inventory/managedObjects/1234/childAssets}
    childDevices    : @{references=System.Object[]; self=https://example.cumulocity.com/inventory/managedObjects/1234/childDevices}
    creationTime    : 1/19/2021 7:49:33 PM
    deviceParents   : @{references=System.Object[]; self=https://example.cumulocity.com/inventory/managedObjects/1234/deviceParents}
    id              : 1234
    lastUpdated     : 1/19/2021 8:52:29 PM
    name            : mynewname
    owner           : user@example.com
    self            : https://example.cumulocity.com/inventory/managedObjects/3882
    ```

## Performance improvements

* Reduced number of API calls within PSc8y and c8y binary by skipping lookups when an ID is given by the user. Previously PSc8y and c8y were sending two API calls to the server in order to normalize the request by retrieving additional information and potentiall shown to the user. Since this is currently not used, it has been removed.