### PR TITLE
adding commands to managed child additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,22 @@ No unreleased features
     self            : https://example.cumulocity.com/inventory/managedObjects/3882
     ```
 
+## New Features
+
+* Added commands to manage managed object child additions
+
+    **PowerShell**
+
+    * `Get-ChildAdditionCollection`
+    * `New-ChildAddition`
+    * `Remove-ChildAddition`
+
+    **Bash/zsh**
+
+    * `c8y inventoryReferences listChildAdditions`
+    * `c8y inventoryReferences createChildAddition`
+    * `c8y inventoryReferences deleteChildAddition`
+
 ## Performance improvements
 
 * Reduced number of API calls within PSc8y and c8y binary by skipping lookups when an ID is given by the user. Previously PSc8y and c8y were sending two API calls to the server in order to normalize the request by retrieving additional information and potentiall shown to the user. Since this is currently not used, it has been removed.

--- a/api/spec/json/inventoryReferences.json
+++ b/api/spec/json/inventoryReferences.json
@@ -717,6 +717,172 @@
           "description": "Child device group"
         }
       ]
+    },
+    {
+      "name": "getManagedObjectChildAdditionCollection",
+      "method": "GET",
+      "description": "Get a collection of managedObjects child additions",
+      "descriptionLong": "Get a collection of managedObjects child additions",
+      "path": "inventory/managedObjects/{id}/childAdditions",
+      "accept": "application/vnd.com.nsn.cumulocity.managedObjectReferenceCollection+json",
+      "collectionType": "application/vnd.com.nsn.cumulocity.managedObject+json",
+      "collectionProperty": "references.#.managedObject",
+      "alias": {
+        "go": "listChildAdditions",
+        "powershell": "Get-ChildAdditionCollection"
+      },
+      "examples": {
+        "powershell": [
+          {
+            "description": "Get a list of the child additions of an existing managed object",
+            "beforeEach": [
+              "$software = PSc8y\\New-ManagedObject -Name softwarePackage1",
+              "$version = PSc8y\\New-ManagedObject -Name softwareVersion1",
+              "PSc8y\\Add-ChildAddition -Id $software.id -NewChild $version.id"
+            ],
+            "command": "Get-ChildAdditionCollection -Id $software.id",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $software.id",
+              "PSc8y\\Remove-ManagedObject -Id $version.id"
+            ]
+          },
+          {
+            "description": "Get a list of the child additions of an existing managed object (using pipeline)",
+            "beforeEach": [
+              "$software = PSc8y\\New-ManagedObject -Name softwarePackage1",
+              "$version = PSc8y\\New-ManagedObject -Name softwareVersion1",
+              "PSc8y\\Add-ChildAddition -Id $software.id -NewChild $version.id"
+            ],
+            "command": "Get-ManagedObject -Id $software.id | Get-ChildAdditionCollection",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $software.id",
+              "PSc8y\\Remove-ManagedObject -Id $version.id"
+            ]
+          }
+        ],
+        "go": [
+          {
+            "description": "Get a list of the child additions of an existing managed object",
+            "command": "c8y inventoryReferences listChildAdditions --id 12345"
+          }
+        ]
+      },
+      "pathParameters": [
+        {
+          "name": "id",
+          "type": "string",
+          "pipeline": true,
+          "required": true,
+          "description": "Managed object id."
+        }
+      ]
+    },
+    {
+      "name": "addManagedObjectChildAddition",
+      "method": "POST",
+      "path": "inventory/managedObjects/{id}/childAdditions",
+      "accept": "application/vnd.com.nsn.cumulocity.managedObjectReference+json",
+      "collectionType": "application/vnd.com.nsn.cumulocity.managedObject+json",
+      "description": "Add a managed object as a child addition to another existing managed object",
+      "descriptionLong": "Add a managed object as a child addition to another existing managed object",
+      "collectionProperty": "managedObject",
+      "alias": {
+        "go": "createChildAddition",
+        "powershell": "Add-ChildAddition"
+      },
+      "examples": {
+        "powershell": [
+          {
+            "description": "Add a related managed object as a child to an existing managed object",
+            "beforeEach": [
+              "$software = PSc8y\\New-ManagedObject -Name softwarePackage1",
+              "$version = PSc8y\\New-ManagedObject -Name softwareVersion1"
+            ],
+            "command": "Add-ChildAddition -Id $software.id -NewChild $version.id",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $software.id",
+              "PSc8y\\Remove-ManagedObject -Id $version.id"
+            ]
+          }
+        ],
+        "go": [
+          {
+            "description": "Add a related managed object as a child to an existing managed object",
+            "command": "c8y inventoryReferences createChildAddition --id 12345 --newChild 6789"
+          }
+        ]
+      },
+      "pathParameters": [
+        {
+          "name": "id",
+          "type": "string",
+          "property": "id",
+          "pipeline": true,
+          "required": true,
+          "description": "Managed object id where the child addition will be added to",
+          "position": 0
+        }
+      ],
+      "body": [
+        {
+          "name": "newChild",
+          "type": "[]string",
+          "position": 1,
+          "required": true,
+          "property": "managedObject.id",
+          "description": "New managed object that will be added as a child addition"
+        }
+      ]
+    },
+    {
+      "name": "deleteChildAddition",
+      "description": "Delete child addition reference",
+      "descriptionLong": "Unassign a child addition from an existing managed object",
+      "method": "DELETE",
+      "path": "inventory/managedObjects/{id}/childAdditions/{childId}",
+      "accept": "",
+      "alias": {
+        "go": "unassignChildAddition",
+        "powershell": "Remove-ChildAddition"
+      },
+      "examples": {
+        "powershell": [
+          {
+            "description": "Unassign a child addition from its parent managed object",
+            "beforeEach": [
+              "$software = PSc8y\\New-ManagedObject -Name softwarePackage1",
+              "$version = PSc8y\\New-ManagedObject -Name softwareVersion1",
+              "PSc8y\\Add-ChildAddition -Id $software.id -NewChild $version.id"
+            ],
+            "command": "Remove-ChildAddition -Id $software.id -ChildId $version.id",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $version.id",
+              "PSc8y\\Remove-ManagedObject -Id $software.id"
+            ]
+          }
+        ],
+        "go": [
+          {
+            "description": "Unassign a child addition from its parent managed object",
+            "command": "c8y inventoryReferences unassignChildAddition --id 12345 --childId 22553"
+          }
+        ]
+      },
+      "pathParameters": [
+        {
+          "name": "id",
+          "type": "string",
+          "pipeline": true,
+          "required": true,
+          "description": "Managed object id"
+        },
+        {
+          "name": "childId",
+          "type": "string",
+          "required": false,
+          "description": "Child managed object id"
+        }
+      ]
     }
   ]
 }

--- a/api/spec/yaml/inventoryReferences.yml
+++ b/api/spec/yaml/inventoryReferences.yml
@@ -529,3 +529,123 @@ endpoints:
         property: reference
         required: false
         description: Child device group
+
+  # Child additions
+  - name: getManagedObjectChildAdditionCollection
+    method: GET
+    description: Get a collection of managedObjects child additions
+    descriptionLong: Get a collection of managedObjects child additions
+    path: inventory/managedObjects/{id}/childAdditions
+    accept: application/vnd.com.nsn.cumulocity.managedObjectReferenceCollection+json
+    collectionType: application/vnd.com.nsn.cumulocity.managedObject+json
+    collectionProperty: 'references.#.managedObject'
+    alias:
+        go: listChildAdditions
+        powershell: Get-ChildAdditionCollection
+    examples:
+      powershell:
+        - description: Get a list of the child additions of an existing managed object
+          beforeEach:
+            - $software = PSc8y\New-ManagedObject -Name softwarePackage1
+            - $version = PSc8y\New-ManagedObject -Name softwareVersion1
+            - PSc8y\Add-ChildAddition -Id $software.id -NewChild $version.id
+          command: Get-ChildAdditionCollection -Id $software.id
+          afterEach:
+            - PSc8y\Remove-ManagedObject -Id $software.id
+            - PSc8y\Remove-ManagedObject -Id $version.id
+
+        - description: Get a list of the child additions of an existing managed object (using pipeline)
+          beforeEach:
+            - $software = PSc8y\New-ManagedObject -Name softwarePackage1
+            - $version = PSc8y\New-ManagedObject -Name softwareVersion1
+            - PSc8y\Add-ChildAddition -Id $software.id -NewChild $version.id
+          command: Get-ManagedObject -Id $software.id | Get-ChildAdditionCollection
+          afterEach:
+            - PSc8y\Remove-ManagedObject -Id $software.id
+            - PSc8y\Remove-ManagedObject -Id $version.id
+
+      go:
+        - description: Get a list of the child additions of an existing managed object
+          command: c8y inventoryReferences listChildAdditions --id 12345
+    pathParameters:
+      - name: id
+        type: 'string'
+        pipeline: true
+        required: true
+        description: Managed object id.
+
+  - name: addManagedObjectChildAddition
+    method: POST
+    path: inventory/managedObjects/{id}/childAdditions
+    accept: application/vnd.com.nsn.cumulocity.managedObjectReference+json
+    collectionType: application/vnd.com.nsn.cumulocity.managedObject+json
+    description: 'Add a managed object as a child addition to another existing managed object'
+    descriptionLong: 'Add a managed object as a child addition to another existing managed object'
+    collectionProperty: managedObject
+    alias:
+        go: createChildAddition
+        powershell: Add-ChildAddition
+    examples:
+        powershell:
+          - description: Add a related managed object as a child to an existing managed object
+            beforeEach:
+              - $software = PSc8y\New-ManagedObject -Name softwarePackage1
+              - $version = PSc8y\New-ManagedObject -Name softwareVersion1
+            command: Add-ChildAddition -Id $software.id -NewChild $version.id
+            afterEach:
+              - PSc8y\Remove-ManagedObject -Id $software.id
+              - PSc8y\Remove-ManagedObject -Id $version.id
+        go:
+          - description: Add a related managed object as a child to an existing managed object
+            command: c8y inventoryReferences createChildAddition --id 12345 --newChild 6789
+    pathParameters:
+      - name: id
+        type: string
+        property: id
+        pipeline: true
+        required: true
+        description: Managed object id where the child addition will be added to
+        position: 0
+    body:
+      - name: newChild
+        type: '[]string'
+        position: 1
+        required: true
+        property: 'managedObject.id'
+        description: New managed object that will be added as a child addition
+  
+  - name: deleteChildAddition
+    description: 'Delete child addition reference'
+    descriptionLong: Unassign a child addition from an existing managed object
+    method: DELETE
+    path: inventory/managedObjects/{id}/childAdditions/{childId}
+    accept: ''
+    alias:
+        go: unassignChildAddition
+        powershell: Remove-ChildAddition
+    examples:
+      powershell:
+        - description: Unassign a child addition from its parent managed object
+          beforeEach:
+            - $software = PSc8y\New-ManagedObject -Name softwarePackage1
+            - $version = PSc8y\New-ManagedObject -Name softwareVersion1
+            - PSc8y\Add-ChildAddition -Id $software.id -NewChild $version.id
+          command: Remove-ChildAddition -Id $software.id -ChildId $version.id
+          afterEach:
+            - PSc8y\Remove-ManagedObject -Id $version.id
+            - PSc8y\Remove-ManagedObject -Id $software.id
+
+      go:
+        - description: Unassign a child addition from its parent managed object
+          command: c8y inventoryReferences unassignChildAddition --id 12345 --childId 22553
+    pathParameters:
+      - name: id
+        type: 'string'
+        pipeline: true
+        required: true
+        description: Managed object id
+
+      - name: childId
+        type: 'string'
+        required: false
+        description: Child managed object id

--- a/pkg/cmd/addManagedObjectChildAdditionCmd.auto.go
+++ b/pkg/cmd/addManagedObjectChildAdditionCmd.auto.go
@@ -1,0 +1,121 @@
+// Code generated from specification version 1.0.0: DO NOT EDIT
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type addManagedObjectChildAdditionCmd struct {
+	*baseCmd
+}
+
+func newAddManagedObjectChildAdditionCmd() *addManagedObjectChildAdditionCmd {
+	ccmd := &addManagedObjectChildAdditionCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "createChildAddition",
+		Short: "Add a managed object as a child addition to another existing managed object",
+		Long:  `Add a managed object as a child addition to another existing managed object`,
+		Example: `
+$ c8y inventoryReferences createChildAddition --id 12345 --newChild 6789
+Add a related managed object as a child to an existing managed object
+        `,
+		PreRunE: validateCreateMode,
+		RunE:    ccmd.addManagedObjectChildAddition,
+	}
+
+	cmd.SilenceUsage = true
+
+	cmd.Flags().String("id", "", "Managed object id where the child addition will be added to (required)")
+	cmd.Flags().StringSlice("newChild", []string{""}, "New managed object that will be added as a child addition (required)")
+	addProcessingModeFlag(cmd)
+
+	// Required flags
+	cmd.MarkFlagRequired("id")
+	cmd.MarkFlagRequired("newChild")
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *addManagedObjectChildAdditionCmd) addManagedObjectChildAddition(cmd *cobra.Command, args []string) error {
+
+	commonOptions, err := getCommonOptions(cmd)
+	if err != nil {
+		return newUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+	}
+
+	// query parameters
+	queryValue := url.QueryEscape("")
+	query := url.Values{}
+	queryValue, err = url.QueryUnescape(query.Encode())
+
+	if err != nil {
+		return newSystemError("Invalid query parameter")
+	}
+
+	// headers
+	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
+
+	// form data
+	formData := make(map[string]io.Reader)
+
+	// body
+	body := mapbuilder.NewMapBuilder()
+	body.SetMap(getDataFlag(cmd))
+	if items, err := cmd.Flags().GetStringSlice("newChild"); err == nil {
+		if len(items) > 0 {
+			for _, v := range items {
+				if v != "" {
+					body.Set("managedObject.id", v)
+				}
+			}
+		}
+	} else {
+		return newUserError("Flag does not exist")
+	}
+	if err := setDataTemplateFromFlags(cmd, body); err != nil {
+		return newUserError("Template error. ", err)
+	}
+	if err := body.Validate(); err != nil {
+		return newUserError("Body validation error. ", err)
+	}
+
+	// path parameters
+	pathParameters := make(map[string]string)
+	if v, err := cmd.Flags().GetString("id"); err == nil {
+		if v != "" {
+			pathParameters["id"] = v
+		}
+	} else {
+		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "id", err))
+	}
+
+	path := replacePathParameters("inventory/managedObjects/{id}/childAdditions", pathParameters)
+
+	req := c8y.RequestOptions{
+		Method:       "POST",
+		Path:         path,
+		Query:        queryValue,
+		Body:         body.GetMap(),
+		FormData:     formData,
+		Header:       headers,
+		IgnoreAccept: false,
+		DryRun:       globalFlagDryRun,
+	}
+
+	return processRequestAndResponse([]c8y.RequestOptions{req}, commonOptions)
+}

--- a/pkg/cmd/deleteChildAdditionCmd.auto.go
+++ b/pkg/cmd/deleteChildAdditionCmd.auto.go
@@ -1,0 +1,109 @@
+// Code generated from specification version 1.0.0: DO NOT EDIT
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type deleteChildAdditionCmd struct {
+	*baseCmd
+}
+
+func newDeleteChildAdditionCmd() *deleteChildAdditionCmd {
+	ccmd := &deleteChildAdditionCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "unassignChildAddition",
+		Short: "Delete child addition reference",
+		Long:  `Unassign a child addition from an existing managed object`,
+		Example: `
+$ c8y inventoryReferences unassignChildAddition --id 12345 --childId 22553
+Unassign a child addition from its parent managed object
+        `,
+		PreRunE: validateDeleteMode,
+		RunE:    ccmd.deleteChildAddition,
+	}
+
+	cmd.SilenceUsage = true
+
+	cmd.Flags().String("id", "", "Managed object id (required)")
+	cmd.Flags().String("childId", "", "Child managed object id")
+	addProcessingModeFlag(cmd)
+
+	// Required flags
+	cmd.MarkFlagRequired("id")
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *deleteChildAdditionCmd) deleteChildAddition(cmd *cobra.Command, args []string) error {
+
+	commonOptions, err := getCommonOptions(cmd)
+	if err != nil {
+		return newUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+	}
+
+	// query parameters
+	queryValue := url.QueryEscape("")
+	query := url.Values{}
+	queryValue, err = url.QueryUnescape(query.Encode())
+
+	if err != nil {
+		return newSystemError("Invalid query parameter")
+	}
+
+	// headers
+	headers := http.Header{}
+	if cmd.Flags().Changed("processingMode") {
+		if v, err := cmd.Flags().GetString("processingMode"); err == nil && v != "" {
+			headers.Add("X-Cumulocity-Processing-Mode", v)
+		}
+	}
+
+	// form data
+	formData := make(map[string]io.Reader)
+
+	// body
+	body := mapbuilder.NewMapBuilder()
+
+	// path parameters
+	pathParameters := make(map[string]string)
+	if v, err := cmd.Flags().GetString("id"); err == nil {
+		if v != "" {
+			pathParameters["id"] = v
+		}
+	} else {
+		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "id", err))
+	}
+	if v, err := cmd.Flags().GetString("childId"); err == nil {
+		if v != "" {
+			pathParameters["childId"] = v
+		}
+	} else {
+		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "childId", err))
+	}
+
+	path := replacePathParameters("inventory/managedObjects/{id}/childAdditions/{childId}", pathParameters)
+
+	req := c8y.RequestOptions{
+		Method:       "DELETE",
+		Path:         path,
+		Query:        queryValue,
+		Body:         body.GetMap(),
+		FormData:     formData,
+		Header:       headers,
+		IgnoreAccept: false,
+		DryRun:       globalFlagDryRun,
+	}
+
+	return processRequestAndResponse([]c8y.RequestOptions{req}, commonOptions)
+}

--- a/pkg/cmd/getManagedObjectChildAdditionCollectionCmd.auto.go
+++ b/pkg/cmd/getManagedObjectChildAdditionCollectionCmd.auto.go
@@ -1,0 +1,96 @@
+// Code generated from specification version 1.0.0: DO NOT EDIT
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type getManagedObjectChildAdditionCollectionCmd struct {
+	*baseCmd
+}
+
+func newGetManagedObjectChildAdditionCollectionCmd() *getManagedObjectChildAdditionCollectionCmd {
+	ccmd := &getManagedObjectChildAdditionCollectionCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "listChildAdditions",
+		Short: "Get a collection of managedObjects child additions",
+		Long:  `Get a collection of managedObjects child additions`,
+		Example: `
+$ c8y inventoryReferences listChildAdditions --id 12345
+Get a list of the child additions of an existing managed object
+        `,
+		PreRunE: nil,
+		RunE:    ccmd.getManagedObjectChildAdditionCollection,
+	}
+
+	cmd.SilenceUsage = true
+
+	cmd.Flags().String("id", "", "Managed object id. (required)")
+
+	// Required flags
+	cmd.MarkFlagRequired("id")
+
+	ccmd.baseCmd = newBaseCmd(cmd)
+
+	return ccmd
+}
+
+func (n *getManagedObjectChildAdditionCollectionCmd) getManagedObjectChildAdditionCollection(cmd *cobra.Command, args []string) error {
+
+	commonOptions, err := getCommonOptions(cmd)
+	if err != nil {
+		return newUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+	}
+
+	// query parameters
+	queryValue := url.QueryEscape("")
+	query := url.Values{}
+	commonOptions.AddQueryParameters(&query)
+	queryValue, err = url.QueryUnescape(query.Encode())
+
+	if err != nil {
+		return newSystemError("Invalid query parameter")
+	}
+
+	// headers
+	headers := http.Header{}
+
+	// form data
+	formData := make(map[string]io.Reader)
+
+	// body
+	body := mapbuilder.NewMapBuilder()
+
+	// path parameters
+	pathParameters := make(map[string]string)
+	if v, err := cmd.Flags().GetString("id"); err == nil {
+		if v != "" {
+			pathParameters["id"] = v
+		}
+	} else {
+		return newUserError(fmt.Sprintf("Flag [%s] does not exist. %s", "id", err))
+	}
+
+	path := replacePathParameters("inventory/managedObjects/{id}/childAdditions", pathParameters)
+
+	req := c8y.RequestOptions{
+		Method:       "GET",
+		Path:         path,
+		Query:        queryValue,
+		Body:         body.GetMap(),
+		FormData:     formData,
+		Header:       headers,
+		IgnoreAccept: false,
+		DryRun:       globalFlagDryRun,
+	}
+
+	return processRequestAndResponse([]c8y.RequestOptions{req}, commonOptions)
+}

--- a/pkg/cmd/inventoryReferencesRootCmd.go
+++ b/pkg/cmd/inventoryReferencesRootCmd.go
@@ -30,6 +30,9 @@ func newInventoryReferencesRootCmd() *inventoryReferencesCmd {
 	cmd.AddCommand(newDeleteManagedObjectChildAssetReferenceCmd().getCommand())
 	cmd.AddCommand(newDeleteDeviceFromGroupCmd().getCommand())
 	cmd.AddCommand(newDeleteAssetFromGroupCmd().getCommand())
+	cmd.AddCommand(newGetManagedObjectChildAdditionCollectionCmd().getCommand())
+	cmd.AddCommand(newAddManagedObjectChildAdditionCmd().getCommand())
+	cmd.AddCommand(newDeleteChildAdditionCmd().getCommand())
 
 	ccmd.baseCmd = newBaseCmd(cmd)
 

--- a/tools/PSc8y/PSc8y.psd1
+++ b/tools/PSc8y/PSc8y.psd1
@@ -92,6 +92,7 @@ FormatsToProcess = @(
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
 	'Add-AssetToGroup',
+	'Add-ChildAddition',
 	'Add-ChildDeviceToDevice',
 	'Add-ChildGroupToGroup',
 	'Add-DeviceToGroup',
@@ -118,6 +119,7 @@ FunctionsToExport = @(
 	'Get-BinaryCollection',
 	'Get-BulkOperation',
 	'Get-BulkOperationCollection',
+	'Get-ChildAdditionCollection',
 	'Get-ChildAssetCollection',
 	'Get-ChildAssetReference',
 	'Get-ChildDeviceCollection',
@@ -205,6 +207,7 @@ FunctionsToExport = @(
 	'Remove-AssetFromGroup',
 	'Remove-Binary',
 	'Remove-BulkOperation',
+	'Remove-ChildAddition',
 	'Remove-ChildDeviceFromDevice',
 	'Remove-Device',
 	'Remove-DeviceFromGroup',

--- a/tools/PSc8y/Public/Add-ChildAddition.ps1
+++ b/tools/PSc8y/Public/Add-ChildAddition.ps1
@@ -1,0 +1,145 @@
+﻿# Code generated from specification version 1.0.0: DO NOT EDIT
+Function Add-ChildAddition {
+<#
+.SYNOPSIS
+Add a managed object as a child addition to another existing managed object
+
+.DESCRIPTION
+Add a managed object as a child addition to another existing managed object
+
+.EXAMPLE
+PS> Add-ChildAddition -Id $software.id -NewChild $version.id
+
+Add a related managed object as a child to an existing managed object
+
+
+#>
+    [cmdletbinding(SupportsShouldProcess = $true,
+                   PositionalBinding=$true,
+                   HelpUri='',
+                   ConfirmImpact = 'High')]
+    [Alias()]
+    [OutputType([object])]
+    Param(
+        # Managed object id where the child addition will be added to (required)
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true)]
+        [string]
+        $Id,
+
+        # New managed object that will be added as a child addition (required)
+        [Parameter(Mandatory = $true)]
+        [string[]]
+        $NewChild,
+
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
+        [string]
+        $ProcessingMode,
+
+        # Template (jsonnet) file to use to create the request body.
+        [Parameter()]
+        [string]
+        $Template,
+
+        # Variables to be used when evaluating the Template. Accepts a file path, json or json shorthand, i.e. "name=peter"
+        [Parameter()]
+        [string]
+        $TemplateVars,
+
+        # Show the full (raw) response from Cumulocity including pagination information
+        [Parameter()]
+        [switch]
+        $Raw,
+
+        # Write the response to file
+        [Parameter()]
+        [string]
+        $OutputFile,
+
+        # Ignore any proxy settings when running the cmdlet
+        [Parameter()]
+        [switch]
+        $NoProxy,
+
+        # Specifiy alternative Cumulocity session to use when running the cmdlet
+        [Parameter()]
+        [string]
+        $Session,
+
+        # TimeoutSec timeout in seconds before a request will be aborted
+        [Parameter()]
+        [double]
+        $TimeoutSec,
+
+        # Don't prompt for confirmation
+        [Parameter()]
+        [switch]
+        $Force
+    )
+
+    Begin {
+        $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("NewChild")) {
+            $Parameters["newChild"] = $NewChild
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
+        if ($PSBoundParameters.ContainsKey("Template") -and $Template) {
+            $Parameters["template"] = $Template
+        }
+        if ($PSBoundParameters.ContainsKey("TemplateVars") -and $TemplateVars) {
+            $Parameters["templateVars"] = $TemplateVars
+        }
+        if ($PSBoundParameters.ContainsKey("OutputFile")) {
+            $Parameters["outputFile"] = $OutputFile
+        }
+        if ($PSBoundParameters.ContainsKey("NoProxy")) {
+            $Parameters["noProxy"] = $NoProxy
+        }
+        if ($PSBoundParameters.ContainsKey("Session")) {
+            $Parameters["session"] = $Session
+        }
+        if ($PSBoundParameters.ContainsKey("TimeoutSec")) {
+            $Parameters["timeout"] = $TimeoutSec * 1000
+        }
+
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
+    Process {
+        foreach ($item in (PSc8y\Expand-Id $Id)) {
+            if ($item) {
+                $Parameters["id"] = if ($item.id) { $item.id } else { $item }
+            }
+
+            if (!$Force -and
+                !$WhatIfPreference -and
+                !$PSCmdlet.ShouldProcess(
+                    (PSc8y\Get-C8ySessionProperty -Name "tenant"),
+                    (Format-ConfirmationMessage -Name $PSCmdlet.MyInvocation.InvocationName -InputObject $item)
+                )) {
+                continue
+            }
+
+            Invoke-ClientCommand `
+                -Noun "inventoryReferences" `
+                -Verb "createChildAddition" `
+                -Parameters $Parameters `
+                -Type "application/vnd.com.nsn.cumulocity.managedObjectReference+json" `
+                -ItemType "application/vnd.com.nsn.cumulocity.managedObject+json" `
+                -ResultProperty "managedObject" `
+                -Raw:$Raw
+        }
+    }
+
+    End {}
+}

--- a/tools/PSc8y/Public/Get-ChildAdditionCollection.ps1
+++ b/tools/PSc8y/Public/Get-ChildAdditionCollection.ps1
@@ -1,0 +1,139 @@
+﻿# Code generated from specification version 1.0.0: DO NOT EDIT
+Function Get-ChildAdditionCollection {
+<#
+.SYNOPSIS
+Get a collection of managedObjects child additions
+
+.DESCRIPTION
+Get a collection of managedObjects child additions
+
+.EXAMPLE
+PS> Get-ChildAdditionCollection -Id $software.id
+
+Get a list of the child additions of an existing managed object
+
+.EXAMPLE
+PS> Get-ManagedObject -Id $software.id | Get-ChildAdditionCollection
+
+Get a list of the child additions of an existing managed object (using pipeline)
+
+
+#>
+    [cmdletbinding(SupportsShouldProcess = $true,
+                   PositionalBinding=$true,
+                   HelpUri='',
+                   ConfirmImpact = 'None')]
+    [Alias()]
+    [OutputType([object])]
+    Param(
+        # Managed object id. (required)
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true)]
+        [string]
+        $Id,
+
+        # Maximum number of results
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateRange(1,2000)]
+        [int]
+        $PageSize,
+
+        # Include total pages statistic
+        [Parameter()]
+        [switch]
+        $WithTotalPages,
+
+        # Get a specific page result
+        [Parameter()]
+        [int]
+        $CurrentPage,
+
+        # Maximum number of pages to retrieve when using -IncludeAll
+        [Parameter()]
+        [int]
+        $TotalPages,
+
+        # Include all results
+        [Parameter()]
+        [switch]
+        $IncludeAll,
+
+        # Show the full (raw) response from Cumulocity including pagination information
+        [Parameter()]
+        [switch]
+        $Raw,
+
+        # Write the response to file
+        [Parameter()]
+        [string]
+        $OutputFile,
+
+        # Ignore any proxy settings when running the cmdlet
+        [Parameter()]
+        [switch]
+        $NoProxy,
+
+        # Specifiy alternative Cumulocity session to use when running the cmdlet
+        [Parameter()]
+        [string]
+        $Session,
+
+        # TimeoutSec timeout in seconds before a request will be aborted
+        [Parameter()]
+        [double]
+        $TimeoutSec
+    )
+
+    Begin {
+        $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("PageSize")) {
+            $Parameters["pageSize"] = $PageSize
+        }
+        if ($PSBoundParameters.ContainsKey("WithTotalPages") -and $WithTotalPages) {
+            $Parameters["withTotalPages"] = $WithTotalPages
+        }
+        if ($PSBoundParameters.ContainsKey("OutputFile")) {
+            $Parameters["outputFile"] = $OutputFile
+        }
+        if ($PSBoundParameters.ContainsKey("NoProxy")) {
+            $Parameters["noProxy"] = $NoProxy
+        }
+        if ($PSBoundParameters.ContainsKey("Session")) {
+            $Parameters["session"] = $Session
+        }
+        if ($PSBoundParameters.ContainsKey("TimeoutSec")) {
+            $Parameters["timeout"] = $TimeoutSec * 1000
+        }
+
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
+    Process {
+        foreach ($item in (PSc8y\Expand-Id $Id)) {
+            if ($item) {
+                $Parameters["id"] = if ($item.id) { $item.id } else { $item }
+            }
+
+
+            Invoke-ClientCommand `
+                -Noun "inventoryReferences" `
+                -Verb "listChildAdditions" `
+                -Parameters $Parameters `
+                -Type "application/vnd.com.nsn.cumulocity.managedObjectReferenceCollection+json" `
+                -ItemType "application/vnd.com.nsn.cumulocity.managedObject+json" `
+                -ResultProperty "references.managedObject" `
+                -Raw:$Raw `
+                -CurrentPage:$CurrentPage `
+                -TotalPages:$TotalPages `
+                -IncludeAll:$IncludeAll
+        }
+    }
+
+    End {}
+}

--- a/tools/PSc8y/Public/Remove-ChildAddition.ps1
+++ b/tools/PSc8y/Public/Remove-ChildAddition.ps1
@@ -1,0 +1,129 @@
+﻿# Code generated from specification version 1.0.0: DO NOT EDIT
+Function Remove-ChildAddition {
+<#
+.SYNOPSIS
+Delete child addition reference
+
+.DESCRIPTION
+Unassign a child addition from an existing managed object
+
+.EXAMPLE
+PS> Remove-ChildAddition -Id $software.id -ChildId $version.id
+
+Unassign a child addition from its parent managed object
+
+
+#>
+    [cmdletbinding(SupportsShouldProcess = $true,
+                   PositionalBinding=$true,
+                   HelpUri='',
+                   ConfirmImpact = 'High')]
+    [Alias()]
+    [OutputType([object])]
+    Param(
+        # Managed object id (required)
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true)]
+        [string]
+        $Id,
+
+        # Child managed object id
+        [Parameter()]
+        [string]
+        $ChildId,
+
+        # Cumulocity processing mode
+        [Parameter()]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [ValidateSet("PERSISTENT", "QUIESCENT", "TRANSIENT", "CEP", "")]
+        [string]
+        $ProcessingMode,
+
+        # Show the full (raw) response from Cumulocity including pagination information
+        [Parameter()]
+        [switch]
+        $Raw,
+
+        # Write the response to file
+        [Parameter()]
+        [string]
+        $OutputFile,
+
+        # Ignore any proxy settings when running the cmdlet
+        [Parameter()]
+        [switch]
+        $NoProxy,
+
+        # Specifiy alternative Cumulocity session to use when running the cmdlet
+        [Parameter()]
+        [string]
+        $Session,
+
+        # TimeoutSec timeout in seconds before a request will be aborted
+        [Parameter()]
+        [double]
+        $TimeoutSec,
+
+        # Don't prompt for confirmation
+        [Parameter()]
+        [switch]
+        $Force
+    )
+
+    Begin {
+        $Parameters = @{}
+        if ($PSBoundParameters.ContainsKey("ChildId")) {
+            $Parameters["childId"] = $ChildId
+        }
+        if ($PSBoundParameters.ContainsKey("ProcessingMode")) {
+            $Parameters["processingMode"] = $ProcessingMode
+        }
+        if ($PSBoundParameters.ContainsKey("OutputFile")) {
+            $Parameters["outputFile"] = $OutputFile
+        }
+        if ($PSBoundParameters.ContainsKey("NoProxy")) {
+            $Parameters["noProxy"] = $NoProxy
+        }
+        if ($PSBoundParameters.ContainsKey("Session")) {
+            $Parameters["session"] = $Session
+        }
+        if ($PSBoundParameters.ContainsKey("TimeoutSec")) {
+            $Parameters["timeout"] = $TimeoutSec * 1000
+        }
+
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+    }
+
+    Process {
+        foreach ($item in (PSc8y\Expand-Id $Id)) {
+            if ($item) {
+                $Parameters["id"] = if ($item.id) { $item.id } else { $item }
+            }
+
+            if (!$Force -and
+                !$WhatIfPreference -and
+                !$PSCmdlet.ShouldProcess(
+                    (PSc8y\Get-C8ySessionProperty -Name "tenant"),
+                    (Format-ConfirmationMessage -Name $PSCmdlet.MyInvocation.InvocationName -InputObject $item)
+                )) {
+                continue
+            }
+
+            Invoke-ClientCommand `
+                -Noun "inventoryReferences" `
+                -Verb "unassignChildAddition" `
+                -Parameters $Parameters `
+                -Type "" `
+                -ItemType "" `
+                -ResultProperty "" `
+                -Raw:$Raw
+        }
+    }
+
+    End {}
+}

--- a/tools/PSc8y/Tests/Add-ChildAddition.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Add-ChildAddition.auto.Tests.ps1
@@ -1,0 +1,23 @@
+﻿. $PSScriptRoot/imports.ps1
+
+Describe -Name "Add-ChildAddition" {
+    BeforeEach {
+        $software = PSc8y\New-ManagedObject -Name softwarePackage1
+        $version = PSc8y\New-ManagedObject -Name softwareVersion1
+
+    }
+
+    It "Add a related managed object as a child to an existing managed object" {
+        $Response = PSc8y\Add-ChildAddition -Id $software.id -NewChild $version.id
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+
+    AfterEach {
+        PSc8y\Remove-ManagedObject -Id $software.id
+        PSc8y\Remove-ManagedObject -Id $version.id
+
+    }
+}
+

--- a/tools/PSc8y/Tests/Get-ChildAdditionCollection.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Get-ChildAdditionCollection.auto.Tests.ps1
@@ -1,0 +1,30 @@
+﻿. $PSScriptRoot/imports.ps1
+
+Describe -Name "Get-ChildAdditionCollection" {
+    BeforeEach {
+        $software = PSc8y\New-ManagedObject -Name softwarePackage1
+        $version = PSc8y\New-ManagedObject -Name softwareVersion1
+        PSc8y\Add-ChildAddition -Id $software.id -NewChild $version.id
+
+    }
+
+    It "Get a list of the child additions of an existing managed object" {
+        $Response = PSc8y\Get-ChildAdditionCollection -Id $software.id
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It "Get a list of the child additions of an existing managed object (using pipeline)" {
+        $Response = PSc8y\Get-ManagedObject -Id $software.id | Get-ChildAdditionCollection
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+
+    AfterEach {
+        PSc8y\Remove-ManagedObject -Id $software.id
+        PSc8y\Remove-ManagedObject -Id $version.id
+
+    }
+}
+

--- a/tools/PSc8y/Tests/Remove-ChildAddition.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Remove-ChildAddition.auto.Tests.ps1
@@ -1,0 +1,23 @@
+﻿. $PSScriptRoot/imports.ps1
+
+Describe -Name "Remove-ChildAddition" {
+    BeforeEach {
+        $software = PSc8y\New-ManagedObject -Name softwarePackage1
+        $version = PSc8y\New-ManagedObject -Name softwareVersion1
+        PSc8y\Add-ChildAddition -Id $software.id -NewChild $version.id
+
+    }
+
+    It "Unassign a child addition from its parent managed object" {
+        $Response = PSc8y\Remove-ChildAddition -Id $software.id -ChildId $version.id
+        $LASTEXITCODE | Should -Be 0
+    }
+
+
+    AfterEach {
+        PSc8y\Remove-ManagedObject -Id $version.id
+        PSc8y\Remove-ManagedObject -Id $software.id
+
+    }
+}
+


### PR DESCRIPTION
* Added commands to manage managed object child additions

    **PowerShell**

    * `Get-ChildAdditionCollection`
    * `New-ChildAddition`
    * `Remove-ChildAddition`

    **Bash/zsh**

    * `c8y inventoryReferences listChildAdditions`
    * `c8y inventoryReferences createChildAddition`
    * `c8y inventoryReferences deleteChildAddition`