### PR TITLE
Bugfix/issue 49/bell in set session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ No unreleased features
 
 * Reduced number of API calls within PSc8y and c8y binary by skipping lookups when an ID is given by the user. Previously PSc8y and c8y were sending two API calls to the server in order to normalize the request by retrieving additional information and potentiall shown to the user. Since this is currently not used, it has been removed.
 
+## Bug fixes
+
+* `Set-Session` no longer causes the terminal bell/chime when using backspace or arrow keys.
+
 ## Released
 
 ### v1.9.1

--- a/pkg/cmd/bellSkipper.go
+++ b/pkg/cmd/bellSkipper.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "os"
+
+// bellSkipper implements an io.WriteCloser that skips the terminal bell
+// character (ASCII code 7), and writes the rest to os.Stderr. It is used to
+// replace readline.Stdout, that is the package used by promptui to display the
+// prompts.
+//
+// This is a workaround for the bell issue documented in
+// https://github.com/manifoldco/promptui/issues/49.
+type bellSkipper struct{}
+
+// Write implements an io.WriterCloser over os.Stderr, but it skips the terminal
+// bell character.
+func (bs *bellSkipper) Write(b []byte) (int, error) {
+	const charBell = 7 // c.f. readline.CharBell
+	if len(b) == 1 && b[0] == charBell {
+		return 0, nil
+	}
+	return os.Stderr.Write(b)
+}
+
+// Close implements an io.WriterCloser over os.Stderr.
+func (bs *bellSkipper) Close() error {
+	return os.Stderr.Close()
+}

--- a/pkg/cmd/listSessionCmd.manual.go
+++ b/pkg/cmd/listSessionCmd.manual.go
@@ -167,7 +167,7 @@ func (n *listSessionCmd) listSession(cmd *cobra.Command, args []string) error {
 	}
 
 	prompt := promptui.Select{
-		Stdout:            os.Stderr,
+		Stdout:            &bellSkipper{}, // Workaround to pervent the terminal bell on MacOS
 		HideSelected:      false,
 		IsVimMode:         false,
 		StartInSearchMode: false,


### PR DESCRIPTION
* `Set-Session` no longer causes the terminal bell/chime when using backspace or arrow keys.