### PR TITLE
removing required flag on domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 No unreleased features
 
+#### Bugfixes
+
+* Update-Tenant: `Domain` is no longer a mandatory/required parameter
+
 ## Released
 
 ### v1.11.0

--- a/api/spec/json/tenants.json
+++ b/api/spec/json/tenants.json
@@ -225,7 +225,7 @@
         {
           "name": "domain",
           "type": "string",
-          "required": true,
+          "required": false,
           "description": "Domain name to be used for the tenant. Maximum 256 characters"
         },
         {

--- a/api/spec/yaml/tenants.yml
+++ b/api/spec/yaml/tenants.yml
@@ -162,7 +162,7 @@ endpoints:
 
       - name: domain
         type: string
-        required: true
+        required: false
         description: Domain name to be used for the tenant. Maximum 256 characters
 
       - name: adminName

--- a/pkg/cmd/updateTenantCmd.auto.go
+++ b/pkg/cmd/updateTenantCmd.auto.go
@@ -35,7 +35,7 @@ Update a tenant by name (from the mangement tenant)
 
 	cmd.Flags().String("id", "", "Tenant id")
 	cmd.Flags().String("company", "", "Company name. Maximum 256 characters")
-	cmd.Flags().String("domain", "", "Domain name to be used for the tenant. Maximum 256 characters (required)")
+	cmd.Flags().String("domain", "", "Domain name to be used for the tenant. Maximum 256 characters")
 	cmd.Flags().String("adminName", "", "Username of the tenant administrator")
 	cmd.Flags().String("adminPass", "", "Password of the tenant administrator")
 	cmd.Flags().String("contactName", "", "A contact name, for example an administrator, of the tenant")
@@ -44,7 +44,6 @@ Update a tenant by name (from the mangement tenant)
 	addProcessingModeFlag(cmd)
 
 	// Required flags
-	cmd.MarkFlagRequired("domain")
 
 	ccmd.baseCmd = newBaseCmd(cmd)
 

--- a/tools/PSc8y/Public/Update-Tenant.ps1
+++ b/tools/PSc8y/Public/Update-Tenant.ps1
@@ -32,8 +32,8 @@ Update a tenant by name (from the mangement tenant)
         [string]
         $Company,
 
-        # Domain name to be used for the tenant. Maximum 256 characters (required)
-        [Parameter(Mandatory = $true)]
+        # Domain name to be used for the tenant. Maximum 256 characters
+        [Parameter()]
         [string]
         $Domain,
 


### PR DESCRIPTION
* Update-Tenant: `Domain` is no longer a mandatory/required parameter