### PR TITLE
Feat: Empty pipeline handling

### DIFF
--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -347,7 +347,7 @@ func WithReferenceByName(client *c8y.Client, fetcher EntityFetcher, args []strin
 				return "", nil, err
 			}
 			minMatches := 0
-			if inputIterators.PipeOptions.Required {
+			if inputIterators.PipeOptions.Required || false {
 				minMatches = 1
 			}
 			iter := NewReferenceByNameIterator(fetcher, client, pipeIter, minMatches, overrideValue)
@@ -422,7 +422,7 @@ func WithSelfReferenceByName(client *c8y.Client, fetcher EntityFetcher, args []s
 				return "", nil, err
 			}
 			minMatches := 0
-			if inputIterators.PipeOptions.Required {
+			if inputIterators.PipeOptions.Required || false {
 				minMatches = 1
 			}
 			iter := NewReferenceByNameIterator(fetcher, client, pipeIter, minMatches, overrideValue)
@@ -626,7 +626,8 @@ func WithReferenceByNamePipeline(client *c8y.Client, fetcher EntityFetcher, opts
 		}
 
 		minMatches := 0
-		if inputIterators.PipeOptions.Required {
+		// TODO: Check if required can be ignored or not
+		if inputIterators.PipeOptions.Required || false {
 			minMatches = 1
 		}
 		iter := NewReferenceByNameIterator(fetcher, client, pipeIter, minMatches, nil)

--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -343,11 +343,15 @@ func WithReferenceByName(client *c8y.Client, fetcher EntityFetcher, args []strin
 			hasPipeSupport := inputIterators.PipeOptions.Name == src
 			pipeIter, err := flags.NewFlagWithPipeIterator(cmd, inputIterators.PipeOptions, hasPipeSupport)
 
+			if err == iterator.ErrEmptyPipeInput && !inputIterators.PipeOptions.EmptyPipe {
+				return inputIterators.PipeOptions.Property, nil, err
+			}
+
 			if err != nil || pipeIter == nil {
 				return "", nil, err
 			}
 			minMatches := 0
-			if inputIterators.PipeOptions.Required || false {
+			if inputIterators.PipeOptions.Required {
 				minMatches = 1
 			}
 			iter := NewReferenceByNameIterator(fetcher, client, pipeIter, minMatches, overrideValue)
@@ -418,11 +422,15 @@ func WithSelfReferenceByName(client *c8y.Client, fetcher EntityFetcher, args []s
 			hasPipeSupport := inputIterators.PipeOptions.Name == src
 			pipeIter, err := flags.NewFlagWithPipeIterator(cmd, inputIterators.PipeOptions, hasPipeSupport)
 
+			if err == iterator.ErrEmptyPipeInput && !inputIterators.PipeOptions.EmptyPipe {
+				return inputIterators.PipeOptions.Property, nil, err
+			}
+
 			if err != nil || pipeIter == nil {
 				return "", nil, err
 			}
 			minMatches := 0
-			if inputIterators.PipeOptions.Required || false {
+			if inputIterators.PipeOptions.Required {
 				minMatches = 1
 			}
 			iter := NewReferenceByNameIterator(fetcher, client, pipeIter, minMatches, overrideValue)
@@ -497,7 +505,10 @@ func WithReferenceByNameFirstMatch(client *c8y.Client, fetcher EntityFetcher, ar
 			// value will be evalulated later
 			return name, v, nil
 		default:
-			return "", "", fmt.Errorf("reference by name: invalid name lookup type. only strings are supported")
+			if err == nil {
+				err = fmt.Errorf("reference by name: invalid name lookup type. only strings are supported")
+			}
+			return "", "", err
 		}
 	}
 }
@@ -523,7 +534,10 @@ func WithSelfReferenceByNameFirstMatch(client *c8y.Client, fetcher EntityFetcher
 			// value will be evalulated later
 			return name, v, nil
 		default:
-			return "", "", fmt.Errorf("reference by name: invalid name lookup type. only strings are supported")
+			if err == nil {
+				err = fmt.Errorf("reference by name: invalid name lookup type. only strings are supported")
+			}
+			return "", "", err
 		}
 	}
 }
@@ -613,25 +627,5 @@ func WithUserGroupByNameFirstMatch(client *c8y.Client, args []string, opts ...st
 	return func(cmd *cobra.Command, inputIterators *flags.RequestInputIterators) (string, interface{}, error) {
 		opt := WithReferenceByNameFirstMatch(client, NewUserGroupFetcher(client), args, opts...)
 		return opt(cmd, inputIterators)
-	}
-}
-
-// WithReferenceByNamePipeline adds pipeline support from cli arguments
-func WithReferenceByNamePipeline(client *c8y.Client, fetcher EntityFetcher, opts *flags.PipelineOptions) flags.GetOption {
-	return func(cmd *cobra.Command, inputIterators *flags.RequestInputIterators) (string, interface{}, error) {
-		pipeIter, err := flags.NewFlagWithPipeIterator(cmd, opts, true)
-
-		if err != nil {
-			return "", nil, err
-		}
-
-		minMatches := 0
-		// TODO: Check if required can be ignored or not
-		if inputIterators.PipeOptions.Required || false {
-			minMatches = 1
-		}
-		iter := NewReferenceByNameIterator(fetcher, client, pipeIter, minMatches, nil)
-
-		return opts.Property, iter, err
 	}
 }

--- a/pkg/cmd/agents/create/create.auto.go
+++ b/pkg/cmd/agents/create/create.auto.go
@@ -81,7 +81,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/agents/delete/delete.auto.go
+++ b/pkg/cmd/agents/delete/delete.auto.go
@@ -78,7 +78,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/agents/get/get.auto.go
+++ b/pkg/cmd/agents/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/agents/list/list.manual.go
+++ b/pkg/cmd/agents/list/list.manual.go
@@ -72,7 +72,7 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/agents/update/update.auto.go
+++ b/pkg/cmd/agents/update/update.auto.go
@@ -78,7 +78,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/create/create.auto.go
+++ b/pkg/cmd/alarms/create/create.auto.go
@@ -84,7 +84,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
@@ -90,7 +90,7 @@ func (n *DeleteCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/get/get.auto.go
+++ b/pkg/cmd/alarms/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/list/list.auto.go
+++ b/pkg/cmd/alarms/list/list.auto.go
@@ -91,7 +91,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/subscribe/subscribe.manual.go
+++ b/pkg/cmd/alarms/subscribe/subscribe.manual.go
@@ -78,7 +78,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/update/update.auto.go
+++ b/pkg/cmd/alarms/update/update.auto.go
@@ -84,7 +84,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/alarms/updatecollection/updateCollection.auto.go
+++ b/pkg/cmd/alarms/updatecollection/updateCollection.auto.go
@@ -87,7 +87,7 @@ func (n *UpdateCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -95,7 +95,7 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/copy/copy.auto.go
+++ b/pkg/cmd/applications/copy/copy.auto.go
@@ -81,7 +81,7 @@ func (n *CopyCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/create/create.auto.go
+++ b/pkg/cmd/applications/create/create.auto.go
@@ -85,7 +85,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/createbinary/createBinary.auto.go
+++ b/pkg/cmd/applications/createbinary/createBinary.auto.go
@@ -83,7 +83,7 @@ func (n *CreateBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/delete/delete.auto.go
+++ b/pkg/cmd/applications/delete/delete.auto.go
@@ -79,7 +79,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
+++ b/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
@@ -80,7 +80,7 @@ func (n *DeleteApplicationBinaryCmd) RunE(cmd *cobra.Command, args []string) err
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/get/get.auto.go
+++ b/pkg/cmd/applications/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/list/list.auto.go
+++ b/pkg/cmd/applications/list/list.auto.go
@@ -76,7 +76,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/listapplicationbinaries/listApplicationBinaries.auto.go
+++ b/pkg/cmd/applications/listapplicationbinaries/listApplicationBinaries.auto.go
@@ -78,7 +78,7 @@ func (n *ListApplicationBinariesCmd) RunE(cmd *cobra.Command, args []string) err
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/applications/update/update.auto.go
+++ b/pkg/cmd/applications/update/update.auto.go
@@ -86,7 +86,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/auditrecords/create/create.auto.go
+++ b/pkg/cmd/auditrecords/create/create.auto.go
@@ -87,7 +87,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/auditrecords/get/get.auto.go
+++ b/pkg/cmd/auditrecords/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/auditrecords/list/list.auto.go
+++ b/pkg/cmd/auditrecords/list/list.auto.go
@@ -82,7 +82,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/binaries/create/create.auto.go
+++ b/pkg/cmd/binaries/create/create.auto.go
@@ -80,7 +80,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/binaries/delete/delete.auto.go
+++ b/pkg/cmd/binaries/delete/delete.auto.go
@@ -75,7 +75,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/binaries/get/get.auto.go
+++ b/pkg/cmd/binaries/get/get.auto.go
@@ -79,7 +79,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/binaries/list/list.auto.go
+++ b/pkg/cmd/binaries/list/list.auto.go
@@ -74,7 +74,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/binaries/update/update.auto.go
+++ b/pkg/cmd/binaries/update/update.auto.go
@@ -78,7 +78,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/bulkoperations/create/create.auto.go
+++ b/pkg/cmd/bulkoperations/create/create.auto.go
@@ -85,7 +85,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/bulkoperations/delete/delete.auto.go
+++ b/pkg/cmd/bulkoperations/delete/delete.auto.go
@@ -75,7 +75,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/bulkoperations/get/get.auto.go
+++ b/pkg/cmd/bulkoperations/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/bulkoperations/list/list.auto.go
+++ b/pkg/cmd/bulkoperations/list/list.auto.go
@@ -75,7 +75,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/bulkoperations/listoperations/listOperations.auto.go
+++ b/pkg/cmd/bulkoperations/listoperations/listOperations.auto.go
@@ -87,7 +87,7 @@ func (n *ListOperationsCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/bulkoperations/update/update.auto.go
+++ b/pkg/cmd/bulkoperations/update/update.auto.go
@@ -78,7 +78,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/pkg/console"
 	"github.com/reubenmiller/go-c8y-cli/pkg/dataview"
 	"github.com/reubenmiller/go-c8y-cli/pkg/encrypt"
+	"github.com/reubenmiller/go-c8y-cli/pkg/iterator"
 	"github.com/reubenmiller/go-c8y-cli/pkg/logger"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
@@ -98,6 +99,12 @@ func CheckCommandError(cmd *cobra.Command, f *cmdutil.Factory, err error) error 
 
 	if errors.Is(err, cmderrors.ErrHelp) {
 		return err
+	}
+
+	if iterator.IsEmptyPipeInputError(err) && !cfg.AllowEmptyPipe() {
+		// Ignore empty pipe errors
+		logg.Debug("detected empty piped data")
+		return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitOK)
 	}
 
 	// read directly from flags, as unknown flag errors are thrown before the config is read

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -439,11 +439,12 @@ func Test_DebugCommand(t *testing.T) {
 
 	// cmdErr := ExecuteCmd(cmd, fmt.Sprintf("devices list --select id,nam* --output csvheader"))
 	// cmdErr := ExecuteCmd(cmd, fmt.Sprintf("applications get --id cockpit --select appId:id,tenantId:owner.**.id"))
+	// stdin := bytes.NewBufferString(``)
 	stdin := bytes.NewBufferString(`` + "\n")
 	cmd.SetIn(stdin)
 	// operations create --device livedemo01 --data "c8y_Restart={}"
 	cmdtext := `
-	agents get --id agent01,agent02 --select name -o csv
+	alarms list --dry
 	`
 	// operations create --dry --template "{v:input.value}" --device livedemo01
 	cmdErr := ExecuteCmd(cmd, strings.TrimSpace(cmdtext))

--- a/pkg/cmd/currentapplication/get/get.auto.go
+++ b/pkg/cmd/currentapplication/get/get.auto.go
@@ -73,7 +73,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currentapplication/listsubscriptions/listSubscriptions.auto.go
+++ b/pkg/cmd/currentapplication/listsubscriptions/listSubscriptions.auto.go
@@ -72,7 +72,7 @@ func (n *ListSubscriptionsCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currentapplication/update/update.auto.go
+++ b/pkg/cmd/currentapplication/update/update.auto.go
@@ -83,7 +83,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currenttenant/get/get.auto.go
+++ b/pkg/cmd/currenttenant/get/get.auto.go
@@ -72,7 +72,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currenttenant/listapplications/listApplications.auto.go
+++ b/pkg/cmd/currenttenant/listapplications/listApplications.auto.go
@@ -73,7 +73,7 @@ func (n *ListApplicationsCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currenttenant/version/version.auto.go
+++ b/pkg/cmd/currenttenant/version/version.auto.go
@@ -72,7 +72,7 @@ func (n *VersionCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currentuser/get/get.auto.go
+++ b/pkg/cmd/currentuser/get/get.auto.go
@@ -72,7 +72,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currentuser/logout/logout.auto.go
+++ b/pkg/cmd/currentuser/logout/logout.auto.go
@@ -72,7 +72,7 @@ func (n *LogoutCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/currentuser/update/update.auto.go
+++ b/pkg/cmd/currentuser/update/update.auto.go
@@ -81,7 +81,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/databroker/get/get.auto.go
+++ b/pkg/cmd/databroker/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/databroker/list/list.auto.go
+++ b/pkg/cmd/databroker/list/list.auto.go
@@ -73,7 +73,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/databroker/update/update.auto.go
+++ b/pkg/cmd/databroker/update/update.auto.go
@@ -79,7 +79,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/assigndevice/assignDevice.auto.go
+++ b/pkg/cmd/devicegroups/assigndevice/assignDevice.auto.go
@@ -83,7 +83,7 @@ func (n *AssignDeviceCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/assigngroup/assignGroup.auto.go
+++ b/pkg/cmd/devicegroups/assigngroup/assignGroup.auto.go
@@ -83,7 +83,7 @@ func (n *AssignGroupCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/create/create.auto.go
+++ b/pkg/cmd/devicegroups/create/create.auto.go
@@ -81,7 +81,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/delete/delete.auto.go
+++ b/pkg/cmd/devicegroups/delete/delete.auto.go
@@ -78,7 +78,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/get/get.auto.go
+++ b/pkg/cmd/devicegroups/get/get.auto.go
@@ -77,7 +77,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/list/list.manual.go
+++ b/pkg/cmd/devicegroups/list/list.manual.go
@@ -72,7 +72,7 @@ func (n *CmdList) getDeviceGroupCollection(cmd *cobra.Command, args []string) er
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/listassets/listAssets.auto.go
+++ b/pkg/cmd/devicegroups/listassets/listAssets.auto.go
@@ -77,7 +77,7 @@ func (n *ListAssetsCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/unassigndevice/unassignDevice.auto.go
+++ b/pkg/cmd/devicegroups/unassigndevice/unassignDevice.auto.go
@@ -79,7 +79,7 @@ func (n *UnassignDeviceCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/unassigngroup/unassignGroup.auto.go
+++ b/pkg/cmd/devicegroups/unassigngroup/unassignGroup.auto.go
@@ -79,7 +79,7 @@ func (n *UnassignGroupCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devicegroups/update/update.auto.go
+++ b/pkg/cmd/devicegroups/update/update.auto.go
@@ -79,7 +79,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deviceregistration/approve/approve.auto.go
+++ b/pkg/cmd/deviceregistration/approve/approve.auto.go
@@ -78,7 +78,7 @@ func (n *ApproveCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deviceregistration/delete/delete.auto.go
+++ b/pkg/cmd/deviceregistration/delete/delete.auto.go
@@ -76,7 +76,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deviceregistration/get/get.auto.go
+++ b/pkg/cmd/deviceregistration/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deviceregistration/getcredentials/getCredentials.auto.go
+++ b/pkg/cmd/deviceregistration/getcredentials/getCredentials.auto.go
@@ -76,7 +76,7 @@ func (n *GetCredentialsCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deviceregistration/list/list.auto.go
+++ b/pkg/cmd/deviceregistration/list/list.auto.go
@@ -73,7 +73,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/deviceregistration/register/register.auto.go
+++ b/pkg/cmd/deviceregistration/register/register.auto.go
@@ -75,7 +75,7 @@ func (n *RegisterCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/assignchild/assignChild.auto.go
+++ b/pkg/cmd/devices/assignchild/assignChild.auto.go
@@ -80,7 +80,7 @@ func (n *AssignChildCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/create/create.auto.go
+++ b/pkg/cmd/devices/create/create.auto.go
@@ -80,7 +80,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/delete/delete.auto.go
+++ b/pkg/cmd/devices/delete/delete.auto.go
@@ -78,7 +78,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/get/get.auto.go
+++ b/pkg/cmd/devices/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/getchild/getChild.auto.go
+++ b/pkg/cmd/devices/getchild/getChild.auto.go
@@ -79,7 +79,7 @@ func (n *GetChildCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/getsupportedmeasurements/getSupportedMeasurements.auto.go
+++ b/pkg/cmd/devices/getsupportedmeasurements/getSupportedMeasurements.auto.go
@@ -78,7 +78,7 @@ func (n *GetSupportedMeasurementsCmd) RunE(cmd *cobra.Command, args []string) er
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/getsupportedseries/getSupportedSeries.auto.go
+++ b/pkg/cmd/devices/getsupportedseries/getSupportedSeries.auto.go
@@ -78,7 +78,7 @@ func (n *GetSupportedSeriesCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/list/list.manual.go
+++ b/pkg/cmd/devices/list/list.manual.go
@@ -77,7 +77,7 @@ func (n *CmdDevicesList) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/listassets/listAssets.auto.go
+++ b/pkg/cmd/devices/listassets/listAssets.auto.go
@@ -77,7 +77,7 @@ func (n *ListAssetsCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/listchildren/listChildren.auto.go
+++ b/pkg/cmd/devices/listchildren/listChildren.auto.go
@@ -77,7 +77,7 @@ func (n *ListChildrenCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/setrequiredavailability/setRequiredAvailability.auto.go
+++ b/pkg/cmd/devices/setrequiredavailability/setRequiredAvailability.auto.go
@@ -78,7 +78,7 @@ func (n *SetRequiredAvailabilityCmd) RunE(cmd *cobra.Command, args []string) err
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/unassignchild/unassignChild.auto.go
+++ b/pkg/cmd/devices/unassignchild/unassignChild.auto.go
@@ -79,7 +79,7 @@ func (n *UnassignChildCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/devices/update/update.auto.go
+++ b/pkg/cmd/devices/update/update.auto.go
@@ -78,7 +78,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/create/create.auto.go
+++ b/pkg/cmd/events/create/create.auto.go
@@ -83,7 +83,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/createbinary/createBinary.auto.go
+++ b/pkg/cmd/events/createbinary/createBinary.auto.go
@@ -77,7 +77,7 @@ func (n *CreateBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/delete/delete.auto.go
+++ b/pkg/cmd/events/delete/delete.auto.go
@@ -75,7 +75,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/deletebinary/deleteBinary.auto.go
+++ b/pkg/cmd/events/deletebinary/deleteBinary.auto.go
@@ -76,7 +76,7 @@ func (n *DeleteBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/events/deletecollection/deleteCollection.auto.go
@@ -84,7 +84,7 @@ func (n *DeleteCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/downloadbinary/downloadBinary.auto.go
+++ b/pkg/cmd/events/downloadbinary/downloadBinary.auto.go
@@ -75,7 +75,7 @@ func (n *DownloadBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/get/get.auto.go
+++ b/pkg/cmd/events/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/list/list.auto.go
+++ b/pkg/cmd/events/list/list.auto.go
@@ -85,7 +85,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/subscribe/subscribe.manual.go
+++ b/pkg/cmd/events/subscribe/subscribe.manual.go
@@ -78,7 +78,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/update/update.auto.go
+++ b/pkg/cmd/events/update/update.auto.go
@@ -80,7 +80,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/events/updatebinary/updateBinary.auto.go
+++ b/pkg/cmd/events/updatebinary/updateBinary.auto.go
@@ -78,7 +78,7 @@ func (n *UpdateBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/identity/create/create.auto.go
+++ b/pkg/cmd/identity/create/create.auto.go
@@ -81,7 +81,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/identity/delete/delete.auto.go
+++ b/pkg/cmd/identity/delete/delete.auto.go
@@ -75,7 +75,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/identity/get/get.auto.go
+++ b/pkg/cmd/identity/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/identity/list/list.auto.go
+++ b/pkg/cmd/identity/list/list.auto.go
@@ -80,7 +80,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/additions/assign/assign.auto.go
+++ b/pkg/cmd/inventory/additions/assign/assign.auto.go
@@ -78,7 +78,7 @@ func (n *AssignCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/additions/list/list.auto.go
+++ b/pkg/cmd/inventory/additions/list/list.auto.go
@@ -76,7 +76,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/additions/unassign/unassign.auto.go
+++ b/pkg/cmd/inventory/additions/unassign/unassign.auto.go
@@ -77,7 +77,7 @@ func (n *UnassignCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/assets/assign/assign.auto.go
+++ b/pkg/cmd/inventory/assets/assign/assign.auto.go
@@ -82,7 +82,7 @@ func (n *AssignCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/assets/get/get.auto.go
+++ b/pkg/cmd/inventory/assets/get/get.auto.go
@@ -79,7 +79,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/assets/list/list.auto.go
+++ b/pkg/cmd/inventory/assets/list/list.auto.go
@@ -79,7 +79,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/assets/unassign/unassign.auto.go
+++ b/pkg/cmd/inventory/assets/unassign/unassign.auto.go
@@ -77,7 +77,7 @@ func (n *UnassignCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/create/create.auto.go
+++ b/pkg/cmd/inventory/create/create.auto.go
@@ -76,7 +76,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/delete/delete.auto.go
+++ b/pkg/cmd/inventory/delete/delete.auto.go
@@ -79,7 +79,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/find/find.manual.go
+++ b/pkg/cmd/inventory/find/find.manual.go
@@ -77,7 +77,7 @@ func (n *CmdFind) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/findbytext/findByText.auto.go
+++ b/pkg/cmd/inventory/findbytext/findByText.auto.go
@@ -85,7 +85,7 @@ func (n *FindByTextCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/get/get.auto.go
+++ b/pkg/cmd/inventory/get/get.auto.go
@@ -79,7 +79,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/list/list.auto.go
+++ b/pkg/cmd/inventory/list/list.auto.go
@@ -89,7 +89,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/subscribe/subscribe.manual.go
+++ b/pkg/cmd/inventory/subscribe/subscribe.manual.go
@@ -76,7 +76,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/inventory/update/update.auto.go
+++ b/pkg/cmd/inventory/update/update.auto.go
@@ -77,7 +77,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/create/create.auto.go
+++ b/pkg/cmd/measurements/create/create.auto.go
@@ -79,7 +79,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/delete/delete.auto.go
+++ b/pkg/cmd/measurements/delete/delete.auto.go
@@ -75,7 +75,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
@@ -80,7 +80,7 @@ func (n *DeleteCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/get/get.auto.go
+++ b/pkg/cmd/measurements/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/getseries/getSeries.auto.go
+++ b/pkg/cmd/measurements/getseries/getSeries.auto.go
@@ -83,7 +83,7 @@ func (n *GetSeriesCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/list/list.auto.go
+++ b/pkg/cmd/measurements/list/list.auto.go
@@ -90,7 +90,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/measurements/subscribe/subscribe.manual.go
+++ b/pkg/cmd/measurements/subscribe/subscribe.manual.go
@@ -78,7 +78,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/createbinary/createBinary.auto.go
+++ b/pkg/cmd/microservices/createbinary/createBinary.auto.go
@@ -83,7 +83,7 @@ func (n *CreateBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/delete/delete.auto.go
+++ b/pkg/cmd/microservices/delete/delete.auto.go
@@ -79,7 +79,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/disable/disable.auto.go
+++ b/pkg/cmd/microservices/disable/disable.auto.go
@@ -82,7 +82,7 @@ func (n *DisableCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/enable/enable.auto.go
+++ b/pkg/cmd/microservices/enable/enable.auto.go
@@ -82,7 +82,7 @@ func (n *EnableCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/get/get.auto.go
+++ b/pkg/cmd/microservices/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/getbootstrapuser/getBootstrapUser.auto.go
+++ b/pkg/cmd/microservices/getbootstrapuser/getBootstrapUser.auto.go
@@ -80,7 +80,7 @@ func (n *GetBootstrapUserCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/getstatus/getStatus.auto.go
+++ b/pkg/cmd/microservices/getstatus/getStatus.auto.go
@@ -81,7 +81,7 @@ func (n *GetStatusCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/list/list.auto.go
+++ b/pkg/cmd/microservices/list/list.auto.go
@@ -77,7 +77,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/serviceuser/get/get.manual.go
+++ b/pkg/cmd/microservices/serviceuser/get/get.manual.go
@@ -72,7 +72,7 @@ func (n *CmdGet) RunE(cmd *cobra.Command, args []string) error {
 	// path parameters
 	appIDs := []string{}
 
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/microservices/update/update.auto.go
+++ b/pkg/cmd/microservices/update/update.auto.go
@@ -83,7 +83,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/create/create.auto.go
+++ b/pkg/cmd/operations/create/create.auto.go
@@ -78,7 +78,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/operations/deletecollection/deleteCollection.auto.go
@@ -83,7 +83,7 @@ func (n *DeleteCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/get/get.auto.go
+++ b/pkg/cmd/operations/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/list/list.auto.go
+++ b/pkg/cmd/operations/list/list.auto.go
@@ -92,7 +92,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/subscribe/subscribe.manual.go
+++ b/pkg/cmd/operations/subscribe/subscribe.manual.go
@@ -76,7 +76,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/update/update.auto.go
+++ b/pkg/cmd/operations/update/update.auto.go
@@ -80,7 +80,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/operations/wait/wait.manual.go
+++ b/pkg/cmd/operations/wait/wait.manual.go
@@ -77,7 +77,7 @@ func (n *CmdWait) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/realtime/subscribeall/subscribeall.manual.go
+++ b/pkg/cmd/realtime/subscribeall/subscribeall.manual.go
@@ -70,7 +70,7 @@ func (n *CmdSubscribeAll) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retentionrules/create/create.auto.go
+++ b/pkg/cmd/retentionrules/create/create.auto.go
@@ -82,7 +82,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retentionrules/delete/delete.auto.go
+++ b/pkg/cmd/retentionrules/delete/delete.auto.go
@@ -76,7 +76,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retentionrules/get/get.auto.go
+++ b/pkg/cmd/retentionrules/get/get.auto.go
@@ -76,7 +76,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retentionrules/list/list.auto.go
+++ b/pkg/cmd/retentionrules/list/list.auto.go
@@ -74,7 +74,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/retentionrules/update/update.auto.go
+++ b/pkg/cmd/retentionrules/update/update.auto.go
@@ -85,7 +85,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -199,6 +199,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 
 	// input parsing
 	cmd.PersistentFlags().BoolP(flags.FlagNullInput, "n", false, "Don't read the input (stdin). Useful if using in shell for/while loops")
+	cmd.PersistentFlags().Bool(flags.FlagAllowEmptyPipe, false, "Don't fail when piped input is empty (stdin)")
 
 	// confirmation
 	cmd.PersistentFlags().BoolP("force", "f", false, "Do not prompt for confirmation. Ignored when using --confirm")

--- a/pkg/cmd/smartgroups/create/create.auto.go
+++ b/pkg/cmd/smartgroups/create/create.auto.go
@@ -84,7 +84,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/smartgroups/delete/delete.auto.go
+++ b/pkg/cmd/smartgroups/delete/delete.auto.go
@@ -77,7 +77,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/smartgroups/get/get.auto.go
+++ b/pkg/cmd/smartgroups/get/get.auto.go
@@ -79,7 +79,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/smartgroups/list/list.manual.go
+++ b/pkg/cmd/smartgroups/list/list.manual.go
@@ -84,7 +84,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/smartgroups/update/update.auto.go
+++ b/pkg/cmd/smartgroups/update/update.auto.go
@@ -79,7 +79,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/systemoptions/get/get.auto.go
+++ b/pkg/cmd/systemoptions/get/get.auto.go
@@ -78,7 +78,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/systemoptions/list/list.auto.go
+++ b/pkg/cmd/systemoptions/list/list.auto.go
@@ -73,7 +73,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/template/execute/execute.manual.go
+++ b/pkg/cmd/template/execute/execute.manual.go
@@ -74,7 +74,7 @@ func (n *CmdExecute) newTemplate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/create/create.auto.go
+++ b/pkg/cmd/tenantoptions/create/create.auto.go
@@ -80,7 +80,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/delete/delete.auto.go
+++ b/pkg/cmd/tenantoptions/delete/delete.auto.go
@@ -78,7 +78,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/get/get.auto.go
+++ b/pkg/cmd/tenantoptions/get/get.auto.go
@@ -78,7 +78,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/getforcategory/getForCategory.auto.go
+++ b/pkg/cmd/tenantoptions/getforcategory/getForCategory.auto.go
@@ -78,7 +78,7 @@ func (n *GetForCategoryCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/list/list.auto.go
+++ b/pkg/cmd/tenantoptions/list/list.auto.go
@@ -73,7 +73,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/update/update.auto.go
+++ b/pkg/cmd/tenantoptions/update/update.auto.go
@@ -80,7 +80,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/updatebulk/updateBulk.auto.go
+++ b/pkg/cmd/tenantoptions/updatebulk/updateBulk.auto.go
@@ -77,7 +77,7 @@ func (n *UpdateBulkCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantoptions/updateedit/updateEdit.auto.go
+++ b/pkg/cmd/tenantoptions/updateedit/updateEdit.auto.go
@@ -82,7 +82,7 @@ func (n *UpdateEditCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/create/create.auto.go
+++ b/pkg/cmd/tenants/create/create.auto.go
@@ -82,7 +82,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/delete/delete.auto.go
+++ b/pkg/cmd/tenants/delete/delete.auto.go
@@ -75,7 +75,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/disableapplication/disableApplication.auto.go
+++ b/pkg/cmd/tenants/disableapplication/disableApplication.auto.go
@@ -78,7 +78,7 @@ func (n *DisableApplicationCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/enableapplication/enableApplication.auto.go
+++ b/pkg/cmd/tenants/enableapplication/enableApplication.auto.go
@@ -78,7 +78,7 @@ func (n *EnableApplicationCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/get/get.auto.go
+++ b/pkg/cmd/tenants/get/get.auto.go
@@ -75,7 +75,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/list/list.auto.go
+++ b/pkg/cmd/tenants/list/list.auto.go
@@ -73,7 +73,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/listreferences/listReferences.auto.go
+++ b/pkg/cmd/tenants/listreferences/listReferences.auto.go
@@ -76,7 +76,7 @@ func (n *ListReferencesCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenants/update/update.auto.go
+++ b/pkg/cmd/tenants/update/update.auto.go
@@ -82,7 +82,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantstatistics/list/list.auto.go
+++ b/pkg/cmd/tenantstatistics/list/list.auto.go
@@ -82,7 +82,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantstatistics/listsummaryalltenants/listSummaryAllTenants.auto.go
+++ b/pkg/cmd/tenantstatistics/listsummaryalltenants/listSummaryAllTenants.auto.go
@@ -81,7 +81,7 @@ func (n *ListSummaryAllTenantsCmd) RunE(cmd *cobra.Command, args []string) error
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tenantstatistics/listsummaryfortenant/listSummaryForTenant.auto.go
+++ b/pkg/cmd/tenantstatistics/listsummaryfortenant/listSummaryForTenant.auto.go
@@ -81,7 +81,7 @@ func (n *ListSummaryForTenantCmd) RunE(cmd *cobra.Command, args []string) error 
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/usergroups/create/create.auto.go
+++ b/pkg/cmd/usergroups/create/create.auto.go
@@ -78,7 +78,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/usergroups/delete/delete.auto.go
+++ b/pkg/cmd/usergroups/delete/delete.auto.go
@@ -78,7 +78,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/usergroups/get/get.auto.go
+++ b/pkg/cmd/usergroups/get/get.auto.go
@@ -78,7 +78,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/usergroups/getbyname/getByName.auto.go
+++ b/pkg/cmd/usergroups/getbyname/getByName.auto.go
@@ -76,7 +76,7 @@ func (n *GetByNameCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/usergroups/list/list.auto.go
+++ b/pkg/cmd/usergroups/list/list.auto.go
@@ -76,7 +76,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/usergroups/update/update.auto.go
+++ b/pkg/cmd/usergroups/update/update.auto.go
@@ -79,7 +79,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userreferences/addusertogroup/addUserToGroup.auto.go
+++ b/pkg/cmd/userreferences/addusertogroup/addUserToGroup.auto.go
@@ -84,7 +84,7 @@ func (n *AddUserToGroupCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userreferences/deleteuserfromgroup/deleteUserFromGroup.auto.go
+++ b/pkg/cmd/userreferences/deleteuserfromgroup/deleteUserFromGroup.auto.go
@@ -84,7 +84,7 @@ func (n *DeleteUserFromGroupCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userreferences/listgroupmembership/listGroupMembership.auto.go
+++ b/pkg/cmd/userreferences/listgroupmembership/listGroupMembership.auto.go
@@ -82,7 +82,7 @@ func (n *ListGroupMembershipCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/addroletogroup/addRoleToGroup.auto.go
+++ b/pkg/cmd/userroles/addroletogroup/addRoleToGroup.auto.go
@@ -81,7 +81,7 @@ func (n *AddRoleToGroupCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/addroletouser/addRoleToUser.auto.go
+++ b/pkg/cmd/userroles/addroletouser/addRoleToUser.auto.go
@@ -81,7 +81,7 @@ func (n *AddRoleToUserCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/deleterolefromgroup/deleteRoleFromGroup.auto.go
+++ b/pkg/cmd/userroles/deleterolefromgroup/deleteRoleFromGroup.auto.go
@@ -81,7 +81,7 @@ func (n *DeleteRoleFromGroupCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/deleterolefromuser/deleteRoleFromUser.auto.go
+++ b/pkg/cmd/userroles/deleterolefromuser/deleteRoleFromUser.auto.go
@@ -81,7 +81,7 @@ func (n *DeleteRoleFromUserCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/getrolereferencecollectionfromgroup/getRoleReferenceCollectionFromGroup.auto.go
+++ b/pkg/cmd/userroles/getrolereferencecollectionfromgroup/getRoleReferenceCollectionFromGroup.auto.go
@@ -79,7 +79,7 @@ func (n *GetRoleReferenceCollectionFromGroupCmd) RunE(cmd *cobra.Command, args [
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/getrolereferencecollectionfromuser/getRoleReferenceCollectionFromUser.auto.go
+++ b/pkg/cmd/userroles/getrolereferencecollectionfromuser/getRoleReferenceCollectionFromUser.auto.go
@@ -79,7 +79,7 @@ func (n *GetRoleReferenceCollectionFromUserCmd) RunE(cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/userroles/list/list.auto.go
+++ b/pkg/cmd/userroles/list/list.auto.go
@@ -73,7 +73,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/create/create.auto.go
+++ b/pkg/cmd/users/create/create.auto.go
@@ -85,7 +85,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/delete/delete.auto.go
+++ b/pkg/cmd/users/delete/delete.auto.go
@@ -80,7 +80,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/get/get.auto.go
+++ b/pkg/cmd/users/get/get.auto.go
@@ -78,7 +78,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/getinventoryrole/getInventoryRole.auto.go
+++ b/pkg/cmd/users/getinventoryrole/getInventoryRole.auto.go
@@ -75,7 +75,7 @@ func (n *GetInventoryRoleCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/getuserbyname/getUserByName.auto.go
+++ b/pkg/cmd/users/getuserbyname/getUserByName.auto.go
@@ -76,7 +76,7 @@ func (n *GetUserByNameCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/list/list.auto.go
+++ b/pkg/cmd/users/list/list.auto.go
@@ -84,7 +84,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/listinventoryroles/listInventoryRoles.auto.go
+++ b/pkg/cmd/users/listinventoryroles/listInventoryRoles.auto.go
@@ -73,7 +73,7 @@ func (n *ListInventoryRolesCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/listusermembership/listUserMembership.auto.go
+++ b/pkg/cmd/users/listusermembership/listUserMembership.auto.go
@@ -79,7 +79,7 @@ func (n *ListUserMembershipCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/resetuserpassword/resetUserPassword.auto.go
+++ b/pkg/cmd/users/resetuserpassword/resetUserPassword.auto.go
@@ -79,7 +79,7 @@ func (n *ResetUserPasswordCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/users/update/update.auto.go
+++ b/pkg/cmd/users/update/update.auto.go
@@ -87,7 +87,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util/repeat/repeat.manual.go
+++ b/pkg/cmd/util/repeat/repeat.manual.go
@@ -121,7 +121,7 @@ func (n *CmdRepeat) newTemplate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/util/show/show.manual.go
+++ b/pkg/cmd/util/show/show.manual.go
@@ -62,7 +62,7 @@ func (n *CmdShow) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	inputIterators, err := flags.NewRequestInputIterators(cmd)
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -305,3 +305,17 @@ func (f *Factory) CheckPostCommandError(err error) error {
 
 	return outErr
 }
+
+// NewRequestInputIterators create a request iterator based on pipe line configuration
+func NewRequestInputIterators(cmd *cobra.Command, cfg *config.Config) (*flags.RequestInputIterators, error) {
+	pipeOpts, err := flags.GetPipeOptionsFromAnnotation(cmd)
+
+	if cfg != nil {
+		pipeOpts.Disabled = cfg.DisableStdin()
+		pipeOpts.EmptyPipe = cfg.AllowEmptyPipe()
+	}
+	inputIter := &flags.RequestInputIterators{
+		PipeOptions: pipeOpts,
+	}
+	return inputIter, err
+}

--- a/pkg/cmdutil/templateflags_test.go
+++ b/pkg/cmdutil/templateflags_test.go
@@ -27,7 +27,7 @@ func Test_WithTemplateValue(t *testing.T) {
 		flags.WithData(),
 		flags.WithTemplate(),
 	)
-	inputIterator, _ := flags.NewRequestInputIterators(cmd)
+	inputIterator, _ := NewRequestInputIterators(cmd, nil)
 
 	cmd.SetArgs([]string{"--template", "{value: input.index}"})
 	cmdErr := cmd.Execute()

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -235,6 +235,9 @@ const (
 	// SettingsDisableInput disable reading from stdin (pipeline input)
 	SettingsDisableInput = "settings.defaults.nullInput"
 
+	// SettingsAllowEmptyPipe allow empty piped data
+	SettingsAllowEmptyPipe = "settings.defaults.allowEmptyPipe"
+
 	// SettingsLoginType preferred login type, i.e. BASIC, OAUTH_INTERNAL etc.
 	SettingsLoginType = "settings.login.type"
 )
@@ -1114,6 +1117,11 @@ func (c *Config) HideSensitive() bool {
 // DisableStdin hide sensitive information in log entries
 func (c *Config) DisableStdin() bool {
 	return c.viper.GetBool(SettingsDisableInput)
+}
+
+// AllowEmptyPipe check if empty piped data is allowed
+func (c *Config) AllowEmptyPipe() bool {
+	return c.viper.GetBool(SettingsAllowEmptyPipe)
 }
 
 // GetConfigPath get global settings file path

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -17,6 +17,7 @@ const (
 	FlagPageSize                  = "pageSize"
 	FlagCurrentPage               = "currentPage"
 	FlagNullInput                 = "nullInput"
+	FlagAllowEmptyPipe            = "allowEmptyPipe"
 )
 const (
 	AnnotationValueFromPipeline       = "valueFromPipeline"

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -269,6 +269,7 @@ func WithStringValue(opts ...string) GetOption {
 
 		if inputIterators != nil && inputIterators.PipeOptions != nil {
 			if inputIterators.PipeOptions.Name == src {
+				inputIterators.PipeOptions.EmptyPipe = false
 				return WithPipelineIterator(inputIterators.PipeOptions)(cmd, inputIterators)
 			}
 		}
@@ -668,6 +669,7 @@ func WithRequiredProperties(values ...string) GetOption {
 type PipelineOptions struct {
 	Name        string              `json:"name"`
 	Required    bool                `json:"required"`
+	EmptyPipe   bool                `json:"allowEmptyPipe"`
 	Disabled    bool                `json:"disabled"`
 	Property    string              `json:"property"`
 	Aliases     []string            `json:"aliases"`

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -701,22 +701,6 @@ func WithPipelineIterator(opts *PipelineOptions) GetOption {
 	}
 }
 
-// NewRequestInputIterators returns input iterations with the pipeline options loaded from the annotations
-func NewRequestInputIterators(cmd *cobra.Command) (*RequestInputIterators, error) {
-	pipeOpts, err := GetPipeOptionsFromAnnotation(cmd)
-
-	if disableStdin, _ := cmd.Root().PersistentFlags().GetBool(FlagNullInput); disableStdin {
-		pipeOpts.Disabled = disableStdin
-	}
-	if allowEmptyPipe, pipeErr := cmd.Root().PersistentFlags().GetBool(FlagAllowEmptyPipe); pipeErr == nil {
-		pipeOpts.EmptyPipe = allowEmptyPipe
-	}
-	inputIter := &RequestInputIterators{
-		PipeOptions: pipeOpts,
-	}
-	return inputIter, err
-}
-
 // RequestInputIterators contains all request input iterators
 type RequestInputIterators struct {
 	Total       int

--- a/pkg/flags/pipeline.go
+++ b/pkg/flags/pipeline.go
@@ -46,6 +46,10 @@ func NewFlagWithPipeIterator(cmd *cobra.Command, pipeOpt *PipelineOptions, suppo
 			lineFilter = pipeOpt.InputFilter
 		}
 		iter, err := iterator.NewJSONPipeIterator(cmd.InOrStdin(), iterOpts, lineFilter)
+
+		if err == iterator.ErrEmptyPipeInput && !pipeOpt.EmptyPipe {
+			return iter, err
+		}
 		if err == nil {
 			return iter, nil
 		}

--- a/pkg/flags/stringtemplate.go
+++ b/pkg/flags/stringtemplate.go
@@ -87,7 +87,9 @@ func (b *StringTemplate) Execute(ignoreIterators bool, template ...string) (outp
 		default:
 			currentValue = fmt.Sprintf("%v", v)
 		}
-		output = strings.ReplaceAll(output, "{"+key+"}", currentValue)
+		if currentValue != "" {
+			output = strings.ReplaceAll(output, "{"+key+"}", currentValue)
+		}
 	}
 
 	return

--- a/pkg/iterator/pipe.go
+++ b/pkg/iterator/pipe.go
@@ -16,6 +16,9 @@ import (
 // ErrNoPipeInput is an error when there is no piped input on standard input
 var ErrNoPipeInput = errors.New("iterator: no piped input")
 
+// ErrEmptyPipeInput pipe input is being used but it is empty
+var ErrEmptyPipeInput = errors.New("iterator: empty pipe input")
+
 // Filter is a funciton applied on every iteration. Returning False will end the iterator
 type Filter func([]byte) bool
 
@@ -177,7 +180,10 @@ func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) 
 
 	reader := bufio.NewReader(input)
 	if _, err := reader.Peek(1); err != nil {
-		return nil, ErrNoPipeInput
+		if err == io.EOF {
+			return nil, ErrEmptyPipeInput
+		}
+		return nil, err
 	}
 
 	var pipelineFilter Filter

--- a/pkg/iterator/pipe.go
+++ b/pkg/iterator/pipe.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"errors"
@@ -18,6 +19,10 @@ var ErrNoPipeInput = errors.New("iterator: no piped input")
 
 // ErrEmptyPipeInput pipe input is being used but it is empty
 var ErrEmptyPipeInput = errors.New("iterator: empty pipe input")
+
+func IsEmptyPipeInputError(err error) bool {
+	return strings.Contains(err.Error(), ErrEmptyPipeInput.Error())
+}
 
 // Filter is a funciton applied on every iteration. Returning False will end the iterator
 type Filter func([]byte) bool
@@ -144,8 +149,8 @@ func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
 	}
 
 	reader := bufio.NewReader(input)
-	if _, err := reader.Peek(1); err != nil {
-		return nil, ErrNoPipeInput
+	if err := PeekReader(reader); err != nil {
+		return nil, err
 	}
 
 	var pipelineFilter Filter
@@ -179,10 +184,7 @@ func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) 
 	}
 
 	reader := bufio.NewReader(input)
-	if _, err := reader.Peek(1); err != nil {
-		if err == io.EOF {
-			return nil, ErrEmptyPipeInput
-		}
+	if err := PeekReader(reader); err != nil {
 		return nil, err
 	}
 
@@ -196,4 +198,22 @@ func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) 
 		filter: pipelineFilter,
 		opts:   pipeOpts,
 	}, nil
+}
+
+// PeekReader check if the reader contains empty input or not
+// An error will be returned if the reader does not contain any data, or the first character
+// is whitespace
+func PeekReader(r *bufio.Reader) error {
+	peek, err := r.Peek(1)
+	if err != nil {
+		if err == io.EOF {
+			return ErrEmptyPipeInput
+		}
+		return err
+	}
+	// check first character contains only whitespace
+	if len(bytes.Trim(peek, "\n\r")) == 0 {
+		return ErrEmptyPipeInput
+	}
+	return nil
 }

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -236,9 +236,6 @@ var customJSONNetFunctions = []string{
 	`Digit: function(max=16) std.native("Digit")(max)`,
 	`AlphaNumeric: function(max=16) std.native("AlphaNumeric")(max)`,
 	`StripKeys: function(value={}) value + {lastUpdated::'','self'::'',creationTime::'',additionParents::'',assetParents::'',childAdditions::'',childAssets::'',childDevices::'',deviceParents::''}`,
-	`Input: function(key, value={}, defaultValue={}) if std.type(value) == "object" && std.objectHas(value, key) then {[key]: value[key]} else {[key]: defaultValue}`,
-	`Merge: function(key, a={}, b={}) _.Input(key, a) + {[key]+: b}`,
-	`Remove: function(key, a={}) _.Input(key, a) + {[key]:: null}`,
 }
 
 func evaluateJsonnet(imports string, snippets ...string) (string, error) {

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -236,6 +236,9 @@ var customJSONNetFunctions = []string{
 	`Digit: function(max=16) std.native("Digit")(max)`,
 	`AlphaNumeric: function(max=16) std.native("AlphaNumeric")(max)`,
 	`StripKeys: function(value={}) value + {lastUpdated::'','self'::'',creationTime::'',additionParents::'',assetParents::'',childAdditions::'',childAssets::'',childDevices::'',deviceParents::''}`,
+	`Input: function(key, value={}, defaultValue={}) if std.type(value) == "object" && std.objectHas(value, key) then {[key]: value[key]} else {[key]: defaultValue}`,
+	`Merge: function(key, a={}, b={}) _.Input(key, a) + {[key]+: b}`,
+	`Remove: function(key, a={}) _.Input(key, a) + {[key]:: null}`,
 }
 
 func evaluateJsonnet(imports string, snippets ...string) (string, error) {

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -489,7 +489,7 @@ func (n *${NameCamel}Cmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-    inputIterators, err := flags.NewRequestInputIterators(cmd)
+    inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
     if err != nil {
         return err
     }

--- a/tools/PSc8y/Private/New-ClientArgument.ps1
+++ b/tools/PSc8y/Private/New-ClientArgument.ps1
@@ -122,6 +122,11 @@ Function New-ClientArgument {
             $null = $c8yargs.Add("--raw")
         }
 
+        # Allow empty pipes (only in powershell as it handles empty pipes in the cmdlets)
+        # This simplifies logic on the powershell side, rather than dynamically checking if there is really piped
+        # input or not
+        $null = $c8yargs.Add("--allowEmptyPipe")
+
         ,$c8yargs
     }
 }

--- a/tools/PSc8y/Tests/New-ClientArgument.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/New-ClientArgument.manual.Tests.ps1
@@ -4,17 +4,17 @@ InModuleScope PSc8y {
     Describe "New-ClientArgument" {
         It "Accepts an array of values" {
             $c8yargs = New-ClientArgument -Parameters @{"Ids" = @("1111", "2222")}
-            $c8yargs | Should -BeExactly @("--ids=`"1111,2222`"")
+            $c8yargs | Should -BeExactly @("--ids=`"1111,2222`"", "--allowEmptyPipe")
         }
 
         It "handles an empty array" {
             $c8yargs = New-ClientArgument -Parameters @{"Ids" = @()}
-            $c8yargs | Should -BeExactly @()
+            $c8yargs | Should -BeExactly @("--allowEmptyPipe")
         }
 
         It "handles an array with a single value" {
             $c8yargs = New-ClientArgument -Parameters @{"Ids" = @("1111")}
-            $c8yargs | Should -BeExactly @("--ids=1111")
+            $c8yargs | Should -BeExactly @("--ids=1111", "--allowEmptyPipe")
         }
 
         It "handles an array of objects picking out the id" {
@@ -22,7 +22,7 @@ InModuleScope PSc8y {
                 @{id="1111"},
                 @{id="2222"}
             )}
-            $c8yargs | Should -BeExactly @("--id=`"1111,2222`"")
+            $c8yargs | Should -BeExactly @("--id=`"1111,2222`"", "--allowEmptyPipe")
         }
 
         It "Converts hashtables to escapped json" {
@@ -30,9 +30,10 @@ InModuleScope PSc8y {
                 complex = @{"id" = 1}
             }
             $c8yargs = New-ClientArgument -Parameters:$Parameters
-            $c8yargs | Should -HaveCount 2
+            $c8yargs | Should -HaveCount 3
             $c8yargs[0] | Should -BeExactly '--complex'
             $c8yargs[1] | Should -BeExactly '{\"id\":1}'
+            $c8yargs[2] | Should -BeExactly "--allowEmptyPipe"
         }
     }
 }

--- a/tools/PSc8y/Tests/c8y/errors.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/c8y/errors.manual.Tests.ps1
@@ -166,7 +166,7 @@ Describe -Name "c8y errors" {
         }
 
         It "handles multiple errors in pipeline" {
-            $stderr = $( $output = "", "" | c8y events create --type "c8y_TestAlarm" --force ) 2>&1
+            $stderr = $( $output = "0", "0" | c8y events create --type "c8y_TestAlarm" --force ) 2>&1
             $LASTEXITCODE | Should -Be 104
             $output | Should -BeNullOrEmpty
             $stderr | Should -HaveCount 3
@@ -176,7 +176,7 @@ Describe -Name "c8y errors" {
         }
 
         It "handles multiple errors in pipeline and when mode is not set properly" {
-            $stderr = $( $output = "", "" | c8y events create --type "c8y_TestAlarm" --force ) 2>&1
+            $stderr = $( $output = "0", "0" | c8y events create --type "c8y_TestAlarm" --force ) 2>&1
             $LASTEXITCODE | Should -Be 104
             $output | Should -BeNullOrEmpty
             $stderr | Should -HaveCount 3

--- a/tools/PSc8y/Tests/c8y/native.pipes.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/c8y/native.pipes.manual.Tests.ps1
@@ -81,6 +81,12 @@ Describe -Name "c8y pipes" {
     Context "Piping to collection commands" {
 
         It "ignores output when piping an empty string" {
+            $output = Write-Output "" -NoEnumerate | c8y alarms get --dry --dryFormat json
+            $LASTEXITCODE | Should -Be 4
+            $output | Should -BeNullOrEmpty
+        }
+
+        It "ignores output when piping an empty string" {
             $output = Write-Output "" -NoEnumerate | c8y alarms list --dry --dryFormat json
             $LASTEXITCODE | Should -Be 4
             $output | Should -BeNullOrEmpty

--- a/tools/PSc8y/Tests/c8y/select.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/c8y/select.manual.Tests.ps1
@@ -26,7 +26,9 @@ Describe -Name "c8y select global parameter" {
         $type = New-RandomString -Prefix "selectType"
         1..2 | c8y devices create --data "type=$type,text=value"
         3 | c8y devices create --data "type=$type"
+        Start-Sleep -Seconds 2  # Wait devices to be created
         $output = c8y devices list --type $type --select "name,id,text,type" --output csv
+        $output | Should -Not -BeNullOrEmpty
         c8y devices list --type $type | c8y devices delete
         $LASTEXITCODE | Should -Be 0
         $output = $output | Sort-Object


### PR DESCRIPTION
If piping an empty list of devices, the alarms list command will not send send any requests because the piped input is empty.

```sh
c8y devices list --name "doesnotexist" | c8y alarms list
```

Previously the above command would have sent an alarms api request with `/alarm/alarm` (without the `source=xx` query parameter set). This resulted in unexpected results for the user.