### PR TITLE
Install c8y binary to /usr/local/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,7 +88,7 @@ nfpms:
     license: MIT
     maintainer: Reuben Miller <reuben.d.miller@gmail.com>
     homepage: http://goc8ycli.netlify.app
-    bindir: /usr/local
+    bindir: /usr/local/bin
     description: Cumulocity's unofficial command line tool
     section: utils
     priority: optional


### PR DESCRIPTION
Fixing default c8y binary installation path to `/usr/local/bin`.