### PR TITLE
Feat/support delete device user

### DIFF
--- a/api/spec/json/agents.json
+++ b/api/spec/json/agents.json
@@ -158,12 +158,37 @@
               "$agent = PSc8y\\New-TestAgent"
             ],
             "command": "Remove-Agent -Id $agent.name"
+          },
+          {
+            "description": "Delete agent and related device user/credentials",
+            "skipTest": true,
+            "command": "Remove-Agent -Id \"agent01\" -WithDeviceUser"
           }
         ],
         "go": [
           {
             "description": "Get agent by id",
             "command": "c8y agents delete --id 12345"
+          },
+          {
+            "description": "Get agent by name",
+            "command": "c8y agents delete --id agent01",
+            "assertStdOut": {
+              "json": {
+                "path": "r//inventory/managedObjects/\\d+$"
+              }
+            }
+          },
+          {
+            "description": "Delete agent and related device user/credentials",
+            "command": "c8y agents delete --id 12345 --withDeviceUser",
+            "assertStdOut": {
+              "json": {
+                "method": "DELETE",
+                "path": "/inventory/managedObjects/12345",
+                "query": "withDeviceUser=true"
+              }
+            }
           }
         ]
       },
@@ -174,6 +199,20 @@
           "pipeline": true,
           "required": true,
           "description": "Agent ID"
+        }
+      ],
+      "queryParameters": [
+        {
+          "name": "withDeviceUser",
+          "type": "boolean",
+          "description": "Delete associated device owner",
+          "position": 11
+        },
+        {
+          "name": "cascade",
+          "type": "boolean",
+          "description": "Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group",
+          "position": 20
         }
       ]
     },

--- a/api/spec/json/devices.json
+++ b/api/spec/json/devices.json
@@ -158,12 +158,37 @@
               "$device = PSc8y\\New-TestDevice"
             ],
             "command": "Remove-Device -Id $device.name"
+          },
+          {
+            "description": "Delete device and related device user/credentials",
+            "skipTest": true,
+            "command": "Remove-Device -Id \"device01\" -WithDeviceUser"
           }
         ],
         "go": [
           {
             "description": "Get device by id",
             "command": "c8y devices delete --id 12345"
+          },
+          {
+            "description": "Get device by name",
+            "command": "c8y devices delete --id device01",
+            "assertStdOut": {
+              "json": {
+                "path": "r//inventory/managedObjects/\\d+$"
+              }
+            }
+          },
+          {
+            "description": "Delete device and related device user/credentials",
+            "command": "c8y devices delete --id 12345 --withDeviceUser",
+            "assertStdOut": {
+              "json": {
+                "method": "DELETE",
+                "path": "/inventory/managedObjects/12345",
+                "query": "withDeviceUser=true"
+              }
+            }
           }
         ]
       },
@@ -178,6 +203,12 @@
         }
       ],
       "queryParameters": [
+        {
+          "name": "withDeviceUser",
+          "type": "boolean",
+          "description": "Delete associated device owner",
+          "position": 11
+        },
         {
           "name": "cascade",
           "type": "boolean",

--- a/api/spec/yaml/agents.yaml
+++ b/api/spec/yaml/agents.yaml
@@ -119,10 +119,29 @@ endpoints:
           beforeEach:
             - $agent = PSc8y\New-TestAgent
           command: Remove-Agent -Id $agent.name
+        
+        - description: Delete agent and related device user/credentials
+          # Skipping as it requires a real device with credentials
+          skipTest: true
+          command: Remove-Agent -Id "agent01" -WithDeviceUser
 
       go:
         - description: Get agent by id
           command: c8y agents delete --id 12345
+        
+        - description: Get agent by name
+          command: c8y agents delete --id agent01
+          assertStdOut:
+            json:
+              path: r//inventory/managedObjects/\d+$
+
+        - description: Delete agent and related device user/credentials
+          command: c8y agents delete --id 12345 --withDeviceUser
+          assertStdOut:
+            json:
+              method: DELETE
+              path: /inventory/managedObjects/12345
+              query: withDeviceUser=true
 
     pathParameters:
       - name: id
@@ -130,6 +149,17 @@ endpoints:
         pipeline: true
         required: true
         description: Agent ID
+
+    queryParameters:
+      - name: withDeviceUser
+        type: boolean
+        description: Delete associated device owner
+        position: 11
+
+      - name: cascade
+        type: boolean
+        description: Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group
+        position: 20
 
   - name: createAgent
     description: 'Create agent'

--- a/api/spec/yaml/devices.yaml
+++ b/api/spec/yaml/devices.yaml
@@ -119,9 +119,28 @@ endpoints:
             - $device = PSc8y\New-TestDevice
           command: Remove-Device -Id $device.name
 
+        - description: Delete device and related device user/credentials
+          # Skipping as it requires a real device with credentials
+          skipTest: true
+          command: Remove-Device -Id "device01" -WithDeviceUser
+
       go:
         - description: Get device by id
           command: c8y devices delete --id 12345
+
+        - description: Get device by name
+          command: c8y devices delete --id device01
+          assertStdOut:
+            json:
+              path: r//inventory/managedObjects/\d+$
+
+        - description: Delete device and related device user/credentials
+          command: c8y devices delete --id 12345 --withDeviceUser
+          assertStdOut:
+            json:
+              method: DELETE
+              path: /inventory/managedObjects/12345
+              query: withDeviceUser=true
 
     pathParameters:
       - name: id
@@ -132,6 +151,11 @@ endpoints:
         position: 10
 
     queryParameters:
+      - name: withDeviceUser
+        type: boolean
+        description: Delete associated device owner
+        position: 11
+
       - name: cascade
         type: boolean
         description: Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group

--- a/pkg/cmd/agents/delete/delete.auto.go
+++ b/pkg/cmd/agents/delete/delete.auto.go
@@ -38,6 +38,12 @@ func NewDeleteCmd(f *cmdutil.Factory) *DeleteCmd {
 		Example: heredoc.Doc(`
 $ c8y agents delete --id 12345
 Get agent by id
+
+$ c8y agents delete --id agent01
+Get agent by name
+
+$ c8y agents delete --id 12345 --withDeviceUser
+Delete agent and related device user/credentials
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.DeleteModeEnabled()
@@ -48,6 +54,8 @@ Get agent by id
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Agent ID (required) (accepts pipeline)")
+	cmd.Flags().Bool("withDeviceUser", false, "Delete associated device owner")
+	cmd.Flags().Bool("cascade", false, "Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group")
 
 	completion.WithOptions(
 		cmd,
@@ -90,6 +98,8 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("withDeviceUser", "withDeviceUser", ""),
+		flags.WithBoolValue("cascade", "cascade", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/devices/delete/delete.auto.go
+++ b/pkg/cmd/devices/delete/delete.auto.go
@@ -37,6 +37,12 @@ func NewDeleteCmd(f *cmdutil.Factory) *DeleteCmd {
 		Example: heredoc.Doc(`
 $ c8y devices delete --id 12345
 Get device by id
+
+$ c8y devices delete --id device01
+Get device by name
+
+$ c8y devices delete --id 12345 --withDeviceUser
+Delete device and related device user/credentials
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.DeleteModeEnabled()
@@ -47,6 +53,7 @@ Get device by id
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device ID (required) (accepts pipeline)")
+	cmd.Flags().Bool("withDeviceUser", false, "Delete associated device owner")
 	cmd.Flags().Bool("cascade", false, "Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group")
 
 	completion.WithOptions(
@@ -90,6 +97,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("withDeviceUser", "withDeviceUser", ""),
 		flags.WithBoolValue("cascade", "cascade", ""),
 	)
 	if err != nil {

--- a/tests/auto/agents/tests/agents_delete.yaml
+++ b/tests/auto/agents/tests/agents_delete.yaml
@@ -1,4 +1,14 @@
 tests:
+    agents_delete_Delete agent and related device user/credentials:
+        command: c8y agents delete --id 12345 --withDeviceUser
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /inventory/managedObjects/12345
+                query: withDeviceUser=true
+            contains:
+                - withDeviceUser=true
     agents_delete_Get agent by id:
         command: c8y agents delete --id 12345
         exit-code: 0
@@ -6,3 +16,10 @@ tests:
             json:
                 method: DELETE
                 path: /inventory/managedObjects/12345
+    agents_delete_Get agent by name:
+        command: c8y agents delete --id agent01
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: r//inventory/managedObjects/\d+$

--- a/tests/auto/devices/tests/devices_delete.yaml
+++ b/tests/auto/devices/tests/devices_delete.yaml
@@ -1,4 +1,14 @@
 tests:
+    devices_delete_Delete device and related device user/credentials:
+        command: c8y devices delete --id 12345 --withDeviceUser
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /inventory/managedObjects/12345
+                query: withDeviceUser=true
+            contains:
+                - withDeviceUser=true
     devices_delete_Get device by id:
         command: c8y devices delete --id 12345
         exit-code: 0
@@ -6,3 +16,10 @@ tests:
             json:
                 method: DELETE
                 path: /inventory/managedObjects/12345
+    devices_delete_Get device by name:
+        command: c8y devices delete --id device01
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: r//inventory/managedObjects/\d+$

--- a/tests/scripts/setup.sh
+++ b/tests/scripts/setup.sh
@@ -15,6 +15,7 @@ setup () {
     create_user "benhologram@example.com"
     create_user "tomwillow@example.com"
 
+    create_agent "agent01"
     create_agent "device01"
     create_smartgroup "my smartgroup"
 

--- a/tests/scripts/setup.sh
+++ b/tests/scripts/setup.sh
@@ -15,6 +15,7 @@ setup () {
     create_user "benhologram@example.com"
     create_user "tomwillow@example.com"
 
+    create_agent "device01"
     create_smartgroup "my smartgroup"
 
     create_app "my-example-app"
@@ -45,6 +46,13 @@ create_smartgroup () {
         c8y smartgroups create \
             --name "$name" \
             --query "name eq '*'"
+}
+
+create_agent () {
+    local name="$1"
+    c8y agents get --id "$name" --silentStatusCodes 404 ||
+        c8y agents create \
+            --name "$name"
 }
 
 setup

--- a/tools/PSc8y/Public/Remove-Agent.ps1
+++ b/tools/PSc8y/Public/Remove-Agent.ps1
@@ -22,6 +22,11 @@ PS> Remove-Agent -Id $agent.name
 
 Remove agent by name
 
+.EXAMPLE
+PS> Remove-Agent -Id "agent01" -WithDeviceUser
+
+Delete agent and related device user/credentials
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,
@@ -29,12 +34,22 @@ Remove agent by name
     [Alias()]
     [OutputType([object])]
     Param(
+        # Delete associated device owner
+        [Parameter()]
+        [switch]
+        $WithDeviceUser,
+
         # Agent ID (required)
         [Parameter(Mandatory = $true,
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group
+        [Parameter()]
+        [switch]
+        $Cascade
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Delete"

--- a/tools/PSc8y/Public/Remove-Device.ps1
+++ b/tools/PSc8y/Public/Remove-Device.ps1
@@ -21,6 +21,11 @@ PS> Remove-Device -Id $device.name
 
 Remove device by name
 
+.EXAMPLE
+PS> Remove-Device -Id "device01" -WithDeviceUser
+
+Delete device and related device user/credentials
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,
@@ -34,6 +39,11 @@ Remove device by name
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
         $Id,
+
+        # Delete associated device owner
+        [Parameter()]
+        [switch]
+        $WithDeviceUser,
 
         # Remove all child devices and child assets will be deleted recursively. By default, the delete operation is propagated to the subgroups only if the deleted object is a group
         [Parameter()]

--- a/tools/PSc8y/Tests/Remove-Agent.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Remove-Agent.auto.Tests.ps1
@@ -6,13 +6,18 @@ Describe -Name "Remove-Agent" {
 
     }
 
-    It "Remove agent by id" {
+    It -Skip "Remove agent by id" {
         $Response = PSc8y\Remove-Agent -Id $agent.id
         $LASTEXITCODE | Should -Be 0
     }
 
-    It "Remove agent by name" {
+    It -Skip "Remove agent by name" {
         $Response = PSc8y\Remove-Agent -Id $agent.name
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It -Skip "Delete agent and related device user/credentials" {
+        $Response = PSc8y\Remove-Agent -Id "agent01" -WithDeviceUser
         $LASTEXITCODE | Should -Be 0
     }
 

--- a/tools/PSc8y/Tests/Remove-Device.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Remove-Device.auto.Tests.ps1
@@ -6,13 +6,18 @@ Describe -Name "Remove-Device" {
 
     }
 
-    It "Remove device by id" {
+    It -Skip "Remove device by id" {
         $Response = PSc8y\Remove-Device -Id $device.id
         $LASTEXITCODE | Should -Be 0
     }
 
-    It "Remove device by name" {
+    It -Skip "Remove device by name" {
         $Response = PSc8y\Remove-Device -Id $device.name
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It -Skip "Delete device and related device user/credentials" {
+        $Response = PSc8y\Remove-Device -Id "device01" -WithDeviceUser
         $LASTEXITCODE | Should -Be 0
     }
 


### PR DESCRIPTION
### Minor Changes

* `c8y devices delete`: Add `withDeviceUser` option to remove related device owner
* `c8y agents delete`: Add `withDeviceUser` and `cascade` options to remove related device owner and child devices (respectively)