### PR TITLE
Feat/bulkoperation list filter

### DIFF
--- a/api/spec/json/bulkOperations.json
+++ b/api/spec/json/bulkOperations.json
@@ -32,6 +32,16 @@
               "Get-BulkOperationCollection | Remove-BulkOperation",
               "Remove-DeviceGroup -Id $Group.id -Cascade"
             ]
+          },
+          {
+            "description": "Get a list of bulk operations created in the last 1 day",
+            "skipTest": true,
+            "command": "Get-BulkOperationCollection -DateFrom -1d"
+          },
+          {
+            "description": "Get a list of bulk operations in the general status SCHEDULED or EXECUTING",
+            "skipTest": true,
+            "command": "Get-BulkOperationCollection -Status SCHEDULED, EXECUTING"
           }
         ],
         "go": [

--- a/api/spec/json/bulkOperations.json
+++ b/api/spec/json/bulkOperations.json
@@ -38,6 +38,24 @@
           {
             "description": "Get a list of bulk operations",
             "command": "c8y bulkoperations list"
+          },
+          {
+            "description": "Get a list of bulk operations created in the last 1 day",
+            "command": "c8y bulkoperations list --dateFrom -1d",
+            "assertStdOut": {
+              "json": {
+                "query": "r/dateFrom=\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*$"
+              }
+            }
+          },
+          {
+            "description": "Get a list of bulk operations in the general status SCHEDULED or EXECUTING",
+            "command": "c8y bulkoperations list --status SCHEDULED --status EXECUTING",
+            "assertStdOut": {
+              "json": {
+                "query": "generalStatus=SCHEDULED&generalStatus=EXECUTING"
+              }
+            }
           }
         ]
       },
@@ -46,6 +64,29 @@
           "name": "withDeleted",
           "type": "boolean",
           "description": "Include CANCELLED bulk operations"
+        },
+        {
+          "name": "dateFrom",
+          "type": "datetime",
+          "description": "Start date or date and time of the bulk operation"
+        },
+        {
+          "name": "dateTo",
+          "type": "datetime",
+          "description": "End date or date and time of the bulk operation"
+        },
+        {
+          "name": "status",
+          "property": "generalStatus",
+          "type": "[]string",
+          "description": "Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING.",
+          "validationSet": [
+            "CANCELED",
+            "SCHEDULED",
+            "EXECUTING",
+            "EXECUTING_WITH_ERROR",
+            "FAILED"
+          ]
         }
       ]
     },

--- a/api/spec/yaml/bulkOperations.yaml
+++ b/api/spec/yaml/bulkOperations.yaml
@@ -32,11 +32,37 @@ endpoints:
       go:
         - description: Get a list of bulk operations
           command: c8y bulkoperations list
+        
+        - description: Get a list of bulk operations created in the last 1 day
+          command: c8y bulkoperations list --dateFrom -1d
+          assertStdOut:
+            json:
+              query: r/dateFrom=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*$
+        
+        - description: Get a list of bulk operations in the general status SCHEDULED or EXECUTING
+          command: c8y bulkoperations list --status SCHEDULED --status EXECUTING
+          assertStdOut:
+            json:
+              query: generalStatus=SCHEDULED&generalStatus=EXECUTING
 
     queryParameters:
       - name: withDeleted
         type: boolean
         description: Include CANCELLED bulk operations
+
+      - name: dateFrom
+        type: datetime
+        description: Start date or date and time of the bulk operation
+
+      - name: dateTo
+        type: datetime
+        description: End date or date and time of the bulk operation
+
+      - name: status
+        property: generalStatus
+        type: '[]string'
+        description: Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING.
+        validationSet: [CANCELED, SCHEDULED, EXECUTING, EXECUTING_WITH_ERROR, FAILED]
 
   - name: getBulkOperation
     description: Get bulk operation

--- a/api/spec/yaml/bulkOperations.yaml
+++ b/api/spec/yaml/bulkOperations.yaml
@@ -29,6 +29,14 @@ endpoints:
             - "Get-BulkOperationCollection | Remove-BulkOperation"
             - "Remove-DeviceGroup -Id $Group.id -Cascade"
 
+        - description: Get a list of bulk operations created in the last 1 day
+          skipTest: true
+          command: Get-BulkOperationCollection -DateFrom -1d
+        
+        - description: Get a list of bulk operations in the general status SCHEDULED or EXECUTING
+          skipTest: true
+          command: Get-BulkOperationCollection -Status SCHEDULED, EXECUTING
+
       go:
         - description: Get a list of bulk operations
           command: c8y bulkoperations list

--- a/tests/auto/bulkoperations/tests/bulkoperations_list.yaml
+++ b/tests/auto/bulkoperations/tests/bulkoperations_list.yaml
@@ -6,3 +6,24 @@ tests:
             json:
                 method: GET
                 path: /devicecontrol/bulkoperations
+    bulkOperations_list_Get a list of bulk operations created in the last 1 day:
+        command: c8y bulkoperations list --dateFrom -1d
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /devicecontrol/bulkoperations
+                query: r/dateFrom=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*$
+            contains:
+                - dateFrom=
+    bulkOperations_list_Get a list of bulk operations in the general status SCHEDULED or EXECUTING:
+        command: c8y bulkoperations list --status SCHEDULED --status EXECUTING
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /devicecontrol/bulkoperations
+                query: generalStatus=SCHEDULED&generalStatus=EXECUTING
+            contains:
+                - generalStatus=SCHEDULED
+                - generalStatus=EXECUTING

--- a/tools/PSc8y/Public/Get-BulkOperationCollection.ps1
+++ b/tools/PSc8y/Public/Get-BulkOperationCollection.ps1
@@ -25,7 +25,23 @@ Get a list of bulk operations
         # Include CANCELLED bulk operations
         [Parameter()]
         [switch]
-        $WithDeleted
+        $WithDeleted,
+
+        # Start date or date and time of the bulk operation
+        [Parameter()]
+        [string]
+        $DateFrom,
+
+        # End date or date and time of the bulk operation
+        [Parameter()]
+        [string]
+        $DateTo,
+
+        # Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING.
+        [Parameter()]
+        [ValidateSet('CANCELED','SCHEDULED','EXECUTING','EXECUTING_WITH_ERROR','FAILED')]
+        [string[]]
+        $Status
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-BulkOperationCollection.ps1
+++ b/tools/PSc8y/Public/Get-BulkOperationCollection.ps1
@@ -15,6 +15,16 @@ PS> Get-BulkOperationCollection
 
 Get a list of bulk operations
 
+.EXAMPLE
+PS> Get-BulkOperationCollection -DateFrom -1d
+
+Get a list of bulk operations created in the last 1 day
+
+.EXAMPLE
+PS> Get-BulkOperationCollection -Status SCHEDULED, EXECUTING
+
+Get a list of bulk operations in the general status SCHEDULED or EXECUTING
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,

--- a/tools/PSc8y/Tests/Get-BulkOperationCollection.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Get-BulkOperationCollection.auto.Tests.ps1
@@ -7,8 +7,20 @@ Describe -Name "Get-BulkOperationCollection" {
 
     }
 
-    It "Get a list of bulk operations" {
+    It -Skip "Get a list of bulk operations" {
         $Response = PSc8y\Get-BulkOperationCollection
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It -Skip "Get a list of bulk operations created in the last 1 day" {
+        $Response = PSc8y\Get-BulkOperationCollection -DateFrom -1d
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It -Skip "Get a list of bulk operations in the general status SCHEDULED or EXECUTING" {
+        $Response = PSc8y\Get-BulkOperationCollection -Status SCHEDULED, EXECUTING
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
`c8y bulkoperations list`: Add `dateFrom`, `dateTo` and `status` (generalStatus) flags.

Example: Get a list of bulk operations in the general status SCHEDULED or EXECUTING

```sh
$ c8y bulkoperations list --status SCHEDULED --status EXECUTING
```