### PR TITLE
Feat/read baseurl env

### DIFF
--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -18,6 +18,25 @@ import (
 	"github.com/spf13/viper"
 )
 
+var EnvCumulocityHostNames = []string{
+	"C8Y_HOST",
+	"C8Y_BASEURL",
+	"C8Y_URL",
+}
+
+// GetHostFromEnvironment gets the first non-empty host environment variable value
+// as Cumulocity uses different environment variable names for different tooling
+func GetHostFromEnvironment() string {
+	var value = ""
+	for _, name := range EnvCumulocityHostNames {
+		value = os.Getenv(name)
+		if value != "" {
+			break
+		}
+	}
+	return value
+}
+
 func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password string, disableEncryptionCheck bool) func() (*c8y.Client, error) {
 	return func() (*c8y.Client, error) {
 		cfg, err := f.Config()
@@ -73,10 +92,11 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 		}
 
 		c8yURL := cfg.GetHost()
-		if c8yURL == "" && os.Getenv("C8Y_HOST") != "" {
+		c8yURLFromEnv := GetHostFromEnvironment()
+		if c8yURL == "" && c8yURLFromEnv != "" {
 			// Get url from env variable if it is empty
-			log.Debugf("Using URL ")
-			c8yURL = os.Getenv("C8Y_HOST")
+			log.Debugf("Using URL from env variable. %s", c8yURLFromEnv)
+			c8yURL = c8yURLFromEnv
 		}
 
 		client := c8y.NewClient(

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -240,8 +240,8 @@ func (r *RequestHandler) PrintRequestDetails(w io.Writer, requestOptions *c8y.Re
 
 	details := &RequestDetails{
 		URL:         fullURL,
-		Host:        req.URL.Scheme + "://" + req.URL.Hostname(),
-		PathEncoded: strings.Replace(fullURL, req.URL.Scheme+"://"+req.URL.Hostname(), "", 1),
+		Host:        req.URL.Scheme + "://" + req.URL.Host, // Include host port number
+		PathEncoded: strings.Replace(fullURL, req.URL.Scheme+"://"+req.URL.Host, "", 1),
 		Method:      req.Method,
 		Headers:     headers,
 		Query:       tryUnescapeURL(req.URL.RawQuery),

--- a/tests/manual/sessions/env.yaml
+++ b/tests/manual/sessions/env.yaml
@@ -1,0 +1,4 @@
+tests:
+    It inherits credentials from microservice environment variables:
+        command: manual/sessions/inherit_env.sh
+        exit-code: 0

--- a/tests/manual/sessions/inherit_env.sh
+++ b/tests/manual/sessions/inherit_env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+export C8Y_SESSION=
+export C8Y_HOST=
+export C8Y_USERNAME=
+export C8Y_PASSWORD=
+
+export C8Y_USERNAME=dummyuser
+export C8Y_PASSWORD=dummypassword
+export C8Y_BASEURL=http://127.0.0.1:5000
+export C8Y_SETTINGS_DEFAULTS_DRYFORMAT=json
+export C8Y_SETTINGS_DEFAULTS_DRY=true
+
+fail () {
+    echo "$1"
+    exit 1
+}
+
+# Session should not throw an error
+[[ $( c8y sessions get ) ]] || fail "Session should not thrown an error"
+
+# API calls should also work
+resp=$( c8y inventory get --id 12345 )
+
+[[ "$(echo "$resp" | c8y util show --select host --output csv )" == "$C8Y_BASEURL" ]] || fail "url did not match"
+[[ "$(echo "$resp" | c8y util show --select pathEncoded --output csv )" == "/inventory/managedObjects/12345" ]] || fail "pathEncoded did not match"


### PR DESCRIPTION
* Support reading Cumulocity host url from the `C8Y_BASEURL` environment variable to better support microservice development
* Fix dry run output fields `host` and `pathEncoded` when host contains a port number