### PR TITLE
Feat/api url template

### DIFF
--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -83,7 +83,8 @@ func NewSubCommand(f *cmdutil.Factory) *CmdAPI {
 		cmd,
 		flags.WithData(),
 		flags.WithTemplate(),
-		flags.WithExtendedPipelineSupport("url", "url", false, "self", "responseSelf"),
+		// Include device management url links (configuration dump, firmware and software)
+		flags.WithExtendedPipelineSupport("url", "url", false, "url", "c8y_Firmware.url", "c8y_Software.url", "self", "responseSelf"),
 	)
 
 	completion.WithOptions(

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -1,0 +1,57 @@
+tests:
+    It sends an api request using a static URL and reference input in the body template:
+        command: >
+          echo "12345" | c8y api POST "/test/endpoint" --template "{value: input.value}" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /test/endpoint
+                body.value: "12345"
+    
+    It sends a POST request using a dynamic url:
+        command: >
+          echo "12345" | c8y api POST "/test/{url}/endpoint" --template "{value: input.value}" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /test/12345/endpoint
+                body.value: "12345"
+    
+    It sends a POST request using explicit url parameter:
+        command: >
+          echo "12345" | c8y api POST --url "/test/{url}/endpoint" --template "{value: input.value}" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /test/12345/endpoint
+                body.value: "12345"
+    
+    It sends a PUT request using piped json:
+        command: >
+          echo "{\"url\": \"12345\", \"name\":\"hello\"}" | c8y api --method PUT --url "/test/{url}/endpoint" --template "input.value" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: PUT
+                path: /test/12345/endpoint
+                body.name: "hello"
+                body.url: "12345"
+
+    It sends a custom create alarm command:
+        command: >
+          c8y api POST "alarm/alarms" --data "text=one,severity=MAJOR,type=test_Type,time=2019-01-01,source.id='12345'" --keepProperties --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /alarm/alarms
+                body.text: "one"
+                body.severity: "MAJOR"
+                body.type: "test_Type"
+                body.time: "2019-01-01"
+                body.source.id: "12345"
+
+                

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -39,6 +39,28 @@ tests:
                 path: /test/12345/endpoint
                 body.name: "hello"
                 body.url: "12345"
+    
+    It sends a PUT request using piped json and a format style url template:
+        command: >
+          echo "{\"url\": \"12345\", \"name\":\"hello\"}" | c8y api --method PUT --url "/test/%s/endpoint" --template "input.value" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: PUT
+                path: /test/12345/endpoint
+                body.name: "hello"
+                body.url: "12345"
+    
+    It sends a PUT request using piped json and a format style url template with multiple substitutions:
+        command: >
+          echo "{\"url\": \"12345\", \"name\":\"hello\"}" | c8y api --method PUT --url "/test/%s/endpoint/%s" --template "input.value" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: PUT
+                path: /test/12345/endpoint/12345
+                body.name: "hello"
+                body.url: "12345"
 
     It sends a custom create alarm command:
         command: >


### PR DESCRIPTION
Improving usefulness of `c8y api` command by allowing the user to specify a url template string

## supporting fixed template string for url

The user can specify a custom string where "%s" will be replaced with the current input value. Or the user can choose to use a fixed string.

### Examples

#### Using a fixed url

```sh
echo "1234" | c8y api POST "/test" --template "{id: input.value}"
=> POST /test
=> {"id":"1234"}
```

#### Use a string template where %s will be replaced with the piped input value

```sh
echo "1234" | c8y api POST "/test/%s" --template "{id: input.value}"
=> POST /test/1234
=> {"id":"1234"}
```

## detecting url from additional json properties: url, c8y_Firwmare.url and c8y_Software.url

The `c8y api` command will automatically map the new properties if the piped input contains any of the fields. The first property found will be used.

### Examples

#### Find configuration dumps (managed object) and download the binary (printing content to the console)

```sh
c8y inventory find --query "type eq 'c8y_ConfigurationDump'" | c8y api
```
