### PR TITLE
Feat/inventory assert filter

### DIFF
--- a/pkg/cmd/inventory/assert/exists.manual.go
+++ b/pkg/cmd/inventory/assert/exists.manual.go
@@ -38,7 +38,7 @@ func NewCmdAssert(f *cmdutil.Factory) *CmdAssert {
 		Use:   "assert",
 		Short: "Assert existance of a managed object",
 		Long: heredoc.Doc(`
-			Assert that a managed objects exists or not and if it matches then pass input object
+			Assert that a managed objects exists or not and pass input untouched
 
 			If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
 			This is useful if you want to filter a list of managed objects by whether they exist or not in the platform, and use the results

--- a/pkg/cmd/inventory/assert/exists.manual.go
+++ b/pkg/cmd/inventory/assert/exists.manual.go
@@ -1,0 +1,171 @@
+package assert
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/c8ywaiter"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmderrors"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/pkg/desiredstate"
+	"github.com/reubenmiller/go-c8y-cli/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/pkg/jsonUtilities"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type CmdAssert struct {
+	*subcommand.SubCommand
+
+	negate  bool
+	exists  bool
+	retries int64
+
+	factory *cmdutil.Factory
+}
+
+func NewCmdAssert(f *cmdutil.Factory) *CmdAssert {
+	ccmd := &CmdAssert{
+		factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "assert",
+		Short: "Assert existance of a managed object",
+		Long: heredoc.Doc(`
+			Assert that a managed objects exists or not and if it matches then pass input object
+
+			If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
+			This is useful if you want to filter a list of managed objects by whether they exist or not in the platform, and use the results
+			in some downstream command (in the pipeline)
+		`),
+		Example: heredoc.Doc(`
+			$ c8y inventory assert --exists --id 1234
+			# Assert the managed object exists
+
+			$ echo "1111" | c8y inventory assert --exists
+			# Pass the piped input only on if the ids exists as a managed object
+
+			$ echo -e "1111\n2222" | c8y inventory assert --not --exists
+			# Only select the managed object ids which do not exist
+		`),
+		RunE: ccmd.RunE,
+	}
+
+	cmd.SilenceUsage = true
+
+	cmd.Flags().String("id", "", "Inventory id (required) (accepts pipeline)")
+	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
+	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
+	cmd.Flags().Int64Var(&ccmd.retries, "retries", 0, "Interval to check on the status, i.e. 10s or 1min")
+	cmd.Flags().BoolVar(&ccmd.negate, "not", false, "Negate the match")
+	cmd.Flags().BoolVar(&ccmd.exists, "exists", true, "Assert the existance")
+	flags.WithOptions(
+		cmd,
+		flags.WithExtendedPipelineSupport("id", "id", true, "deviceId", "source.id", "managedObject.id", "id"),
+	)
+
+	completion.WithOptions(
+		cmd,
+	)
+
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+func (n *CmdAssert) RunE(cmd *cobra.Command, args []string) error {
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return err
+	}
+	client, err := n.factory.Client()
+	if err != nil {
+		return err
+	}
+
+	consol, err := n.factory.Console()
+	if err != nil {
+		return err
+	}
+
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
+	if err != nil {
+		return err
+	}
+
+	interval, err := flags.GetDurationFlag(cmd, "interval", true, time.Second)
+	if err != nil {
+		return err
+	}
+
+	timeout, err := flags.GetDurationFlag(cmd, "timeout", true, time.Second)
+	if err != nil {
+		return err
+	}
+
+	// path parameters
+	path := flags.NewStringTemplate("{id}")
+	err = flags.WithPathParameters(
+		cmd,
+		path,
+		inputIterators,
+		flags.WithStringValue("id", "id"),
+	)
+	if err != nil {
+		return err
+	}
+
+	state := &c8ywaiter.InventoryExistance{
+		Client: client,
+		Negate: n.negate,
+	}
+
+	totalErrors := 0
+	var lastErr error
+	for {
+		itemID, input, inputErr := path.Execute(false)
+
+		if inputErr == io.EOF {
+			break
+		}
+
+		if totalErrors >= cfg.AbortOnErrorCount() {
+			msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
+			return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
+		}
+
+		state.ID = itemID
+		result, err := desiredstate.WaitForWithRetries(n.retries, interval, timeout, state)
+
+		if v, ok := result.(*c8y.ManagedObject); ok {
+			_ = n.factory.WriteJSONToConsole(cfg, cmd, "", []byte(v.Item.Raw))
+		} else {
+			if err == nil {
+				switch v := input.(type) {
+				case []byte:
+					if jsonUtilities.IsJSONObject(v) {
+						_ = n.factory.WriteJSONToConsole(cfg, cmd, "", v)
+					} else {
+						fmt.Fprintf(consol, "%s\n", v)
+					}
+				}
+			}
+		}
+
+		if err != nil && !strings.Contains(err.Error(), "Max retries exceeded") {
+			totalErrors++
+			cfg.Logger.Infof("%s", err)
+			lastErr = err
+		}
+	}
+	if totalErrors > 0 {
+		return lastErr
+	}
+	return nil
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -37,6 +37,7 @@ import (
 	identityCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/identity"
 	inventoryCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/inventory"
 	inventoryAdditionsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/inventory/additions"
+	inventoryAssertCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/inventory/assert"
 	inventoryAssetsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/inventory/assets"
 	inventoryFindCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/inventory/find"
 	inventorySubscribeCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/inventory/subscribe"
@@ -307,6 +308,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	inventory.AddCommand(inventoryAdditionsCmd.NewSubCommand(f).GetCommand())
 	inventory.AddCommand(inventoryAssetsCmd.NewSubCommand(f).GetCommand())
 	inventory.AddCommand(inventoryWaitCmd.NewCmdWait(f).GetCommand())
+	inventory.AddCommand(inventoryAssertCmd.NewCmdAssert(f).GetCommand())
 	cmd.AddCommand(inventory)
 
 	// applications

--- a/pkg/desiredstate/desiredstate.go
+++ b/pkg/desiredstate/desiredstate.go
@@ -46,7 +46,7 @@ func WaitFor(interval time.Duration, timeout time.Duration, predicate StateDefin
 	for {
 		select {
 		case <-timeoutCh:
-			return lastValue, cmderrors.NewUserErrorWithExitCode(cmderrors.ExitTimeout, fmt.Sprintf("Timeout after %d second/s", int64(timeout/time.Second)))
+			return lastValue, cmderrors.NewUserErrorWithExitCode(cmderrors.ExitTimeout, fmt.Sprintf("Timeout after %v", timeout))
 
 		case msg := <-valueCh:
 			if err, ok := msg.(error); ok {

--- a/tests/manual/inventory/assert/001_assert.sh
+++ b/tests/manual/inventory/assert/001_assert.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eou pipefail
+
+mo_id=$( c8y inventory create -n --select id --output csv )
+cleanup () {
+    c8y inventory delete --id $mo_id > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "$mo_id" | c8y inventory assert --exists | grep "^${mo_id}$"
+
+# Combine with a c8y get Pipe json objects
+echo "$mo_id" | c8y inventory get | c8y inventory assert --exists --select id --output csv | grep "^${mo_id}$"

--- a/tests/manual/inventory/assert/inventory_assert.yaml
+++ b/tests/manual/inventory/assert/inventory_assert.yaml
@@ -1,0 +1,32 @@
+tests:
+    It filters a single id that does not exist:
+        command: echo "1" | c8y inventory assert --not --exists
+        exit-code: 0
+        stdout:
+            exactly: '1'
+    
+    It filters multiple ids given in a list:
+        command: echo "1\n2" | c8y inventory assert --not --exists
+        exit-code: 0
+        stdout:
+            line-count: 2
+            lines:
+              1: '1'
+              2: '2'
+
+    It filters a list of json objects:
+        command: >
+          echo "{\"id\":\"1\"}" | c8y inventory assert --not --exists
+        exit-code: 0
+        stdout:
+            json:
+                id: '1'
+    
+    It asserts that a mo exists and passes it through untouched:
+        command: manual/inventory/assert/001_assert.sh
+        exit-code: 0
+    
+    It checks if a managed object exists, and then uses a downstream command to safely get a value:
+        command: >
+          echo "1" | c8y inventory assert --exists | c8y inventory get
+        exit-code: 0


### PR DESCRIPTION
**Description**

From a list of devices or managed objects, allow the user to either only select the ids that exist or do not exist. The filter does not throw an error if the ID does not match the assertion.

**Use-case**

The user has a list of managed object ids and they want to only select the ids which no longer exist so that they can use each non-existent ID in a custom downstream api call.

```sh
cat id.list | c8y inventory assert --not -exists | c8y api /service/remove_from_cache --template "{id: input.value}"
```

**Command**

```sh
c8y inventory assert
```

**Examples**

```sh
$ c8y inventory assert --exists --id 1234
# => 1234 (if the ID exists)
# => <no response> (if the ID does not exist)
# Assert the managed object exists

$ echo "1111" | c8y inventory assert --exists
# Pass the piped input only on if the ids exists as a managed object

$ echo -e "1111\n2222" | c8y inventory assert --not --exists
# Only select the managed object ids which do not exist
```