### PR TITLE
add externalId and name to pipable properties for c8y identity delete

### DIFF
--- a/api/spec/json/identity.json
+++ b/api/spec/json/identity.json
@@ -110,7 +110,12 @@
           "type": "string",
           "required": true,
           "pipeline": true,
-          "description": "External identity id/name"
+          "description": "External identity id/name",
+          "pipelineAliases": [
+            "externalId",
+            "name",
+            "id"
+          ]
         }
       ]
     },
@@ -159,7 +164,12 @@
           "type": "string",
           "required": true,
           "pipeline": true,
-          "description": "External identity id/name"
+          "description": "External identity id/name",
+          "pipelineAliases": [
+            "externalId",
+            "name",
+            "id"
+          ]
         }
       ]
     },

--- a/api/spec/yaml/identity.yaml
+++ b/api/spec/yaml/identity.yaml
@@ -88,6 +88,10 @@ endpoints:
         required: true
         pipeline: true
         description: External identity id/name
+        pipelineAliases:
+          - externalId
+          - name
+          - id
 
   - name: deleteExternalID
     description: Delete external id
@@ -123,6 +127,10 @@ endpoints:
         required: true
         pipeline: true
         description: External identity id/name
+        pipelineAliases:
+          - externalId
+          - name
+          - id
 
   - name: newExternalID
     method: POST

--- a/pkg/cmd/identity/delete/delete.auto.go
+++ b/pkg/cmd/identity/delete/delete.auto.go
@@ -55,7 +55,7 @@ Delete external identity
 		cmd,
 		flags.WithProcessingMode(),
 
-		flags.WithExtendedPipelineSupport("name", "name", true, "id"),
+		flags.WithExtendedPipelineSupport("name", "name", true, "externalId", "name", "id"),
 	)
 
 	// Required flags

--- a/pkg/cmd/identity/get/get.auto.go
+++ b/pkg/cmd/identity/get/get.auto.go
@@ -56,7 +56,7 @@ Get external identity
 	flags.WithOptions(
 		cmd,
 
-		flags.WithExtendedPipelineSupport("name", "name", true, "id"),
+		flags.WithExtendedPipelineSupport("name", "name", true, "externalId", "name", "id"),
 	)
 
 	// Required flags


### PR DESCRIPTION
**Command**

```sh
c8y identity delete
```

**Example**

```sh
c8y devices list --name "exdemo*" | c8y identity list --filter "type eq example" | c8y identity delete --dry
```

One liner:
`c8y identity delete`:  Add `externalId` and `name` to pipeline aliases for the `name` flag