### PR TITLE
fixing early return after processing the --data flag

### DIFF
--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -180,7 +180,6 @@ func WithBody(cmd *cobra.Command, body *mapbuilder.MapBuilder, inputIterators *R
 			if v != nil {
 				if name != "" {
 					err = body.Set(name, v)
-					return err
 				} else {
 					body.SetOptionalMap(v)
 				}

--- a/tests/auto/bulkoperations/tests/bulkoperations_create.yaml
+++ b/tests/auto/bulkoperations/tests/bulkoperations_create.yaml
@@ -12,7 +12,7 @@ tests:
             contains:
                 - '"startDate":'
     bulkOperations_create_Create bulk operation for a group (using pipeline):
-        command: $TEST_SHELL -c 'c8y devicegroups get --id 12345 | c8y bulkoperations create --startDate "10s" --creationRampSec 15 --operation "c8y_Restart={}"'
+        command: $TEST_SHELL -c 'cat ./testdata/c8y.devicegroups.get.json | c8y bulkoperations create --startDate "10s" --creationRampSec 15 --operation "c8y_Restart={}"'
         exit-code: 0
         stdout:
             json:

--- a/tests/manual/bulkoperations/bulkoperations.yaml
+++ b/tests/manual/bulkoperations/bulkoperations.yaml
@@ -8,6 +8,18 @@ tests:
                 method: PUT
                 path: /devicecontrol/bulkoperations/12345
                 body.creationRamp: "1.2"
+    
+    It uses default values:
+        command: >
+            c8y bulkoperations create --group 1234 --operation "{}" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /devicecontrol/bulkoperations
+                body.creationRamp: "1"
+                body.groupId: '1234'
+                body.startDate: r/\d+
 
     Explicit time argument overwrites template value:
         command: >

--- a/tests/mocks.yaml
+++ b/tests/mocks.yaml
@@ -8,6 +8,7 @@ mocks:
     c8y users list: cat ./testdata/c8y.users.list.json
     c8y users get --id peterpi@example.com: cat ./testdata/c8y.users.get.json
     c8y bulkoperations list --filter "status eq IN_PROGRESS": cat ./testdata/c8y.bulkoperations.list.in_progress.json
+    c8y devicegroups get --id 12345: cat ./testdata/c8y.devicegroups.get.json
 
 files:
     myConfig.json: ./testdata/myConfig.json

--- a/tests/testdata/c8y.devicegroups.get.json
+++ b/tests/testdata/c8y.devicegroups.get.json
@@ -1,0 +1,1 @@
+{"c8y_IsDeviceGroup":{},"id":"12345","name":"group1","owner":"ciuser01","type":"c8y_DeviceGroup"}

--- a/tools/PSc8y/Public-manual/New-TestDeviceGroup.ps1
+++ b/tools/PSc8y/Public-manual/New-TestDeviceGroup.ps1
@@ -76,7 +76,7 @@ Create a test device group with 10 newly created devices
         
         if ($TotalDevices -gt 0) {
             for ($i = 0; $i -lt $TotalDevices; $i++) {
-                $iDevice = PSc8y\New-TestAgent -Force
+                $iDevice = PSc8y\New-TestAgent -Force -AsPSObject
                 $null = PSc8y\Add-AssetToGroup -Group $Group.id -NewChildDevice $iDevice.id -Force
             }
         }


### PR DESCRIPTION
Flags placed after `--data` or `--operation` or default values (set via the command definition), where being ignored due to an accidental return statement after processing the flag.

i.e. from the documentation, the `c8y bulkoperations create` command should have default values for `startDate` and `creationRamp`, however these values were not being applied due to the processing stopping after `--operation`

Now the following command works as documented:

```sh
c8y bulkoperations create --group 1234 --operation "c8y_Restart={}" --dry --dryFormat markdown
```

**Request body**

```json
{
  "creationRamp": 1,
  "groupId": "1234",
  "operationPrototype": {
    "c8y_Restart": {}
  },
  "startDate": "2021-09-15T06:26:42.928Z"
}
```