### PR TITLE
Adding delete external id example using pipeline

### DIFF
--- a/api/spec/json/identity.json
+++ b/api/spec/json/identity.json
@@ -142,12 +142,22 @@
               "Remove-ManagedObject -Id $Device.id"
             ],
             "command": "Remove-ExternalId -Type \"my_SerialNumber\" -Name \"myserialnumber2\""
+          },
+          {
+            "description": "Delete a specific external identity type (via pipeline)",
+            "command": "Get-DeviceCollection | Get-ExternalIdCollection -Filter 'type eq c8y_Serial' | Remove-ExternalId -Type c8y_Serial",
+            "skipTest": true
           }
         ],
         "go": [
           {
             "description": "Delete external identity",
             "command": "c8y identity delete --type test --name myserialnumber"
+          },
+          {
+            "description": "Delete a specific external identity type (via pipeline)",
+            "command": "c8y devices list | c8y identity list --filter 'type eq c8y_Serial' | c8y identity delete --type c8y_Serial",
+            "skipTest": true
           }
         ]
       },

--- a/api/spec/yaml/identity.yaml
+++ b/api/spec/yaml/identity.yaml
@@ -112,9 +112,18 @@ endpoints:
             - Remove-ManagedObject -Id $Device.id
           command: Remove-ExternalId -Type "my_SerialNumber" -Name "myserialnumber2"
 
+        - description: Delete a specific external identity type (via pipeline)
+          command: Get-DeviceCollection | Get-ExternalIdCollection -Filter 'type eq c8y_Serial' | Remove-ExternalId -Type c8y_Serial
+          skipTest: true
+
       go:
         - description: Delete external identity
           command: c8y identity delete --type test --name myserialnumber
+
+        - description: Delete a specific external identity type (via pipeline)
+          command: c8y devices list | c8y identity list --filter 'type eq c8y_Serial' | c8y identity delete --type c8y_Serial
+          skipTest: true
+
     pathParameters:
       - name: type
         type: string

--- a/pkg/cmd/identity/delete/delete.auto.go
+++ b/pkg/cmd/identity/delete/delete.auto.go
@@ -35,6 +35,9 @@ func NewDeleteCmd(f *cmdutil.Factory) *DeleteCmd {
 		Example: heredoc.Doc(`
 $ c8y identity delete --type test --name myserialnumber
 Delete external identity
+
+$ c8y devices list | c8y identity list --filter 'type eq c8y_Serial' | c8y identity delete --type c8y_Serial
+Delete a specific external identity type (via pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.DeleteModeEnabled()

--- a/tests/auto/identity/tests/identity_delete.yaml
+++ b/tests/auto/identity/tests/identity_delete.yaml
@@ -1,4 +1,12 @@
 tests:
+    identity_delete_Delete a specific external identity type (via pipeline):
+        command: $TEST_SHELL -c 'cat ./testdata/c8y.devices.list.json | c8y identity list --filter 'type eq c8y_Serial' | c8y identity delete --type c8y_Serial'
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                method: DELETE
+                path: /identity/externalIds/c8y_Serial/{name}
     identity_delete_Delete external identity:
         command: c8y identity delete --type test --name myserialnumber
         exit-code: 0

--- a/tools/PSc8y/Public/Remove-ExternalId.ps1
+++ b/tools/PSc8y/Public/Remove-ExternalId.ps1
@@ -15,6 +15,11 @@ PS> Remove-ExternalId -Type "my_SerialNumber" -Name "myserialnumber2"
 
 Delete external identity
 
+.EXAMPLE
+PS> Get-DeviceCollection | Get-ExternalIdCollection -Filter 'type eq c8y_Serial' | Remove-ExternalId -Type c8y_Serial
+
+Delete a specific external identity type (via pipeline)
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,

--- a/tools/PSc8y/Tests/Remove-ExternalId.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Remove-ExternalId.auto.Tests.ps1
@@ -7,8 +7,13 @@ Describe -Name "Remove-ExternalId" {
 
     }
 
-    It "Delete external identity" {
+    It -Skip "Delete external identity" {
         $Response = PSc8y\Remove-ExternalId -Type "my_SerialNumber" -Name "myserialnumber2"
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It -Skip "Delete a specific external identity type (via pipeline)" {
+        $Response = PSc8y\Get-DeviceCollection | Get-ExternalIdCollection -Filter 'type eq c8y_Serial' | Remove-ExternalId -Type c8y_Serial
         $LASTEXITCODE | Should -Be 0
     }
 


### PR DESCRIPTION
Adding example on how to delete a device's external id by chaining commands together

```sh
c8y devices list | c8y identity list --filter 'type eq c8y_Serial' | c8y identity delete --type c8y_Serial
```