### PR TITLE
[bugfix] Remove fragmentType from c8y alarms commands

### DIFF
--- a/api/spec/json/alarms.json
+++ b/api/spec/json/alarms.json
@@ -109,14 +109,14 @@
           "description": "When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED."
         },
         {
-          "name": "withAssets",
+          "name": "withSourceAssets",
           "type": "boolean",
-          "description": "Include assets"
+          "description": "When set to true also alarms for related source devices will be included in the request. When this parameter is provided a source must be specified."
         },
         {
-          "name": "withDevices",
+          "name": "withSourceDevices",
           "type": "boolean",
-          "description": "Include devices"
+          "description": "When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined."
         }
       ]
     },

--- a/api/spec/json/alarms.json
+++ b/api/spec/json/alarms.json
@@ -83,11 +83,6 @@
           "description": "Alarm type."
         },
         {
-          "name": "fragmentType",
-          "type": "string",
-          "description": "Alarm fragment type."
-        },
-        {
           "name": "status",
           "type": "string",
           "description": "Comma separated alarm statuses, for example ACTIVE,CLEARED.",
@@ -568,11 +563,6 @@
           "name": "type",
           "type": "string",
           "description": "Alarm type."
-        },
-        {
-          "name": "fragmentType",
-          "type": "string",
-          "description": "Alarm fragment type."
         },
         {
           "name": "status",

--- a/api/spec/yaml/alarms.yaml
+++ b/api/spec/yaml/alarms.yaml
@@ -64,10 +64,6 @@ endpoints:
         type: string
         description: Alarm type.
 
-      - name: fragmentType
-        type: string
-        description: Alarm fragment type.
-
       - name: status
         type: string
         description: Comma separated alarm statuses, for example ACTIVE,CLEARED.
@@ -393,10 +389,6 @@ endpoints:
       - name: type
         type: string
         description: 'Alarm type.'
-
-      - name: fragmentType
-        type: string
-        description: Alarm fragment type.
 
       - name: status
         type: string

--- a/api/spec/yaml/alarms.yaml
+++ b/api/spec/yaml/alarms.yaml
@@ -78,13 +78,13 @@ endpoints:
         type: boolean
         description: When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.
 
-      - name: withAssets
+      - name: withSourceAssets
         type: boolean
-        description: Include assets
+        description: When set to true also alarms for related source devices will be included in the request. When this parameter is provided a source must be specified.
 
-      - name: withDevices
+      - name: withSourceDevices
         type: boolean
-        description: Include devices
+        description: When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.
 
   - name: newAlarm
     method: POST

--- a/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
@@ -52,7 +52,6 @@ Remove alarms on the device which are active and created in the last 10 minutes
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of alarm occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of alarm occurrence.")
 	cmd.Flags().String("type", "", "Alarm type.")
-	cmd.Flags().String("fragmentType", "", "Alarm fragment type.")
 	cmd.Flags().String("status", "", "Comma separated alarm statuses, for example ACTIVE,CLEARED.")
 	cmd.Flags().String("severity", "", "Alarm severity, for example CRITICAL, MAJOR, MINOR or WARNING.")
 	cmd.Flags().Bool("resolved", false, "When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.")
@@ -106,7 +105,6 @@ func (n *DeleteCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithEncodedRelativeTimestamp("dateFrom", "dateFrom", ""),
 		flags.WithEncodedRelativeTimestamp("dateTo", "dateTo", ""),
 		flags.WithStringValue("type", "type"),
-		flags.WithStringValue("fragmentType", "fragmentType"),
 		flags.WithStringValue("status", "status"),
 		flags.WithStringValue("severity", "severity"),
 		flags.WithBoolValue("resolved", "resolved", ""),

--- a/pkg/cmd/alarms/list/list.auto.go
+++ b/pkg/cmd/alarms/list/list.auto.go
@@ -56,8 +56,8 @@ Get collection of active alarms which occurred in the last 10 minutes
 	cmd.Flags().String("status", "", "Comma separated alarm statuses, for example ACTIVE,CLEARED.")
 	cmd.Flags().String("severity", "", "Alarm severity, for example CRITICAL, MAJOR, MINOR or WARNING.")
 	cmd.Flags().Bool("resolved", false, "When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.")
-	cmd.Flags().Bool("withAssets", false, "Include assets")
-	cmd.Flags().Bool("withDevices", false, "Include devices")
+	cmd.Flags().Bool("withSourceAssets", false, "When set to true also alarms for related source devices will be included in the request. When this parameter is provided a source must be specified.")
+	cmd.Flags().Bool("withSourceDevices", false, "When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.")
 
 	completion.WithOptions(
 		cmd,
@@ -109,8 +109,8 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("status", "status"),
 		flags.WithStringValue("severity", "severity"),
 		flags.WithBoolValue("resolved", "resolved", ""),
-		flags.WithBoolValue("withAssets", "withAssets", ""),
-		flags.WithBoolValue("withDevices", "withDevices", ""),
+		flags.WithBoolValue("withSourceAssets", "withSourceAssets", ""),
+		flags.WithBoolValue("withSourceDevices", "withSourceDevices", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/alarms/list/list.auto.go
+++ b/pkg/cmd/alarms/list/list.auto.go
@@ -53,7 +53,6 @@ Get collection of active alarms which occurred in the last 10 minutes
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of alarm occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of alarm occurrence.")
 	cmd.Flags().String("type", "", "Alarm type.")
-	cmd.Flags().String("fragmentType", "", "Alarm fragment type.")
 	cmd.Flags().String("status", "", "Comma separated alarm statuses, for example ACTIVE,CLEARED.")
 	cmd.Flags().String("severity", "", "Alarm severity, for example CRITICAL, MAJOR, MINOR or WARNING.")
 	cmd.Flags().Bool("resolved", false, "When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.")
@@ -107,7 +106,6 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithEncodedRelativeTimestamp("dateFrom", "dateFrom", ""),
 		flags.WithEncodedRelativeTimestamp("dateTo", "dateTo", ""),
 		flags.WithStringValue("type", "type"),
-		flags.WithStringValue("fragmentType", "fragmentType"),
 		flags.WithStringValue("status", "status"),
 		flags.WithStringValue("severity", "severity"),
 		flags.WithBoolValue("resolved", "resolved", ""),

--- a/tools/PSc8y/Public/Get-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Get-AlarmCollection.ps1
@@ -53,11 +53,6 @@ Get active alarms from a device (using pipeline)
         [string]
         $Type,
 
-        # Alarm fragment type.
-        [Parameter()]
-        [string]
-        $FragmentType,
-
         # Comma separated alarm statuses, for example ACTIVE,CLEARED.
         [Parameter()]
         [ValidateSet('ACTIVE','ACKNOWLEDGED','CLEARED')]

--- a/tools/PSc8y/Public/Get-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Get-AlarmCollection.ps1
@@ -70,15 +70,15 @@ Get active alarms from a device (using pipeline)
         [switch]
         $Resolved,
 
-        # Include assets
+        # When set to true also alarms for related source devices will be included in the request. When this parameter is provided a source must be specified.
         [Parameter()]
         [switch]
-        $WithAssets,
+        $WithSourceAssets,
 
-        # Include devices
+        # When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.
         [Parameter()]
         [switch]
-        $WithDevices
+        $WithSourceDevices
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Remove-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Remove-AlarmCollection.ps1
@@ -53,11 +53,6 @@ Remove alarms on the device which are active and created in the last 10 minutes 
         [string]
         $Type,
 
-        # Alarm fragment type.
-        [Parameter()]
-        [string]
-        $FragmentType,
-
         # Comma separated alarm statuses, for example ACTIVE,CLEARED.
         [Parameter()]
         [ValidateSet('ACTIVE','ACKNOWLEDGED','CLEARED')]


### PR DESCRIPTION
* Remove `fragmentType` flag from `c8y alarms list` and `c8y alarms delete` as it was never supported by Cumulocity REST API
* Rename `c8y alarms list` flags
  * `withDevices` -> `withSourceDevices`
  * `withAssets` -> `withSourceAssets` 