### PR TITLE
Prevent duplicate query paramters when using iterators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ share/**
 docs/go-c8y-cli/build
 docs/go-c8y-cli/i18n
 tools/docs/demos/*.asc
+pkg/cmd/__debug_bin

--- a/pkg/requestiterator/requestiterator.go
+++ b/pkg/requestiterator/requestiterator.go
@@ -117,7 +117,8 @@ func (r *RequestIterator) GetNext() (*c8y.RequestOptions, interface{}, error) {
 			return nil, nil, err
 		}
 		inputLine = input
-		queryParts = append(queryParts, strings.ReplaceAll(string(q), " ", "+"))
+		// Override any existing query parts to prevent duplication
+		queryParts = append([]string{}, strings.ReplaceAll(string(q), " ", "+"))
 	}
 
 	if len(queryParts) > 0 {

--- a/tests/manual/common/common.yaml
+++ b/tests/manual/common/common.yaml
@@ -1,0 +1,34 @@
+tests:
+  ? It does not duplicate query parameters when combining iterators with other query parameters
+  : command: >
+      c8y events list --device 1 --fragmentType test1 --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        path: /event/events
+        pathEncoded: /event/events?fragmentType=test1&source=1
+
+  ? It does not duplicate query parameters when only fixed query parameters are used
+  : command: >
+      c8y events list --fragmentType test1 --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        path: /event/events
+        pathEncoded: /event/events?fragmentType=test1
+
+  It supports adding common query parameters with fixed:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_PAGESIZE: 21
+
+    command: >
+      c8y events list --fragmentType test1 --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        path: /event/events
+        pathEncoded: /event/events?fragmentType=test1&pageSize=21


### PR DESCRIPTION
Resolves #69. Duplicate query parameters are avoided when combining iterator flags with fixed flags