### PR TITLE
Feat/issue 72/support mixing iterators

### DIFF
--- a/pkg/iterator/override.go
+++ b/pkg/iterator/override.go
@@ -1,0 +1,58 @@
+package iterator
+
+import (
+	"io"
+	"reflect"
+)
+
+type OverrideIterator struct {
+	valueIterator Iterator
+	OverrideValue Iterator
+}
+
+// NewOverrideIterator create a new iterator which can be override with other values
+func NewOverrideIterator(valueIterator Iterator, overrideValue Iterator) *OverrideIterator {
+	return &OverrideIterator{
+		valueIterator: valueIterator,
+		OverrideValue: overrideValue,
+	}
+}
+
+// MarshalJSON return the value in a json compatible value
+func (i *OverrideIterator) MarshalJSON() (line []byte, err error) {
+	return MarshalJSON(i)
+}
+
+// IsBound return true if the iterator is bound
+func (i *OverrideIterator) IsBound() bool {
+	return true
+}
+
+func (i *OverrideIterator) GetNext() (value []byte, input interface{}, err error) {
+	if i.valueIterator == nil {
+		return nil, nil, io.EOF
+	}
+	value, rawValue, err := i.valueIterator.GetNext()
+
+	if err == io.EOF && len(value) > 0 {
+		// ignore EOF if the value is not empty
+		err = nil
+	}
+
+	// override the value if it is not nil
+	if i.OverrideValue != nil && !reflect.ValueOf(i.OverrideValue).IsNil() {
+		overrideValue, _, overrideErr := i.OverrideValue.GetNext()
+
+		if overrideErr != nil {
+			if i.valueIterator.IsBound() && overrideErr == io.EOF {
+				// ignore as the other iterator is bound, so let it control the loop
+			} else {
+				return overrideValue, rawValue, overrideErr
+			}
+		}
+		if len(overrideValue) > 0 {
+			value = overrideValue
+		}
+	}
+	return value, rawValue, err
+}

--- a/tests/manual/common/pipe.yaml
+++ b/tests/manual/common/pipe.yaml
@@ -1,0 +1,24 @@
+tests:
+  ? It supports piping json via stdin and using pipeline parameter with a fixed value
+  : command: >
+      echo "{\"other\":\"2\"}" | c8y alarms update --id 1 --dry --template input.value
+    exit-code: 0
+    stderr:
+      line-count: 0
+    stdout:
+      json:
+        path: /alarm/alarms/1
+        method: PUT
+        body.other: '2'
+
+  ? It supports overriding the pipeline argument in stdin with fixed parameters
+  : command: >
+      echo "{\"id\":\"2\"}" | c8y alarms update --id 1 --dry --template input.value
+    exit-code: 0
+    stderr:
+      line-count: 0
+    stdout:
+      json:
+        path: /alarm/alarms/1
+        method: PUT
+        body.id: '2'

--- a/tests/manual/common/pipe.yaml
+++ b/tests/manual/common/pipe.yaml
@@ -22,3 +22,15 @@ tests:
         path: /alarm/alarms/1
         method: PUT
         body.id: '2'
+  
+  ? It supports overriding the pipeline argument in stdin with plain string parameters
+  : command: >
+      echo "{\"name\":\"test02\"}" | c8y devices create --name test01 --dry --template input.value
+    exit-code: 0
+    stderr:
+      line-count: 0
+    stdout:
+      json:
+        path: /inventory/managedObjects
+        method: POST
+        body.name: 'test01'


### PR DESCRIPTION
Fixes #72. The mixing of stdin and fixed parameters (as detailed in a previous PR #68) is now extended to support `--id` parameters.

```sh
# ok
echo "{\"id\":\"2\",\"otherProps\":{}}" | c8y alarms update --dry --template input.value

# also supported ok
echo "{\"id\":\"2\",\"otherProps\":{}}" | c8y alarms update --id 1 --dry --template input.value
```