### PR TITLE
Feat/request caching

### DIFF
--- a/Proposals.md
+++ b/Proposals.md
@@ -3,6 +3,17 @@
 
 ## current todo
 
+### Caching
+
+* [x] Add cache management commands 
+  * [x] c8y cache delete
+  * [x] c8y cache renew
+* [x] Add global parameter to support cache and cacheTTL
+* [x] Option to cache specific api requests (i.e. GET, PUT, POST, DELETE)
+* [x] Settings management (c8y settings update )
+* [ ] Preload cache, how to calculate cache file location?
+* [x] Add powershell global parameters
+
 ## Bugs
 
 * Subscription tests are flakey

--- a/docs/go-c8y-cli/docs/concepts/caching.md
+++ b/docs/go-c8y-cli/docs/concepts/caching.md
@@ -5,15 +5,6 @@ title: Caching
 import CodeExample from '@site/src/components/CodeExample';
 import Video from '@site/src/components/video';
 
-## Demo
-
-<Video
-  videoSrcURL="https://asciinema.org/a/416566/embed?speed=1.0&autoplay=false&size=small&rows=30"
-  videoTitle="Views example"
-  width="90%"
-  height="550px"
-  ></Video>
-
 ## Overview
 
 Caching provides an easy way to reduce the number of requests sent to the server by caching the responses locally on disk.
@@ -34,6 +25,64 @@ c8y devices list --type "c8y_Linux" --cache
 echo agent01 | c8y util repeat 2 | c8y devices get --cache --cacheTTL 60s -v
 # => Control time-to-live for single commands 
 ```
+
+
+## Configuration
+
+Caching is disabled by default, and only set for `GET` https methods. However these defaults can be changed to suite your
+
+* Enabled/Disabled
+* Time-to-Live (TTL)
+* Cache key generation (include auth/host etc.)
+
+
+### defaults.cache: boolean
+
+Enable caching. Defaults to `false`.
+
+Caching can be turned on for individual commands by using the `--cache` global parameter.
+
+When the setting is activated, then all requests which match the `cache.methods` settings will be cached. Users can opt out of caching for individual commands by using the `--noCache` global parameter.
+
+### defaults.cacheTTL: string
+
+Cache time-to-live (TTL) settings to control the maximum age that a cached response. If the cached response is older than the TTL settings, then the cached item will be ignored.
+
+### cache.keyauth: boolean
+
+Include the request's Authorization header value when generating the cache key. Defaults to `true`.
+
+This can be useful if you want to share caching across multiple users. Normally the authorization header is used in the cache key generation, so the cached item will be a different file key for multiple users
+
+### cache.keyhost: boolean
+
+Include the host name when generating the cache key. Defaults to `true`.
+
+This can be useful when setting up a mock system where you want to fake server response by using cached response regardless of the server. This is a more advanced settings, so just ignore it if you don't understand it.
+
+### cache.methods: string
+
+Space separated list of HTTP methods which should be cached. By default only `GET` is configured.
+
+<CodeExample>
+
+# Enable more http methods to be cached
+c8y settings update cache.methods "GET PUT POST"
+
+</CodeExample>
+
+### cache.path: string
+
+Location of the cache directory. If the path does not exist it was be created when the first cached item is created.
+
+Defaults to:
+
+* Linux/MacOS: `{tmp}/go-c8y-cli-cache`, where `{tmp}` is set to `$TMPDIR` if not empty otherwise `/tmp`
+* Windows: `{tmp}/go-c8y-cli-cache`, where `{tmp}` is set to the first non-empty value of `%TMP%`, `%TEMP%`, `%USERPROFILE%`
+
+:::note
+If go-c8y-cli is being by multiple users on the same computer/server and you need to prevent users from accessing the local cached files, then you should change the default location of the cache, and apply the appropriate folder permissions to prevent other users from accessing the response from other users.
+:::
 
 ## Cache expiration
 
@@ -70,15 +119,85 @@ If you only want to cache for files which are only older than a time period, the
 c8y cache delete --age 1h
 ```
 
-### Performance improvements
+## Checking if a response is cached or not
 
-The performance increase of using caching can be easily demonstrated with a simple example.
+The cac
 
-Let's assume that you want to p
+```sh
+c8y devices list --cache -v
+c8y devices list --cache -v
+```
 
-```sh title="example.sh"
-#!/bin/bash
-echo agent01 | c8y util repeat 2 | c8y devices get --cache --cacheTTL 60s
+```sh title="output"
+√ go-c8y-cli % c8y devices list -p 1 --cache -v
+2021-09-27T05:50:24.723Z        INFO    Binding authorization environment variables
+2021-09-27T05:50:24.724Z        INFO    activityLog path: /home/vscode/.cumulocity/activitylog/c8y.activitylog.2021-09-27.json
+2021-09-27T05:50:24.727Z        INFO    Loaded session: /workspaces/go-c8y-cli/.cumulocity/example.json
+2021-09-27T05:50:24.728Z        INFO    command: c8y devices list -p 1 --cache -v 
+2021-09-27T05:50:24.733Z        INFO    Max jobs: 0
+2021-09-27T05:50:24.734Z        INFO    worker 1: started job 1
+2021-09-27T05:50:24.734Z        INFO    Current username: {tenant}/{username}
+2021-09-27T05:50:24.735Z        INFO    Headers: map[Accept:[application/json] Authorization:[Basic  {base64 tenant/username:password}] User-Agent:[go-client] X-Application:[go-client]]
+2021-09-27T05:50:24.735Z        INFO    Sending request: GET https://{host}/inventory/managedObjects?pageSize=1&q=$filter=+$orderby=name
+2021-09-27T05:50:24.735Z        INFO    Using cached response. file: /tmp/go-c8y-cli-cache/5a/f6/f2d746aba15b47d3f2dfc517c782f030bb28cfc1acca6fc3698ed532948b, age: 2.2051073s, ttl: 1m0s
+2021-09-27T05:50:24.735Z        INFO    Status code: 200
+2021-09-27T05:50:24.735Z        INFO    Response time: 0ms
+2021-09-27T05:50:24.735Z        INFO    Response Content-Type: application/vnd.com.nsn.cumulocity.managedobjectcollection+json;charset=UTF-8;ver=0.9
+2021-09-27T05:50:24.735Z        INFO    Response Length: 1.3KB
+2021-09-27T05:50:24.735Z        INFO    Unfiltered array size. len=1
+2021-09-27T05:50:24.736Z        INFO    View mode: auto
+2021-09-27T05:50:24.737Z        INFO    Detected view: id, name, type, owner, lastUpdated, c8y_Availability.status
+| id          | name            | type       | owner         | lastUpdated                   | c8y_availability.status |
+|-------------|-----------------|------------|---------------|-------------------------------|-------------------------|
+| 764806      | 74xsyz1veu      |            | ciuser01      | 2021-09-24T12:41:33.385Z      |                         |
+2021-09-27T05:50:24.738Z        INFO    worker 1: finished job 1 in 4ms
+```
+
+An additional line is included when a cached response is being used which shows the cache file being used along with the age and the time-to-live (TTL).
+
+```sh
+Using cached response. file: /tmp/go-c8y-cli-cache/5a/f6/f2d746aba15b47d3f2dfc517c782f030bb28cfc1acca6fc3698ed532948b, age: 2.2051073s, ttl: 1m0s
+```
+
+In addition, the activity log now has additional fields, `.cached` and `.etag` to show if the response was cached and the hashed key of the request. The `.responseTimeMS` is also a key indicator that a cached response is being used, as the response time is generally under 5 milliseconds when a cached response is being used as the response is being read from local disk instead of being sent to the server.
+
+```sh
+c8y activity log --dateFrom -5m | jq
+```
+
+```sh title="output"
+{
+  "accept": "application/json",
+  "cached": false,
+  "ctx": "qPgGLFHs",
+  "etag": "",
+  "host": "main.example.c8y.io",
+  "method": "GET",
+  "path": "/inventory/managedObjects",
+  "processingMode": "",
+  "query": "pageSize=1&q=$filter= $orderby=name",
+  "responseSelf": "https://t12345.example.c8y.io/inventory/managedObjects?q=$filter%3D%20$orderby%3Dname&pageSize=1&currentPage=1",
+  "responseTimeMS": 194,
+  "statusCode": 200,
+  "time": "2021-09-27T05:50:22.5373115Z",
+  "type": "request"
+}
+{
+  "accept": "application/json",
+  "cached": true,
+  "ctx": "kTtcTBBb",
+  "etag": "5af6f2d746aba15b47d3f2dfc517c782f030bb28cfc1acca6fc3698ed532948b",
+  "host": "main.example.c8y.io",
+  "method": "GET",
+  "path": "/inventory/managedObjects",
+  "processingMode": "",
+  "query": "pageSize=1&q=$filter= $orderby=name",
+  "responseSelf": "https://t12345.example.c8y.io/inventory/managedObjects?q=$filter%3D%20$orderby%3Dname&pageSize=1&currentPage=1",
+  "responseTimeMS": 0,
+  "statusCode": 200,
+  "time": "2021-09-27T05:50:24.735405Z",
+  "type": "request"
+}
 ```
 
 ## Usage
@@ -99,7 +218,7 @@ c8y alarms list
 # => Cached response is used
 ```
 
-Caching can be enabled or disabled for individual commands
+Or caching can be enabled or disabled for individual commands
 
 ```sh
 c8y devices list --cache

--- a/docs/go-c8y-cli/docs/concepts/caching.md
+++ b/docs/go-c8y-cli/docs/concepts/caching.md
@@ -1,0 +1,216 @@
+---
+title: Caching
+---
+
+import CodeExample from '@site/src/components/CodeExample';
+import Video from '@site/src/components/video';
+
+## Demo
+
+<Video
+  videoSrcURL="https://asciinema.org/a/416566/embed?speed=1.0&autoplay=false&size=small&rows=30"
+  videoTitle="Views example"
+  width="90%"
+  height="550px"
+  ></Video>
+
+## Overview
+
+Caching provides an easy way to reduce the number of requests sent to the server by caching the responses locally on disk.
+
+The responses from large requests can be cached so that when the same request is sent again (within the cache's time-to-live (TTL) setting), instead of sending the request to the server, the response is retrieved from file (assuming the cache has not expired). This improves the performance of repetitive queries by reusing already existing responses across commands.
+
+The caching works be intercepting every HTTP request and writing the HTTP response to file using a unique hash based on the URL, path, authorization header and body (if set).
+
+The commands can be cached via control via global parameters `cache`, `noCache` and `cacheTTL`
+
+```sh
+c8y devices list --type "c8y_Linux" --cache
+# => Sends a request to the server the first time
+
+c8y devices list --type "c8y_Linux" --cache
+# => A cached response is used as the same command is being used within the cache TTL
+
+echo agent01 | c8y util repeat 2 | c8y devices get --cache --cacheTTL 60s -v
+# => Control time-to-live for single commands 
+```
+
+## Cache expiration
+
+The cache's validity is controlled via a time-to-live (TTL) setting where if the cached file last modified time is older than the TTL setting, then the cached file is ignored and the request is sent to the server.
+
+
+### Renewing cache
+
+The cached files can be renewed (i.e. updating the last modified time to current timestamp).
+
+```sh
+c8y cache renew
+```
+
+Alternatively you can always just increase the time-to-live (TTL) cache to a value which should cover all of the cached items.
+
+```sh
+c8y devices list --cache --cacheTTL 30d
+```
+
+## Deleting cache
+
+The cache will grow from time to time as it is not actively deleted by go-c8y-cli during normal operation
+
+To delete the cache, run the following command
+
+```sh
+c8y cache delete
+```
+
+If you only want to cache for files which are only older than a time period, then the `age` parameter can be used: 
+
+```sh
+c8y cache delete --age 1h
+```
+
+### Performance improvements
+
+The performance increase of using caching can be easily demonstrated with a simple example.
+
+Let's assume that you want to p
+
+```sh title="example.sh"
+#!/bin/bash
+echo agent01 | c8y util repeat 2 | c8y devices get --cache --cacheTTL 60s
+```
+
+## Usage
+
+### Enable/disable for individual commands
+
+The cache is controlled via the global `cache/noCache` parameter. The global parameter can also be set via the configuration.
+
+```sh
+# Enable permanent caching by updating session settings
+c8y settings update defaults.cache true
+c8y settings update defaults.cacheTTL 10m
+
+c8y alarms list
+# => Sends a response the first time, then caches the response
+
+c8y alarms list
+# => Cached response is used
+```
+
+Caching can be enabled or disabled for individual commands
+
+```sh
+c8y devices list --cache
+# => Enable caching
+
+c8y devices list --noCache
+# => Disable caching
+```
+
+## Using in scripts
+
+Caching can be helpful in scripts to reduce the amount of code to write an efficient script, as you don't need to save the whole command response to variables, you can just reuse the same command with the `--cache` parameter and let go-c8y-cli look after it for you.
+
+### Retrieving list of devices
+
+
+
+```sh title="./operation-summary.sh"
+#!/bin/bash
+
+export C8Y_SETTINGS_CI=true
+export C8Y_SETTINGS_DEFAULTS_CACHE=true
+export C8Y_SETTINGS_DEFAULTS_CACHETTL=30m
+
+#
+# Perform some task (i.e. gather statistics)
+#
+input_file="$1"
+
+while read name; do
+
+    # Note. c8y devices get will use cache so no need to assign it to a variable.
+    echo -n "Operation Summary: Device - "
+    echo "$name" | c8y devices get | c8y template execute --template "{label: input.value.name + '(' + input.value.id + ')'}" --select label --output csv
+    
+    # Get stats about completed operations
+    echo -n "Total SUCCESSFUL: "
+    echo "$name" | c8y devices get | c8y operations list --status SUCCESSFUL --pageSize 1 --withTotalPages --select statistics.totalPages -o csv
+
+    echo -n "Total FAILED: "
+    echo "$name" | c8y devices get | c8y operations list --status FAILED --pageSize 1 --withTotalPages --select statistics.totalPages -o csv
+
+    echo ""
+done <"$input_file"
+
+# cleanup (to save space)
+c8y cache delete --age 2h
+```
+
+
+
+```sh title="usage"
+echo -e "agent01\nagent01\nagent01" > devices.list
+
+./operation-summary.sh devices.list
+```
+
+```sh title="output"
+Operation Summary: Device - agent01(761834)
+Total SUCCESSFUL: 0
+Total FAILED: 0
+
+Operation Summary: Device - agent01(761834)
+Total SUCCESSFUL: 0
+Total FAILED: 0
+
+Operation Summary: Device - agent01(761834)
+Total SUCCESSFUL: 0
+Total FAILED: 0
+
+✓ Deleted cache /tmp/go-c8y-cli-cache
+```
+
+Since caching is enabled, the requests on the server are reduced because the same GET request is not sent twice, instead it just retrieves the response from cache. The handling of the response does not change so it can fit very nicely into existing scripts. 
+
+### Using cache to prevent creating duplicate items
+
+Caching can also be applied to all HTTP Methods, not just GET requests. This enables the ability to write idempotent scripts to prevent accidentally creating duplicates.
+
+Let's say you want to copy measurements from one device to another, but since it could take a long time (depending on how many measurements there are), you want to be able to stop a script and restart it without creating duplicates.
+
+Normally, this would require the tracking of measurements by keeping track of the source measurement id and before creating it on the target device, you would have to check if the id already exists in the locally managed list.
+
+However because of in-built caching support, the script becomes very simple. The following shows how simple the script really is:
+
+```sh title="./copy_measurements.sh"
+#!/bin/bash
+
+#
+# Input arguments to set source and target device
+source_device=$1
+target_device=$2
+
+#
+# Enable caching by default for all commands
+export C8Y_SETTINGS_DEFAULTS_CACHE="true"
+
+# Enable caching of POST commands as well as GET
+export C8Y_SETTINGS_CACHE_METHODS="GET POST"
+
+# Use a really large TTL, as we want to prevent creating it for a long time
+export C8Y_SETTINGS_DEFAULTS_CACHETTL="100d"
+
+#
+# Copy the measurements from source => target device
+# If the measurement was already created then the cached response will be returned
+c8y measurements list \
+    --device "$source_device" \
+    --includeAll \
+    --view ignoreinbuilt_id \
+| c8y measurements create \
+    --device "$target_device" \
+    --template input.value \
+```

--- a/docs/go-c8y-cli/docs/concepts/caching.md
+++ b/docs/go-c8y-cli/docs/concepts/caching.md
@@ -232,9 +232,11 @@ c8y devices list --noCache
 
 Caching can be helpful in scripts to reduce the amount of code to write an efficient script, as you don't need to save the whole command response to variables, you can just reuse the same command with the `--cache` parameter and let go-c8y-cli look after it for you.
 
-### Retrieving list of devices
+### Getting complete operations overview for multiple devices
 
+Below is a small script to get the an overview of the completed operations for a list of devices. It excepts an input file to contain a list of device ids or names, and prints out the total number of SUCCESSFUL and FAILED operations for the device.
 
+By using cache, the `c8y devices get` command can be repeated without worrying about spamming the server with duplicated requests.
 
 ```sh title="./operation-summary.sh"
 #!/bin/bash
@@ -268,7 +270,7 @@ done <"$input_file"
 c8y cache delete --age 2h
 ```
 
-
+Below shows the script being used, and some example output:
 
 ```sh title="usage"
 echo -e "agent01\nagent01\nagent01" > devices.list

--- a/docs/go-c8y-cli/docs/configuration/settings.md
+++ b/docs/go-c8y-cli/docs/configuration/settings.md
@@ -48,6 +48,8 @@ c8y settings list --select "**" --output json
   },
   "defaults": {
     "abortonerrors": 10,
+    "cache": false,
+    "cachettl": "60s",
     "compact": false,
     "confirm": false,
     "confirmtext": "",
@@ -287,6 +289,54 @@ c8y settings update activitylog.path '$C8Y_HOME/activityLog'
 
 :::tip
 `$C8Y_HOME` is a special go-c8y-cli variable that can be used to reference your c8y home folder, so you will need to make sure you use single quotes when setting it via the command line so it does not get expanded to a shell variable.
+:::
+
+### defaults.cache: boolean
+
+Enable caching. Defaults to `false`.
+
+Caching can be turned on for individual commands by using the `--cache` global parameter.
+
+When the setting is activated, then all requests which match the `cache.methods` settings will be cached. Users can opt out of caching for individual commands by using the `--noCache` global parameter.
+
+### defaults.cacheTTL: string
+
+Cache time-to-live (TTL) settings to control the maximum age that a cached response. If the cached response is older than the TTL settings, then the cached item will be ignored.
+
+### cache.keyauth: boolean
+
+Include the request's Authorization header value when generating the cache key. Defaults to `true`.
+
+This can be useful if you want to share caching across multiple users. Normally the authorization header is used in the cache key generation, so the cached item will be a different file key for multiple users
+
+### cache.keyhost: boolean
+
+Include the host name when generating the cache key. Defaults to `true`.
+
+This can be useful when setting up a mock system where you want to fake server response by using cached response regardless of the server. This is a more advanced settings, so just ignore it if you don't understand it.
+
+### cache.methods: string
+
+Space separated list of HTTP methods which should be cached. By default only `GET` is configured.
+
+<CodeExample>
+
+# Enable more http methods to be cached
+c8y settings update cache.methods "GET PUT POST"
+
+</CodeExample>
+
+### cache.path: string
+
+Location of the cache directory. If the path does not exist it was be created when the first cached item is created.
+
+Defaults to:
+
+* Linux/MacOS: `{tmp}/go-c8y-cli-cache`, where `{tmp}` is set to `$TMPDIR` if not empty otherwise `/tmp`
+* Windows: `{tmp}/go-c8y-cli-cache`, where `{tmp}` is set to the first non-empty value of `%TMP%`, `%TEMP%`, `%USERPROFILE%`
+
+:::note
+If go-c8y-cli is being by multiple users on the same computer/server and you need to prevent users from accessing the local cached files, then you should change the default location of the cache, and apply the appropriate folder permissions to prevent other users from accessing the response from other users.
 :::
 
 ### ci: boolean

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
-	github.com/reubenmiller/go-c8y v0.9.1-rc.5
+	github.com/reubenmiller/go-c8y v0.9.1-rc.6
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
-	github.com/reubenmiller/go-c8y v0.9.0-rc.16
+	github.com/reubenmiller/go-c8y v0.9.1-rc.5
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/reubenmiller/go-c8y v0.9.1-rc.5 h1:NTLyR4nr6PBCSLRXAUhiggI91QIOXPd+5SzJXlt19Eg=
-github.com/reubenmiller/go-c8y v0.9.1-rc.5/go.mod h1:F7BxOnstMFuOofxtDnj9pQEv8ENKtkpS9tjLblZzHuo=
+github.com/reubenmiller/go-c8y v0.9.1-rc.6 h1:QTbd4x59ad1A4tYygog5bRyVyP8xHOdaGOzOUmvr6VA=
+github.com/reubenmiller/go-c8y v0.9.1-rc.6/go.mod h1:F7BxOnstMFuOofxtDnj9pQEv8ENKtkpS9tjLblZzHuo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/reubenmiller/go-c8y v0.9.0-rc.16 h1:fs5HPyfvAo7MNeEDgCUHPxIw1Dux9HlsswxTENxBrH4=
-github.com/reubenmiller/go-c8y v0.9.0-rc.16/go.mod h1:F7BxOnstMFuOofxtDnj9pQEv8ENKtkpS9tjLblZzHuo=
+github.com/reubenmiller/go-c8y v0.9.1-rc.5 h1:NTLyR4nr6PBCSLRXAUhiggI91QIOXPd+5SzJXlt19Eg=
+github.com/reubenmiller/go-c8y v0.9.1-rc.5/go.mod h1:F7BxOnstMFuOofxtDnj9pQEv8ENKtkpS9tjLblZzHuo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/activitylogger/activitylogger.go
+++ b/pkg/activitylogger/activitylogger.go
@@ -167,8 +167,10 @@ func (l *ActivityLogger) LogRequest(resp *http.Response, body *gjson.Result, res
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		cacheTag := resp.Header.Get("ETag")
+		isCachedResponse := cacheTag != ""
 		fmt.Fprintf(l.w,
-			`{"time":"%s","ctx":"%s","type":"request","method":"%s","host":"%s","path":"%s","query":"%s","accept":"%s","processingMode":"%s","statusCode":%d,"responseTimeMS":%d,"responseSelf":"%s"}`+"\n",
+			`{"time":"%s","ctx":"%s","type":"request","method":"%s","host":"%s","path":"%s","query":"%s","accept":"%s","processingMode":"%s","statusCode":%d,"responseTimeMS":%d,"responseSelf":"%s","etag":"%s","cached":%v}`+"\n",
 			time.Now().Format(time.RFC3339Nano),
 			l.contextID,
 			resp.Request.Method,
@@ -180,6 +182,8 @@ func (l *ActivityLogger) LogRequest(resp *http.Response, body *gjson.Result, res
 			resp.StatusCode,
 			responseTime,
 			body.Get("self").Str,
+			cacheTag,
+			isCachedResponse,
 		)
 	} else {
 		errorResponse := body.Raw

--- a/pkg/cmd/cache/cache.manual.go
+++ b/pkg/cmd/cache/cache.manual.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	cmdDelete "github.com/reubenmiller/go-c8y-cli/pkg/cmd/cache/delete"
+	cmdRenew "github.com/reubenmiller/go-c8y-cli/pkg/cmd/cache/renew"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type SubCmdCache struct {
+	*subcommand.SubCommand
+}
+
+func NewSubCommand(f *cmdutil.Factory) *SubCmdCache {
+	ccmd := &SubCmdCache{}
+
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Local cache management",
+		Long:  `Commands to manage the local cache, i.e. to cleanup the cache or refresh it`,
+	}
+
+	// Subcommands
+	cmd.AddCommand(cmdDelete.NewCmdDelete(f).GetCommand())
+	cmd.AddCommand(cmdRenew.NewCmdRenew(f).GetCommand())
+
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}

--- a/pkg/cmd/cache/delete/delete.manual.go
+++ b/pkg/cmd/cache/delete/delete.manual.go
@@ -1,0 +1,157 @@
+package delete
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/pkg/flags"
+	"github.com/spf13/cobra"
+)
+
+type CmdDelete struct {
+	*subcommand.SubCommand
+
+	factory *cmdutil.Factory
+	age     string
+	expired bool
+}
+
+func NewCmdDelete(f *cmdutil.Factory) *CmdDelete {
+	ccmd := &CmdDelete{
+		factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete the cache",
+		Long:  `Delete existing cache items either partially or cached items older than a time period`,
+		Example: heredoc.Doc(`
+			$ c8y cache delete
+			Remove all of the existing cache. If there is no cache, then nothing will be done
+
+			$ c8y cache delete --age -1h
+			Remove cache items which are older than 1 hour
+		`),
+		RunE: ccmd.RunE,
+	}
+
+	cmd.Flags().StringVar(&ccmd.age, "age", "", "Age duration, i.e. 30s, 2m, 1h, 1d")
+	cmd.Flags().BoolVar(&ccmd.expired, "expired", false, "Only removed expired cached items")
+
+	cmdutil.DisableEncryptionCheck(cmd)
+	cmd.SilenceUsage = true
+
+	cmdutil.DisableAuthCheck(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+func (n *CmdDelete) RunE(cmd *cobra.Command, args []string) error {
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return err
+	}
+	cs := n.factory.IOStreams.ColorScheme()
+
+	cacheDir := cfg.CacheDir()
+
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		_, bErr := fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Nothing to delete. %s\n", cs.SuccessIconWithColor(cs.Green), cacheDir)
+		return bErr
+	}
+
+	if n.age == "" && !n.expired {
+		if err := os.RemoveAll(cacheDir); err != nil {
+			return err
+		}
+		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Deleted cache. %s\n", cs.SuccessIconWithColor(cs.Red), cacheDir)
+		return nil
+	}
+
+	dryRun := cfg.DryRun()
+	var ageDuration time.Duration
+	if n.expired {
+		ageDuration = cfg.CacheTTL()
+	} else {
+		ageDuration, err = flags.GetDuration(n.age, true, time.Hour)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = removeOldFiles(n.factory.IOStreams.ErrOut, cacheDir, ageDuration, dryRun)
+	if err != nil {
+		return err
+	}
+	if err := removeEmptyDirectories(n.factory.IOStreams.ErrOut, cacheDir, dryRun); err != nil {
+		return err
+	}
+	fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Deleted cache %s\n", cs.SuccessIconWithColor(cs.Red), cacheDir)
+
+	return err
+}
+
+func removeOldFiles(w io.Writer, root string, age time.Duration, dryRun bool) error {
+	err := filepath.WalkDir(root, func(path string, info os.DirEntry, err error) error {
+		if err != nil {
+			fmt.Fprintf(w, "prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			// return nil
+			return err
+		}
+		if !info.IsDir() {
+			file, err := os.Stat(path)
+			if err != nil {
+				return nil
+			}
+			if file.Mode().IsRegular() {
+				// older than
+				if time.Since(file.ModTime()) > age {
+					if dryRun {
+						fmt.Fprintf(w, "DRY: Deleting cache file: %s\n", path)
+					} else {
+						os.Remove(path)
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	return err
+}
+
+func removeEmptyDirectories(w io.Writer, root string, dryRun bool) error {
+	err := filepath.WalkDir(root, func(path string, info os.DirEntry, err error) error {
+		if err != nil {
+			// ignore as we may have deleted the dir ourselves
+			// fmt.Fprintf(w, "prevent dir panic by handling failure accessing a path %q: %v\n", path, err)
+			return filepath.SkipDir
+		}
+		if info.IsDir() {
+			files, err := ioutil.ReadDir(path)
+
+			if err != nil {
+				return err
+			}
+
+			if len(files) == 0 {
+				if dryRun {
+					fmt.Fprintf(w, "DRY: Deleting empty directory: %s\n", path)
+				} else {
+					return os.Remove(path)
+				}
+			}
+		}
+
+		return nil
+	})
+	return err
+}

--- a/pkg/cmd/cache/renew/renew.manual.go
+++ b/pkg/cmd/cache/renew/renew.manual.go
@@ -1,0 +1,94 @@
+package renew
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type CmdRenew struct {
+	*subcommand.SubCommand
+
+	factory *cmdutil.Factory
+}
+
+func NewCmdRenew(f *cmdutil.Factory) *CmdRenew {
+	ccmd := &CmdRenew{
+		factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "renew",
+		Short: "Renew existing cache items",
+		Long:  `Renew existing cache items by changing the modified dates of the files to "now" so that the cache has a full time-to-live period`,
+		Example: heredoc.Doc(`
+			$ c8y cache renew
+			Renew all existing cache items. If there is no cache, then nothing will be done
+		`),
+		RunE: ccmd.RunE,
+	}
+
+	cmdutil.DisableEncryptionCheck(cmd)
+	cmd.SilenceUsage = true
+
+	cmdutil.DisableAuthCheck(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+func (n *CmdRenew) RunE(cmd *cobra.Command, args []string) error {
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return err
+	}
+	cs := n.factory.IOStreams.ColorScheme()
+
+	cacheDir := cfg.CacheDir()
+
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		_, bErr := fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Nothing to renew. %s\n", cs.SuccessIconWithColor(cs.Green), cacheDir)
+		return bErr
+	}
+
+	currentTime := time.Now().Local()
+	err = renewCacheFiles(n.factory.IOStreams.ErrOut, cacheDir, currentTime, cfg.DryRun())
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Renewed cache %s\n", cs.SuccessIconWithColor(cs.Green), cacheDir)
+
+	return err
+}
+
+func renewCacheFiles(w io.Writer, root string, currentTime time.Time, dryRun bool) error {
+	err := filepath.WalkDir(root, func(path string, info os.DirEntry, err error) error {
+		if err != nil {
+			fmt.Fprintf(w, "prevent panic by handling failure accessing a path %q: %v\n", path, err)
+			return err
+		}
+		if !info.IsDir() {
+			file, err := os.Stat(path)
+			if err != nil {
+				return nil
+			}
+			if file.Mode().IsRegular() {
+				if dryRun {
+					fmt.Fprintf(w, "DRY: Renewing cache file: %s\n", path)
+				} else {
+					_ = os.Chtimes(path, currentTime, currentTime)
+				}
+			}
+		}
+
+		return nil
+	})
+	return err
+}

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -463,7 +463,7 @@ func Test_DebugStdinCommand(t *testing.T) {
 	// stdin.Write(`{"source":{"id":"1111"}}` + "\n")
 
 	cmdtext := `
-	__complete software versions install --software linux-software-typea_JlHuAzug --version 0.8.6
+	cache clean --dry --age 1s
 	`
 	cmdErr := ExecuteCmd(cmd, strings.TrimSpace(cmdtext))
 

--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -73,9 +73,10 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 				func(r *http.Request) bool {
 					return strings.Contains(cachableMethods, r.Method)
 				},
-				c8y.KeyOptions{
+				c8y.CacheOptions{
 					ExcludeAuth: !cfg.CacheKeyIncludeAuth(),
 					ExcludeHost: !cfg.CacheKeyIncludeHost(),
+					Mode:        cfg.CacheMode(),
 				},
 			)
 		}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -22,6 +22,7 @@ import (
 	auditrecordsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/auditrecords"
 	binariesCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/binaries"
 	bulkoperationsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/bulkoperations"
+	cacheCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/cache"
 	completionCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/completion"
 	configurationCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/configuration"
 	configurationListCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/configuration/list"
@@ -226,6 +227,14 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	cmd.PersistentFlags().Bool("confirm", false, "Prompt for confirmation")
 	cmd.PersistentFlags().String("confirmText", "", "Custom confirmation text")
 
+	// caching
+	cmd.PersistentFlags().Bool("cache", false, "Enable cached responses")
+	cmd.PersistentFlags().Bool("noCache", false, "Force disabling of cached responses (overwrites cache setting)")
+	cmd.PersistentFlags().String("cacheTTL", "60s", "Cache time-to-live (TTL) as a duration, i.e. 60s, 2m")
+
+	// ssl settings
+	cmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")
+
 	completion.WithOptions(
 		cmd,
 		completion.WithValidateSet("dryFormat", "json", "dump", "curl", "markdown"),
@@ -270,6 +279,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 		completionCmd.NewCmdCompletion().GetCommand(),
 		templateCmd.NewSubCommand(f).GetCommand(),
 		utilCmd.NewSubCommand(f).GetCommand(),
+		cacheCmd.NewSubCommand(f).GetCommand(),
 		settingsCmd.NewSubCommand(f).GetCommand(),
 		realtimeCmd.NewSubCommand(f).GetCommand(),
 		currenttenantCmd.NewSubCommand(f).GetCommand(),

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -292,6 +292,42 @@ var updateSettingsOptions = map[string]argumentHandler{
 
 	// session
 	"session.defaultUsername": {"session.defaultUsername", "string", "settings.session.defaultUsername", []string{}, nil, cobra.ShellCompDirectiveDefault},
+
+	// cache
+	"defaults.cache": {"defaults.cache", "bool", config.SettingsDefaultsCacheEnabled, []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"cache.path": {"cache.path", "string", "settings.cache.path", []string{}, nil, cobra.ShellCompDirectiveDefault},
+
+	"defaults.cacheTTL": {"defaults.cacheTTL", "string", config.SettingsDefaultsCacheTTL, []string{
+		"30s",
+		"60s",
+		"5m",
+		"30m",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"cache.methods": {"cache.methods", "string", config.SettingsCacheMethods, []string{
+		"GET",
+		"GET PUT POST DELETE",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"cache.keyhost": {"cache.keyhost", "bool", config.SettingsCacheKeyHost, []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"cache.keyauth": {"cache.keyauth", "bool", config.SettingsCacheKeyAuth, []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	// insecure ssl
+	"defaults.insecure": {"defaults.insecure", "bool", config.SettingsDefaultsInsecure, []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
 }
 
 // NewCmdUpdate returns a new command used to update session settings

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -368,7 +368,6 @@ func (c *Config) bindSettings() {
 	c.viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	c.viper.SetEnvPrefix(EnvSettingsPrefix)
 	err := c.WithOptions(
-		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingEncryptionCachePassphrase, true),
 		WithBindEnv(SettingsMaxWorkers, 50),
 		WithBindEnv(SettingsWorkers, 1),
@@ -404,7 +403,8 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsCacheMethods, "GET"),
 		WithBindEnv(SettingsCacheKeyHost, true),
 		WithBindEnv(SettingsCacheKeyAuth, true),
-		WithDefault(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
+		WithBindEnv(SettingsCacheMode, nil),
+		WithBindEnv(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
 	)
 
 	if err != nil {

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -273,6 +273,9 @@ const (
 	// SettingsCacheKeyHost include host in cache key generation
 	SettingsCacheKeyHost = "settings.cache.keyhost"
 
+	// SettingsCacheMode cache mode. Only used for testing purposes
+	SettingsCacheMode = "settings.cache.mode"
+
 	// SettingsCacheKeyAuth include authorization header in cache key generation
 	SettingsCacheKeyAuth = "settings.cache.keyauth"
 
@@ -365,6 +368,7 @@ func (c *Config) bindSettings() {
 	c.viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	c.viper.SetEnvPrefix(EnvSettingsPrefix)
 	err := c.WithOptions(
+		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingEncryptionCachePassphrase, true),
 		WithBindEnv(SettingsMaxWorkers, 50),
 		WithBindEnv(SettingsWorkers, 1),
@@ -843,7 +847,9 @@ func (c *Config) CachePassphraseVariables() bool {
 
 func (c *Config) bindEnv(name string, defaultValue interface{}) error {
 	err := c.viper.BindEnv(name)
-	c.viper.SetDefault(name, defaultValue)
+	if defaultValue != nil {
+		c.viper.SetDefault(name, defaultValue)
+	}
 	return err
 }
 
@@ -1268,6 +1274,15 @@ func (c *Config) CacheDir() string {
 // CacheMethods HTTP methods which should be cached
 func (c *Config) CacheMethods() string {
 	return c.viper.GetString(SettingsCacheMethods)
+}
+
+// CacheMode caching mode which controls
+func (c *Config) CacheMode() c8y.StoreMode {
+	rawValue := c.viper.GetString(SettingsCacheMode)
+	if strings.EqualFold(rawValue, "storeonly") {
+		return c8y.StoreModeWrite
+	}
+	return c8y.StoreModeReadWrite
 }
 
 // CacheKeyIncludeHost include full host name in cache key generation

--- a/tests/manual/cache/cache_delete.yaml
+++ b/tests/manual/cache/cache_delete.yaml
@@ -1,0 +1,25 @@
+tests:
+  It deletes existing cache folder:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+    command: |
+      c8y devices list -p 1
+      c8y cache delete
+    exit-code: 0
+    stderr:
+      contains:
+        - "Deleted cache"
+
+  It does nothing if the cache folder does not exist:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-empty
+    command: |
+      rm -Rf /tmp/go-c8y-cli-cache-empty
+      c8y cache delete
+    exit-code: 0
+    stderr:
+      contains:
+        - "Nothing to delete"

--- a/tests/manual/cache/cache_renew.yaml
+++ b/tests/manual/cache/cache_renew.yaml
@@ -1,0 +1,17 @@
+tests:
+  It renews cached items:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-08
+    command: |
+      c8y devices list -p 1 --output json -c
+      c8y cache renew
+      c8y cache delete
+      c8y cache renew
+    exit-code: 0
+    stderr:
+      lines:
+        1: ✓ Renewed cache /tmp/go-c8y-cli-cache-test-08
+        2: ✓ Deleted cache. /tmp/go-c8y-cli-cache-test-08
+        3: ✓ Nothing to renew. /tmp/go-c8y-cli-cache-test-08

--- a/tests/manual/cache/cached_commands.yaml
+++ b/tests/manual/cache/cached_commands.yaml
@@ -1,0 +1,136 @@
+tests:
+  It does not use cache by default:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_VERBOSE: true
+    command: |
+      c8y devices list -p 1
+      c8y devices list -p 1
+    exit-code: 0
+    stderr:
+      not-contains:
+        - "Using cached response"
+
+  It allows single commands to be cached:
+    config:
+      env:
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-01
+        C8Y_SETTINGS_DEFAULTS_VERBOSE: true
+    command: |
+      c8y devices list --cache
+      c8y devices list --cache
+    exit-code: 0
+    stderr:
+      contains:
+        - "Using cached response"
+
+  It enables caching by defaults using env variables:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_VERBOSE: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-02
+    command: |
+      c8y cache delete
+      c8y devices list
+      c8y devices list
+    exit-code: 0
+    stderr:
+      contains:
+        - "Using cached response"
+
+  It disables caches for single commands:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_VERBOSE: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-03
+    command: |
+      c8y cache delete
+      c8y devices list
+      c8y devices list --noCache
+    exit-code: 0
+    stderr:
+      not-contains:
+        - "Using cached response"
+
+  It includes caching information in the response headers:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_DEBUG: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-04
+    command: |
+      c8y cache delete
+      c8y devices list -p 1
+      c8y devices list -p 1
+    exit-code: 0
+    stderr:
+      contains:
+        - "Last-Modified:"
+        - "Etag:"
+
+  It only caches commands which are the same:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_VERBOSE: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-05
+    command: |
+      c8y cache delete
+      c8y devices list -p 1
+      c8y devices list -p 2
+    exit-code: 0
+    stderr:
+      not-contains:
+        - "Last-Modified:"
+        - "Etag:"
+
+  It does not cache PUT or POST requests by default:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_DEBUG: true
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-06
+    command: |
+      c8y cache delete
+      c8y inventory create --name cached-device | c8y inventory update  --data "some.value=1" | c8y inventory update --data "some.value=1"
+      c8y inventory create --name cached-device
+      c8y inventory find --query "name eq 'cached-device'" | c8y inventory delete
+    exit-code: 0
+    stderr:
+      not-contains:
+        - "Last-Modified:"
+        - "Etag:"
+
+  It can cache PUT requests:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_DEBUG: true
+        C8Y_SETTINGS_CACHE_METHODS: "GET PUT POST"
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-07
+    command: |
+      c8y cache delete
+      c8y inventory create --name cached-device --noCache | c8y inventory update --data "some.value=1" | c8y inventory update  --data "some.value=1"
+    exit-code: 0
+    stderr:
+      contains:
+        - "Last-Modified:"
+        - "Etag:"
+
+  It can cache POST requests:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_CACHE: true
+        C8Y_SETTINGS_DEFAULTS_DEBUG: true
+        C8Y_SETTINGS_CACHE_METHODS: "GET PUT POST"
+        C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-07
+    command: |
+      c8y cache delete
+      c8y inventory create --name cached-device | c8y inventory create --name cached-device | c8y inventory delete
+    exit-code: 0
+    stderr:
+      contains:
+        - "Last-Modified:"
+        - "Etag:"

--- a/tools/PSc8y/Public-manual/Get-ClientCommonParameters.ps1
+++ b/tools/PSc8y/Public-manual/Get-ClientCommonParameters.ps1
@@ -101,6 +101,14 @@ Inherit common parameters to a custom function. This will add parameters such as
         New-DynamicParam -Name Compact -Alias "Compress" -Type "switch" -DPDictionary $Dictionary -HelpMessage "Compact instead of pretty-printed output when using json output. Pretty print is the default if output is the terminal"
         New-DynamicParam -Name NoColor -Type "switch" -DPDictionary $Dictionary -HelpMessage "Don't use colors when displaying log entries on the console"
         
+        # Cache
+        New-DynamicParam -Name Cache -Type "switch" -DPDictionary $Dictionary -HelpMessage "Enable cached responses"
+        New-DynamicParam -Name NoCache -Type "switch" -DPDictionary $Dictionary -HelpMessage "Force disabling of cached responses (overwrites cache setting)"
+        New-DynamicParam -Name CacheTTL -Type "string" -DPDictionary $Dictionary -HelpMessage "Cache time-to-live (TTL) as a duration, i.e. 60s, 2m"
+        
+        # SSL Verify
+        New-DynamicParam -Name Insecure -Type "switch" -DPDictionary $Dictionary -HelpMessage "Allow insecure server connections when using SSL"
+        
         # Help
         New-DynamicParam -Name Help -Type "switch" -DPDictionary $Dictionary -HelpMessage "Show command help"
         New-DynamicParam -Name Examples -Type "switch" -DPDictionary $Dictionary -HelpMessage "Show examples for the current command"


### PR DESCRIPTION
## Overview

Caching provides an easy way to reduce the number of requests sent to the server by caching the responses locally on disk.

The responses from large requests can be cached so that when the same request is sent again (within the cache's time-to-live (TTL) setting), instead of sending the request to the server, the response is retrieved from file (assuming the cache has not expired). This improves the performance of repetitive queries by reusing already existing responses across commands.

The caching works be intercepting every HTTP request and writing the HTTP response to file using a unique hash based on the URL, path, authorization header and body (if set).

The commands can be cached via control via global parameters `cache`, `noCache` and `cacheTTL`

```sh
c8y devices list --type "c8y_Linux" --cache
# => Sends a request to the server the first time

c8y devices list --type "c8y_Linux" --cache
# => A cached response is used as the same command is being used within the cache TTL

echo agent01 | c8y util repeat 2 | c8y devices get --cache --cacheTTL 60s -v
# => Control time-to-live for single commands 
```