### PR TITLE
bugfix: support filtering multiline text

### DIFF
--- a/pkg/matcher/matcher.go
+++ b/pkg/matcher/matcher.go
@@ -13,8 +13,9 @@ func MatchWithWildcards(s, pattern string) (bool, error) {
 	// convert wildcards to a regex
 	pattern = strings.ReplaceAll(pattern, "*", ".*")
 
-	// case insensitive matching and whole string matching
-	pattern = "(?i)^" + pattern + "$"
+	// case-insensitive matching, multi-line matching and . matches \n
+	// and whole string matching
+	pattern = "(?ims)^" + pattern + "$"
 
 	r, err := regexp.Compile(pattern)
 
@@ -26,8 +27,8 @@ func MatchWithWildcards(s, pattern string) (bool, error) {
 }
 
 func MatchWithRegex(s, pattern string) (bool, error) {
-	// case-insensitive matching
-	pattern = "(?i)" + pattern
+	// case-insensitive matching, multi-line matching and . matches \n
+	pattern = "(?ims)" + pattern
 
 	r, err := regexp.Compile(pattern)
 

--- a/tests/manual/common/filter/filter_options.yml
+++ b/tests/manual/common/filter/filter_options.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_OUTPUT: csv
+
+
+tests:
+  It can filter properties with newline characters using wildcards:
+    command: |
+      cat manual/common/filter/input_newline.jsonl | c8y util show --filter "failureReason like *complex*" -o json
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"failureReason":"Some complex\nreason\nwith\nmultiple lines","id":"1"}
+  
+  It can filter properties with newline characters using regex:
+    command: |
+      cat manual/common/filter/input_newline.jsonl | c8y util show --filter "failureReason match .*complex.*" -o json
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"failureReason":"Some complex\nreason\nwith\nmultiple lines","id":"1"}

--- a/tests/manual/common/filter/input_newline.jsonl
+++ b/tests/manual/common/filter/input_newline.jsonl
@@ -1,0 +1,1 @@
+{"id": "1", "failureReason": "Some complex\nreason\nwith\nmultiple lines"}


### PR DESCRIPTION
Support multiline matching with filter operators `match` and `like`

### Example

**input.json**
Some multi line json input (or response from c8y) which contains newline chars `\n`

```json
{"failureReason": "some\ncomplex\nmultiline\njson"}
```

Then it can be filtered using the `--filter` parameter.

```sh
cat input.json | c8y util show --filter "failureReason like *complex*" -o json
```