### PR TITLE
removing brackets around queryTemplate input string

### DIFF
--- a/pkg/flags/c8yQuery.go
+++ b/pkg/flags/c8yQuery.go
@@ -76,7 +76,7 @@ func BuildCumulocityQuery(cmd *cobra.Command, fixedParts []string, orderBy strin
 		}
 
 		if len(b) > 0 {
-			queryParts = append(queryParts, "("+string(b)+")")
+			queryParts = append(queryParts, string(b))
 		}
 
 		if v, err := cmd.Flags().GetString("queryTemplate"); err == nil && v != "" {

--- a/tests/manual/devices/list/devices_list.yaml
+++ b/tests/manual/devices/list/devices_list.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_OUTPUT: csv
+
+
+tests:
+  It can build an inventory query via piped input:
+    command: |
+      echo "type1" | c8y devices list --queryTemplate "type eq '%s'" --dry |
+        c8y util show --select pathEncoded
+    exit-code: 0
+    stdout:
+      exactly: |
+        /inventory/managedObjects?q=$filter=type+eq+'type1'+$orderby=name


### PR DESCRIPTION
Fixing bug where the piped input to a query was being wrapped with braces `(<input>)`.

**Example**

```sh
echo "c8y_Linux" | c8y devices list --queryTemplate "type eq '%s'" --dry

# Incorrect query with extra brackets
# => /inventory/managedObjects?q=$filter=type eq '(c8y_Linux)' $orderby=name

# Corrected query
# => /inventory/managedObjects?q=$filter=type eq 'c8y_Linux' $orderby=name
```

**Affected Commands**

The following command were affected by the bug when the `--queryTemplate` option was used.
* `c8y agents list`
* `c8y devices list`
* `c8y devicegroups list`
* `c8y smartgroups list`