### PR TITLE
bugfix: allow empty version numbers

### DIFF
--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -672,7 +672,7 @@ func WithSoftwareByNameFirstMatch(client *c8y.Client, args []string, opts ...str
 }
 
 // WithSoftwareVersionData adds software information (name, version and url)
-func WithSoftwareVersionData(client *c8y.Client, flagSoftware, flagVersion string, args []string, opts ...string) flags.GetOption {
+func WithSoftwareVersionData(client *c8y.Client, flagSoftware, flagVersion, flagURL string, args []string, opts ...string) flags.GetOption {
 	return func(cmd *cobra.Command, inputIterators *flags.RequestInputIterators) (string, interface{}, error) {
 		var err error
 		software := ""
@@ -685,9 +685,22 @@ func WithSoftwareVersionData(client *c8y.Client, flagSoftware, flagVersion strin
 			version = v[0]
 		}
 
+		url := ""
+		if v, err := flags.GetFlagStringValues(cmd, flagURL); err == nil && len(v) > 0 {
+			url = v[0]
+		}
+
 		_, dst, _ := flags.UnpackGetterOptions("", opts...)
 
 		output := map[string]string{}
+
+		// If version is empty, then pass the values as is
+		if version == "" {
+			output["name"] = software
+			output["version"] = version
+			output["url"] = url
+			return dst, output, nil
+		}
 
 		// Check for explicit managed object id
 		if IsID(version) {

--- a/pkg/cmd/software/versions/install/install.auto.go
+++ b/pkg/cmd/software/versions/install/install.auto.go
@@ -144,7 +144,7 @@ func (n *InstallCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("version", "c8y_SoftwareUpdate.0.version"),
 		flags.WithStringValue("url", "c8y_SoftwareUpdate.0.url"),
 		flags.WithStringValue("description", "description"),
-		c8yfetcher.WithSoftwareVersionData(client, "software", "version", args, "", "c8y_SoftwareUpdate.0"),
+		c8yfetcher.WithSoftwareVersionData(client, "software", "version", "url", args, "", "c8y_SoftwareUpdate.0"),
 		flags.WithStringValue("action", "c8y_SoftwareUpdate.0.action"),
 		cmdutil.WithTemplateValue(cfg),
 		flags.WithTemplateVariablesValue(),

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -94,7 +94,7 @@
         "[]software" = "c8yfetcher.WithSoftwareByNameFirstMatch(client, args, `"${prop}`", `"${queryParam}`"),"
 
         "softwareDetails" = @(
-            "c8yfetcher.WithSoftwareVersionData(client, `"software`", `"version`", args, `"`", `"${queryParam}`"),"
+            "c8yfetcher.WithSoftwareVersionData(client, `"software`", `"version`", `"url`", args, `"`", `"${queryParam}`"),"
         ) -join "`n"
 
         # software name

--- a/tests/manual/software/install/software_versions_install.yaml
+++ b/tests/manual/software/install/software_versions_install.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+
+tests:
+  It creates an operation to update software without a version:
+    command: |
+      c8y software versions install --device 1 --software "myapp" --description "Installing software" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_SoftwareUpdate": [
+              {
+                "action": "install",
+                "name": "myapp",
+                "url": "",
+                "version": ""
+              }
+            ],
+            "description": "Installing software",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }
+  
+  It creates an operation to update software without a version but a custom url:
+    command: |
+      c8y software versions install \
+        --device 1 \
+        --software "myapp" \
+        --description "Installing software" \
+        --url "https://test.com/binary/package.zip" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_SoftwareUpdate": [
+              {
+                "action": "install",
+                "name": "myapp",
+                "url": "https://test.com/binary/package.zip",
+                "version": ""
+              }
+            ],
+            "description": "Installing software",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }


### PR DESCRIPTION

* `c8y software versions install` allow empty version field

    **Example**

    ```sh
    c8y software versions install \
        --device 1 \
        --software "myapp" \
        --description "Installing software" \
        --url "https://test.com/binary/package.zip" \
        --dry
    ```

    **Request**
    ```sh
    {
        "body": {
            "c8y_SoftwareUpdate": [
                {
                    "action": "install",
                    "name": "myapp",
                    "url": "https://test.com/binary/package.zip",
                    "version": ""
                }
            ],
            "description": "Installing software",
            "deviceId": "1"
        },
        "method": "POST",
        "pathEncoded": "/devicecontrol/operations"
    }
    ```
