### PR TITLE
add support for template and data parameters in software and firmware commands

### DIFF
--- a/api/spec/json/firmwareVersions.json
+++ b/api/spec/json/firmwareVersions.json
@@ -328,6 +328,11 @@
           "required": false,
           "property": "c8y_Firmware.url",
           "description": "Firmware url. TODO, not currently automatically added"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties describing the operation which will be performed on the device."
         }
       ],
       "bodyRequiredKeys": [

--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -313,6 +313,11 @@
           "validationSet": [
             "install"
           ]
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties describing the operation which will be performed on the device."
         }
       ],
       "bodyRequiredKeys": [
@@ -383,6 +388,11 @@
           "validationSet": [
             "delete"
           ]
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties describing the operation which will be performed on the device."
         }
       ],
       "bodyRequiredKeys": [

--- a/api/spec/yaml/firmwareVersions.yaml
+++ b/api/spec/yaml/firmwareVersions.yaml
@@ -251,6 +251,10 @@ endpoints:
         property: c8y_Firmware.url
         description: Firmware url. TODO, not currently automatically added
 
+      - name: data
+        type: json
+        description: Additional properties describing the operation which will be performed on the device.
+
     bodyRequiredKeys:
       - "deviceId"
       - "c8y_Firmware.name"

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -238,6 +238,10 @@ endpoints:
         validationSet:
           - install
 
+      - name: data
+        type: json
+        description: Additional properties describing the operation which will be performed on the device.
+
     bodyRequiredKeys:
       - "deviceId"
       - "c8y_SoftwareUpdate.0.name"
@@ -292,6 +296,10 @@ endpoints:
         default: 'delete'
         validationSet:
           - delete
+
+      - name: data
+        type: json
+        description: Additional properties describing the operation which will be performed on the device.
     bodyRequiredKeys:
       - "deviceId"
       - "c8y_SoftwareUpdate.0.name"

--- a/pkg/cmd/firmware/versions/install/install.auto.go
+++ b/pkg/cmd/firmware/versions/install/install.auto.go
@@ -60,7 +60,8 @@ Install a firmware version
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("device", "deviceId", false, "deviceId", "source.id", "managedObject.id", "id"),
 	)
 

--- a/pkg/cmd/software/versions/install/install.auto.go
+++ b/pkg/cmd/software/versions/install/install.auto.go
@@ -63,7 +63,8 @@ Install a software package version
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("device", "deviceId", false, "deviceId", "source.id", "managedObject.id", "id"),
 	)
 

--- a/pkg/cmd/software/versions/uninstall/uninstall.auto.go
+++ b/pkg/cmd/software/versions/uninstall/uninstall.auto.go
@@ -61,7 +61,8 @@ Uninstall a software package version
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("device", "deviceId", false, "deviceId", "source.id", "managedObject.id", "id"),
 	)
 


### PR DESCRIPTION
Add support for `--template` and `--data` parameters to:
* `c8y software versions install`
* `c8y software versions uninstall`
* `c8y firmware version install`
