### PR TITLE
Fix pipeline variable handling on c8y applications deleteApplicationBinary

### DIFF
--- a/api/spec/json/applications.json
+++ b/api/spec/json/applications.json
@@ -579,7 +579,7 @@
         {
           "name": "binaryId",
           "alias": "id",
-          "type": "[]string",
+          "type": "[]id",
           "pipeline": true,
           "required": true,
           "description": "Application binary id"

--- a/api/spec/yaml/applications.yaml
+++ b/api/spec/yaml/applications.yaml
@@ -427,7 +427,7 @@ endpoints:
       
       - name: binaryId
         alias: id
-        type: '[]string'
+        type: '[]id'
         pipeline: true
         required: true
         description: Application binary id

--- a/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
+++ b/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
@@ -145,7 +145,7 @@ func (n *DeleteApplicationBinaryCmd) RunE(cmd *cobra.Command, args []string) err
 		path,
 		inputIterators,
 		c8yfetcher.WithApplicationByNameFirstMatch(client, args, "application", "application"),
-		flags.WithStringSliceValues("binaryId", "binaryId", ""),
+		c8yfetcher.WithIDSlice(args, "binaryId", "binaryId"),
 	)
 	if err != nil {
 		return err

--- a/tests/manual/applications/deleteApplicationBinary/applications_deleteApplicationBinary.yaml
+++ b/tests/manual/applications/deleteApplicationBinary/applications_deleteApplicationBinary.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+    C8Y_SETTINGS_DEFAULTS_OUTPUT: json
+
+tests:
+    Delete application binary:
+        command: |
+          c8y applications deleteApplicationBinary --application 12345 --binaryId 1111 --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /application/applications/12345/binaries/1111
+
+    Delete application binary (using pipeline):
+        command: |
+          echo "1111" | c8y applications deleteApplicationBinary --application 12345
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /application/applications/12345/binaries/1111
+
+    Delete application binary with application name lookup (using pipeline):
+        command: |
+          c8y template execute --template "{id: '1111'}" | c8y applications deleteApplicationBinary --application "my-example-app" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: r//application/applications/\d+/binaries/1111
+
+    Delete application binaries piping property alias (using pipeline):
+        command: |
+          c8y template execute --template "{binaryId: '1111', id: '2222'}" | c8y applications deleteApplicationBinary --application 12345 --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /application/applications/12345/binaries/2222

--- a/tools/PSc8y/Public/Remove-ApplicationBinary.ps1
+++ b/tools/PSc8y/Public/Remove-ApplicationBinary.ps1
@@ -39,7 +39,7 @@ Remove all application binaries (except for the active one) for an application (
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [Alias("id")]
-        [string[]]
+        [object[]]
         $BinaryId
     )
     DynamicParam {


### PR DESCRIPTION
* Fixed pipeline variable type
* Add supported for pipeline handling for `[]string` type within the api spec