### PR TITLE
support filtering by configuration type

### DIFF
--- a/pkg/cmd/configuration/list/list.manual.go
+++ b/pkg/cmd/configuration/list/list.manual.go
@@ -40,6 +40,7 @@ Get a list of configuration files
 				ccmd.factory,
 				flags.WithC8YQueryFixedString("(type eq 'c8y_ConfigurationDump')"),
 				flags.WithC8YQueryFormat("name", "(name eq '%s')"),
+				flags.WithC8YQueryFormat("configurationType", "(configurationType eq '%s')"),
 				flags.WithC8YQueryFormat("deviceType", "(c8y_Filter.type eq '%s')"),
 				flags.WithC8YQueryFormat("description", "(description eq '%s')"),
 			)
@@ -50,6 +51,7 @@ Get a list of configuration files
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("name", "", "Configuration name filter")
+	cmd.Flags().String("configurationType", "", "Configuration type filter")
 	cmd.Flags().String("description", "", "Configuration description filter")
 	cmd.Flags().String("deviceType", "", "Configuration device type filter")
 

--- a/tests/manual/configuration/configuration_list.yaml
+++ b/tests/manual/configuration/configuration_list.yaml
@@ -7,3 +7,12 @@ tests:
         method: GET
         path: /inventory/managedObjects
         query: r/type eq 'c8y_ConfigurationDump'
+
+  configuration_list_Get a list of configuration files filtering by configurationType:
+    command: c8y configuration list --configurationType "AGENT" --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        path: /inventory/managedObjects
+        query: r/\(type eq 'c8y_ConfigurationDump'\) and \(configurationType eq 'AGENT'\)


### PR DESCRIPTION
* `c8y configuration list` added `--configurationType <string>` flag to filter by configuration type

    ```
    c8y configuration list --configurationType "AGENT_CONFIG"

    # => Cumulocity inventory query
    # => GET /inventory/managedObjects?query=$filter=(type eq 'c8y_ConfigurationDump') and (configurationType eq 'AGENT_CONFIG') $orderby=name
    ```