### PR TITLE
feat: improved firmware/software install commands

### DIFF
--- a/api/spec/json/firmwareVersions.json
+++ b/api/spec/json/firmwareVersions.json
@@ -292,8 +292,12 @@
         ],
         "go": [
           {
-            "description": "Install a firmware version",
+            "description": "Install a firmware version (lookup url automatically).\nIf the firmware/version exists in the firmware repository, then it will add the url automatically\n",
             "command": "c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0"
+          },
+          {
+            "description": "Install a firmware version with an explicit url",
+            "command": "c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0 --url \"https://my.blobstore.com/linux-iot.tar.gz\""
           }
         ]
       },
@@ -327,7 +331,19 @@
           "type": "string",
           "required": false,
           "property": "c8y_Firmware.url",
-          "description": "Firmware url. TODO, not currently automatically added"
+          "description": "Firmware url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository"
+        },
+        {
+          "name": "firmwareDetails",
+          "type": "firmwareDetails",
+          "position": 98,
+          "property": "c8y_Firmware",
+          "description": "Computed parameter which is filled in when the firmware details, name, version and url"
+        },
+        {
+          "name": "description",
+          "type": "string",
+          "description": "Operation description"
         },
         {
           "name": "data",
@@ -339,7 +355,11 @@
         "deviceId",
         "c8y_Firmware.name",
         "c8y_Firmware.version"
-      ]
+      ],
+      "bodyTemplate": {
+        "type": "jsonnet",
+        "template": "{\n  _version:: if std.objectHas(self.c8y_Firmware, 'version') then self.c8y_Firmware.version else '',\n  description:\n    ('Update firmware to: \"%s\"' % self.c8y_Firmware.name)\n    + (if self._version != \"\" then \" (%s)\" % self._version else \"\")\n}\n"
+      }
     }
   ]
 }

--- a/api/spec/json/firmwareVersions.json
+++ b/api/spec/json/firmwareVersions.json
@@ -293,7 +293,8 @@
         "go": [
           {
             "description": "Install a firmware version (lookup url automatically).\nIf the firmware/version exists in the firmware repository, then it will add the url automatically\n",
-            "command": "c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0"
+            "command": "c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0",
+            "skipTest": true
           },
           {
             "description": "Install a firmware version with an explicit url",

--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -251,8 +251,13 @@
         ],
         "go": [
           {
-            "description": "Install a software package version",
+            "description": "Install a software package version\nIf the software/version exists in the software repository, then it will add the url automatically\n",
             "command": "c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0",
+            "skipTest": true
+          },
+          {
+            "description": "Install a software package version with an explicit url\n",
+            "command": "c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0 --url \"https://mybloblstore/go-c8y-cli.deb\"",
             "skipTest": true
           }
         ]
@@ -287,7 +292,7 @@
           "type": "string",
           "required": false,
           "property": "c8y_SoftwareUpdate.0.url",
-          "description": "Software url"
+          "description": "Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository"
         },
         {
           "name": "description",

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -105,6 +105,7 @@
         "[]firmwarepatch",
         "firmwareName",
         "firmwareVersionName",
+        "firmwareDetails",
         "firmwarepatchName",
         "[]software",
         "softwareDetails",

--- a/api/spec/yaml/firmwareVersions.yaml
+++ b/api/spec/yaml/firmwareVersions.yaml
@@ -225,6 +225,7 @@ endpoints:
             Install a firmware version (lookup url automatically).
             If the firmware/version exists in the firmware repository, then it will add the url automatically
           command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0
+          skipTest: true
 
         - description: Install a firmware version with an explicit url
           command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0 --url "https://my.blobstore.com/linux-iot.tar.gz"

--- a/api/spec/yaml/firmwareVersions.yaml
+++ b/api/spec/yaml/firmwareVersions.yaml
@@ -221,8 +221,13 @@ endpoints:
           command: Install-FirmwareVersion -Device $mo.id -Firmware linux-iot -Version 1.0.0
 
       go:
-        - description: Install a firmware version
+        - description: |
+            Install a firmware version (lookup url automatically).
+            If the firmware/version exists in the firmware repository, then it will add the url automatically
           command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0
+
+        - description: Install a firmware version with an explicit url
+          command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0 --url "https://my.blobstore.com/linux-iot.tar.gz"
 
     body:
       - name: device
@@ -249,7 +254,18 @@ endpoints:
         type: string
         required: false
         property: c8y_Firmware.url
-        description: Firmware url. TODO, not currently automatically added
+        description: Firmware url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository
+      
+      # Special property. Should after name, version, url but before action
+      - name: firmwareDetails
+        type: firmwareDetails
+        position: 98
+        property: c8y_Firmware
+        description: Computed parameter which is filled in when the firmware details, name, version and url
+
+      - name: description
+        type: string
+        description: Operation description
 
       - name: data
         type: json
@@ -259,3 +275,13 @@ endpoints:
       - "deviceId"
       - "c8y_Firmware.name"
       - "c8y_Firmware.version"
+    
+    bodyTemplate:
+      type: jsonnet
+      template: |
+        {
+          _version:: if std.objectHas(self.c8y_Firmware, 'version') then self.c8y_Firmware.version else '',
+          description:
+            ('Update firmware to: "%s"' % self.c8y_Firmware.name)
+            + (if self._version != "" then " (%s)" % self._version else "")
+        }

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -185,8 +185,15 @@ endpoints:
           command: Install-SoftwareVersion -Device $mo.id -Software go-c8y-cli -Version 1.0.0
 
       go:
-        - description: Install a software package version
+        - description: |
+            Install a software package version
+            If the software/version exists in the software repository, then it will add the url automatically
           command: c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0
+          skipTest: true
+
+        - description: |
+            Install a software package version with an explicit url
+          command: c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0 --url "https://mybloblstore/go-c8y-cli.deb"
           skipTest: true
 
     body:
@@ -214,7 +221,8 @@ endpoints:
         type: 'string'
         required: false
         property: c8y_SoftwareUpdate.0.url
-        description: Software url
+        description: Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository
+
 
       - name: description
         type: string

--- a/pkg/cmd/software/versions/install/install.auto.go
+++ b/pkg/cmd/software/versions/install/install.auto.go
@@ -36,6 +36,12 @@ func NewInstallCmd(f *cmdutil.Factory) *InstallCmd {
 		Example: heredoc.Doc(`
 $ c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0
 Install a software package version
+If the software/version exists in the software repository, then it will add the url automatically
+
+
+$ c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0 --url "https://mybloblstore/go-c8y-cli.deb"
+Install a software package version with an explicit url
+
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()
@@ -48,7 +54,7 @@ Install a software package version
 	cmd.Flags().StringSlice("device", []string{""}, "Device or agent where the software should be installed (accepts pipeline)")
 	cmd.Flags().String("software", "", "Software name (required)")
 	cmd.Flags().String("version", "", "Software version id or name")
-	cmd.Flags().String("url", "", "Software url")
+	cmd.Flags().String("url", "", "Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository")
 	cmd.Flags().String("description", "Install software package", "Operation description")
 	cmd.Flags().String("action", "install", "Software action")
 

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -118,6 +118,10 @@
         # firmware version name
         "firmwareversionName" = "flags.WithStringValue(`"${prop}`", `"${queryParam}`"),"
 
+        "firmwareDetails" = @(
+            "c8yfetcher.WithFirmwareVersionData(client, `"firmware`", `"version`", `"url`", args, `"`", `"${queryParam}`"),"
+        ) -join "`n"
+
         # firmware version patch array
         "[]firmwarepatch" = "c8yfetcher.WithFirmwarePatchByNameFirstMatch(client, args, `"${prop}`", `"${queryParam}`"),"
 

--- a/scripts/build-powershell/New-C8yPowershellArguments.ps1
+++ b/scripts/build-powershell/New-C8yPowershellArguments.ps1
@@ -104,6 +104,7 @@
 
         # Complex lookup types. These should not be visible in powershell
         "softwareDetails" { $Ignore = $true; ""; break }
+        "firmwareDetails" { $Ignore = $true; ""; break }
         default {
             Write-Error "Unsupported Type. $_"
         }

--- a/tests/auto/firmwareversions/tests/firmware/versions_install.yaml
+++ b/tests/auto/firmwareversions/tests/firmware/versions_install.yaml
@@ -1,10 +1,23 @@
 tests:
-    firmware/versions_install_Install a firmware version:
-        command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0
+    ? |
+        firmware/versions_install_Install a firmware version (lookup url automatically).
+        If the firmware/version exists in the firmware repository, then it will add the url automatically
+    :   command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0
         exit-code: 0
         stdout:
             json:
                 body.c8y_Firmware.name: linux-iot
+                body.c8y_Firmware.version: 1.0.0
+                body.deviceId: "1234"
+                method: POST
+                path: /devicecontrol/operations
+    firmware/versions_install_Install a firmware version with an explicit url:
+        command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0 --url "https://my.blobstore.com/linux-iot.tar.gz"
+        exit-code: 0
+        stdout:
+            json:
+                body.c8y_Firmware.name: linux-iot
+                body.c8y_Firmware.url: https://my.blobstore.com/linux-iot.tar.gz
                 body.c8y_Firmware.version: 1.0.0
                 body.deviceId: "1234"
                 method: POST

--- a/tests/auto/firmwareversions/tests/firmware/versions_install.yaml
+++ b/tests/auto/firmwareversions/tests/firmware/versions_install.yaml
@@ -4,6 +4,7 @@ tests:
         If the firmware/version exists in the firmware repository, then it will add the url automatically
     :   command: c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0.0
         exit-code: 0
+        skip: true
         stdout:
             json:
                 body.c8y_Firmware.name: linux-iot

--- a/tests/auto/softwareversions/tests/software/versions_install.yaml
+++ b/tests/auto/softwareversions/tests/software/versions_install.yaml
@@ -1,11 +1,26 @@
 tests:
-    software/versions_install_Install a software package version:
-        command: c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0
+    ? |
+        software/versions_install_Install a software package version
+        If the software/version exists in the software repository, then it will add the url automatically
+    :   command: c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0
         exit-code: 0
         skip: true
         stdout:
             json:
                 body.c8y_SoftwareUpdate.0.name: go-c8y-cli
+                body.c8y_SoftwareUpdate.0.version: 1.0.0
+                body.deviceId: "1234"
+                method: POST
+                path: /devicecontrol/operations
+    ? |
+        software/versions_install_Install a software package version with an explicit url
+    :   command: c8y software versions install --device 1234 --software go-c8y-cli --version 1.0.0 --url "https://mybloblstore/go-c8y-cli.deb"
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.c8y_SoftwareUpdate.0.name: go-c8y-cli
+                body.c8y_SoftwareUpdate.0.url: https://mybloblstore/go-c8y-cli.deb
                 body.c8y_SoftwareUpdate.0.version: 1.0.0
                 body.deviceId: "1234"
                 method: POST

--- a/tests/manual/firmware/versions/firmware_versions_install.yaml
+++ b/tests/manual/firmware/versions/firmware_versions_install.yaml
@@ -1,0 +1,97 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+
+tests:
+  It creates an operation to update firmware with name and version:
+    command: |
+      c8y firmware versions install --device 1 --firmware "iot-linux" --version "1.0.0" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_Firmware": {
+              "name": "iot-linux",
+              "url": "https://example.com",
+              "version": "1.0.0"
+            },
+            "description": "Update firmware to: \"iot-linux\" (1.0.0)",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }
+  
+  It creates an operation to update firmware with name and version but overriding url:
+    command: |
+      c8y firmware versions install --device 1 --firmware "iot-linux" --version "1.0.0" --url "http://custom.com" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_Firmware": {
+              "name": "iot-linux",
+              "url": "http://custom.com",
+              "version": "1.0.0"
+            },
+            "description": "Update firmware to: \"iot-linux\" (1.0.0)",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }
+  
+  It creates an operation to update firmware with name:
+    command: |
+      c8y firmware versions install --device 1 --firmware "iot-linux" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_Firmware": {
+              "name": "iot-linux",
+              "url": "",
+              "version": ""
+            },
+            "description": "Update firmware to: \"iot-linux\"",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }
+  
+  It creates an operation to update firmware without a version but a custom url:
+    command: |
+      c8y firmware versions install \
+        --device 1 \
+        --firmware "custom-firmware" \
+        --description "Installing custom firmware" \
+        --url "https://test.com/binary/package.zip" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_Firmware": {
+              "name": "custom-firmware",
+              "url": "https://test.com/binary/package.zip",
+              "version": ""
+            },
+            "description": "Installing custom firmware",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }

--- a/tests/manual/software/install/software_versions_install.yaml
+++ b/tests/manual/software/install/software_versions_install.yaml
@@ -59,3 +59,60 @@ tests:
           "method": "POST",
           "pathEncoded": "/devicecontrol/operations"
         }
+
+  It creates an operation to update software with a version where url is automatically added:
+    command: |
+      c8y software versions install \
+        --device 1 \
+        --software "my-app" \
+        --version "1.2.3" \
+        --description "Installing software" \
+        | c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_SoftwareUpdate": [
+              {
+                "action": "install",
+                "name": "my-app",
+                "url": "https://example.com/debian/my-app-1.2.3.deb",
+                "version": "1.2.3"
+              }
+            ],
+            "description": "Installing software",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }
+
+  It creates an operation to update software with a version but a custom url:
+    command: |
+      c8y software versions install \
+        --device 1 \
+        --software "my-app" \
+        --version "1.2.3" \
+        --description "Installing software" \
+        --url "https://test.com/binary/package.zip" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_SoftwareUpdate": [
+              {
+                "action": "install",
+                "name": "my-app",
+                "url": "https://test.com/binary/package.zip",
+                "version": "1.2.3"
+              }
+            ],
+            "description": "Installing software",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }

--- a/tests/scripts/setup.sh
+++ b/tests/scripts/setup.sh
@@ -24,6 +24,9 @@ setup () {
     create_firmware "iot-linux"
     create_firmware_version "iot-linux" "1.0.0" "https://example.com"
 
+    create_software "my-app"
+    create_software_version "my-app" "1.2.3" "https://example.com/debian/my-app-1.2.3.deb"
+
     create_device_profile "profile01"
 }
 
@@ -73,6 +76,20 @@ create_firmware_version () {
     local url="$3"
     c8y firmware versions get --firmware "$name" --id "$version" --silentStatusCodes 404 ||
         c8y firmware versions create --firmware "$name" --version "$version" --url "$url"
+}
+
+create_software () {
+    local name="$1"
+    c8y software get --id "$name" --silentStatusCodes 404 ||
+        c8y software create --name "$name"
+}
+
+create_software_version () {
+    local name="$1"
+    local version="$2"
+    local url="$3"
+    c8y software versions get --software "$name" --id "$version" --silentStatusCodes 404 ||
+        c8y software versions create --software "$name" --version "$version" --url "$url"
 }
 
 create_device_profile () {

--- a/tools/PSc8y/Public/Install-FirmwareVersion.ps1
+++ b/tools/PSc8y/Public/Install-FirmwareVersion.ps1
@@ -38,10 +38,15 @@ Get a firmware version
         [object[]]
         $Version,
 
-        # Firmware url. TODO, not currently automatically added
+        # Firmware url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository
         [Parameter()]
         [string]
-        $Url
+        $Url,
+
+        # Operation description
+        [Parameter()]
+        [string]
+        $Description
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Create", "Template"

--- a/tools/PSc8y/Public/Install-SoftwareVersion.ps1
+++ b/tools/PSc8y/Public/Install-SoftwareVersion.ps1
@@ -38,7 +38,7 @@ Get a software package
         [object[]]
         $Version,
 
-        # Software url
+        # Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository
         [Parameter()]
         [string]
         $Url,


### PR DESCRIPTION

### Features


#### cmd: `c8y firmware versions install`

* Added support for `--description` flag. By default the description will be automatically generated in the following format:

    ```sh
    # If a version is specified
    Install firmware: "{name}" ({version})

    # With an empty version
    Install firmware: "{name}"
    ```
* Url field is automatically added if the matching firmware name/version is found in the Cumulocity firmware repository

    ```sh
    # Create a firmware and version
    c8y firmware create --name iot-linux |
        c8y firmware versions create --version 1.0.0 --url "https://example.com/image.tar.gz"
    
    # Install the firmware by referencing name/version
    c8y firmware versions install --device 12345 --firmware iot-linux --version 1.0.0
    ```

    The above `c8y firmware versions install` command produces the following operation body:
    
    ```jsonc
    // POST /devicecontrol/operations
    {
        "c8y_Firmware": {
            "name": "iot-linux",
            "url": "https://example.com/image.tar.gz",
            "version": "1.0.0"
        },
        "description": "Update firmware to: \"iot-linux\" (1.0.0)",
        "deviceId": "12345"
    }
    ```

#### cmd: `c8y software versions install`

* Ignore software version lookup when software, version and url are provided
