### PR TITLE
feat: c8y template execute: support non-json output

### DIFF
--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -396,10 +396,15 @@ func (b *MapBuilder) ApplyTemplates(existingJSON []byte, input []byte, appendTem
 		templates = append(templates, strings.TrimSpace(template))
 	}
 
-	if appendTemplates {
-		templates = append([]string{string(existingJSON)}, templates...)
-	} else {
-		templates = append(templates, string(existingJSON))
+	// Only merge in existing JSON if it is not just an empty object
+	// as the other templates might not be objects which can be merged together in jsonne
+	// e.g. "_.Int(1) + {}"  will cause an error
+	if !bytes.Equal(existingJSON, []byte("{}")) {
+		if appendTemplates {
+			templates = append([]string{string(existingJSON)}, templates...)
+		} else {
+			templates = append(templates, string(existingJSON))
+		}
 	}
 
 	var mergedJSON string

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -7,3 +7,45 @@ tests:
             line-count: 1
             json:
                 ..0.body.nestedProp.otherValue: '1'
+
+    It produces non-json output - integer:
+        command: |
+            c8y template execute --template "_.Int(10, 10)"
+        exit-code: 0
+        stdout:
+            exactly: |
+                10
+
+    It produces non-json output - boolean:
+        command: |
+            c8y template execute --template "true"
+        exit-code: 0
+        stdout:
+            exactly: |
+                true
+    
+    It produces non-json output - string:
+        command: |
+            c8y template execute --template "'device äöüß\n \u0031😀'"
+        exit-code: 0
+        stdout:
+            exactly: |
+                device äöüß
+                 1😀
+
+    It produces non-json output - ini output:
+        command: |
+            c8y template execute --template "std.manifestIni({sections: {main: {one:1,two:'2'}}})"
+        exit-code: 0
+        stdout:
+            exactly: |
+                [main]
+                one = 1
+                two = 2
+    
+    It produces non-json output - timestamp function:
+        command: |
+            c8y template execute --template "_.Now('-30d')"
+        exit-code: 0
+        stdout:
+            match-pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+.+)$


### PR DESCRIPTION
### `c8y template execute` support non-json output

Support for non-json output which allows more use-cases to generate output using the extensive [jsonnet](https://jsonnet.org/) templating language.

**Examples**

```sh
# Generate random integer
$ c8y template execute --template "_.Int(10,20)"
14

# Use to get relative date times using go-c8y-cli functions
$ c8y template execute --template "_.Now('-30d')"
2021-12-23T21:15:59.618Z

# Create ini format
$ c8y template execute --template "std.manifestIni({sections: {main: {one:1,two:'2'}}})"
[main]
one = 1
two = 2
```