### PR TITLE
fix: prevent panic during golang atomic operation when running on arm 32 bit cpu

### DIFF
--- a/pkg/iterator/func.go
+++ b/pkg/iterator/func.go
@@ -7,9 +7,9 @@ import (
 
 // FuncIterator is generic iterator which executes a function on every iteration
 type FuncIterator struct {
-	next         func(int64) (string, error)
+	currentIndex int64 // access atomically (must be defined at the top)
 	endIndex     int64
-	currentIndex int64
+	next         func(int64) (string, error)
 }
 
 // GetNext will count through the values and return them one by one

--- a/pkg/iterator/repeat.go
+++ b/pkg/iterator/repeat.go
@@ -7,9 +7,9 @@ import (
 
 // RepeatIterator is an empty iterator that always returns no value
 type RepeatIterator struct {
-	value        string
+	currentIndex int64 // access atomically (must be defined at the top)
 	endIndex     int64
-	currentIndex int64
+	value        string
 }
 
 // GetNext will count through the values and return them one by one

--- a/pkg/iterator/slice.go
+++ b/pkg/iterator/slice.go
@@ -7,8 +7,8 @@ import (
 
 // SliceIterator is iterates over a given array
 type SliceIterator struct {
+	currentIndex int64 // access atomically (must be defined at the top)
 	values       []string
-	currentIndex int64
 }
 
 // GetNext will count through the values and return them one by one


### PR DESCRIPTION
Fixes #104 by aligning int64 numbers to the top of structs.