### PR TITLE
Feat/user support templates and boolean filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,10 @@ checkout_addons:				## Checkout the go-c8y-cli-addons repository
 test: test_powershell test_powershell_sessions		## Run all tests
 
 test_powershell:				## Run powershell tests
-	pwsh -ExecutionPolicy bypass -NonInteractive -File tools/PSc8y/test.parallel.ps1 -ThrottleLimit $(TEST_THROTTLE_LIMIT) -TestFileFilter "$(TEST_FILE_FILTER)" -TestFileExclude "Set-Session|Get-SessionHomePath|Login|DisableCommands|BulkOperation|activitylog"
+	pwsh -ExecutionPolicy bypass -NonInteractive -File tools/PSc8y/test.parallel.ps1 -ThrottleLimit $(TEST_THROTTLE_LIMIT) -TestFileFilter "$(TEST_FILE_FILTER)" -TestFileExclude "Set-Session|Get-SessionHomePath|Login|DisableCommands|BulkOperation|activitylog|Invoke-UserLogout"
 
 test_powershell_sessions:		## Run powershell tests which interfere with the session variable
-	pwsh -ExecutionPolicy bypass -NonInteractive -File tools/PSc8y/test.parallel.ps1 -ThrottleLimit 1 -TestFileFilter "Set-Session|Get-SessionHomePath|Login|DisableCommands|BulkOperation|activitylog"
+	pwsh -ExecutionPolicy bypass -NonInteractive -File tools/PSc8y/test.parallel.ps1 -ThrottleLimit 1 -TestFileFilter "Set-Session|Get-SessionHomePath|Login|DisableCommands|BulkOperation|activitylog|Invoke-UserLogout"
 
 test_cli: test_cli_auto test_cli_manual
 

--- a/api/spec/json/users.json
+++ b/api/spec/json/users.json
@@ -176,6 +176,11 @@
           {
             "description": "Create a user",
             "command": "c8y users create --userName \"testuser1\" --email \"testuser@no-reply.dummy.com\" --password \"a0)8k2kld9lm!\""
+          },
+          {
+            "description": "Create a user using a template",
+            "command": "c8y users create --template \"{email: 'test@me.com', userName: $.email, firstName: 'Peter'}\" --sendPasswordResetEmail\n",
+            "skipTest": true
           }
         ]
       },
@@ -246,11 +251,13 @@
           "type": "json_custom",
           "required": false,
           "description": "Custom properties to be added to the user"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Custom properties"
         }
       ],
-      "bodyTemplateOptions": {
-        "enabled": true
-      },
       "bodyRequiredKeys": [
         "userName"
       ]
@@ -424,6 +431,11 @@
           {
             "description": "Update a user",
             "command": "c8y users update --id \"myuser\" --firstName \"Simon\""
+          },
+          {
+            "description": "Update the email field in each user to match the id (if the id includes the @ sign)",
+            "command": "c8y users list --filter \"id like *@*\" | c8y users update --template \"{email: input.value.id}\"\n",
+            "skipTest": true
           }
         ]
       },
@@ -495,6 +507,11 @@
           "type": "json_custom",
           "required": false,
           "description": "Custom properties to be added to the user"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Custom properties"
         }
       ]
     },

--- a/api/spec/yaml/users.yaml
+++ b/api/spec/yaml/users.yaml
@@ -132,6 +132,12 @@ endpoints:
       go:
         - description: Create a user
           command: c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password "a0)8k2kld9lm!"
+
+        - description: Create a user using a template
+          command: |
+            c8y users create --template "{email: 'test@me.com', userName: $.email, firstName: 'Peter'}" --sendPasswordResetEmail
+          skipTest: true
+
     pathParameters:
       - name: tenant
         type: tenant
@@ -187,8 +193,9 @@ endpoints:
         required: false
         description: 'Custom properties to be added to the user'
 
-    bodyTemplateOptions:
-      enabled: true
+      - name: data
+        type: json
+        description: Custom properties
 
     bodyRequiredKeys:
       - "userName"
@@ -312,6 +319,12 @@ endpoints:
       go:
         - description: Update a user
           command: c8y users update --id "myuser" --firstName "Simon"
+
+        - description: Update the email field in each user to match the id (if the id includes the @ sign)
+          command: |
+            c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"
+          skipTest: true
+
     pathParameters:
       - name: id
         type: '[]user'
@@ -324,6 +337,7 @@ endpoints:
         required: false
         position: 99
         description: Tenant
+
     body:
       - name: firstName
         type: string
@@ -367,6 +381,11 @@ endpoints:
         type: json_custom
         required: false
         description: 'Custom properties to be added to the user'
+
+      - name: data
+        type: json
+        description: Custom properties
+
 
   - name: resetUserPassword
     description: Reset user password

--- a/pkg/cmd/users/create/create.auto.go
+++ b/pkg/cmd/users/create/create.auto.go
@@ -35,6 +35,10 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 		Example: heredoc.Doc(`
 $ c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password "a0)8k2kld9lm!"
 Create a user
+
+$ c8y users create --template "{email: 'test@me.com', userName: $.email, firstName: 'Peter'}" --sendPasswordResetEmail
+
+Create a user using a template
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()
@@ -64,6 +68,7 @@ Create a user
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
+		flags.WithData(),
 		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("userName", "userName", false, "id"),
 	)

--- a/pkg/cmd/users/update/update.auto.go
+++ b/pkg/cmd/users/update/update.auto.go
@@ -36,6 +36,10 @@ func NewUpdateCmd(f *cmdutil.Factory) *UpdateCmd {
 		Example: heredoc.Doc(`
 $ c8y users update --id "myuser" --firstName "Simon"
 Update a user
+
+$ c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"
+
+Update the email field in each user to match the id (if the id includes the @ sign)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.UpdateModeEnabled()
@@ -66,7 +70,8 @@ Update a user
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true),
 	)
 

--- a/pkg/jsonfilter/jsonfilter.go
+++ b/pkg/jsonfilter/jsonfilter.go
@@ -78,6 +78,9 @@ func (f *JSONFilters) AddRawFilters(rawFilters []string) error {
 				// use int (required by jsonq in some cases, i.e. array length operators like leneq etc.)
 				f.Add(strings.TrimSpace(parts[0]), operator, int(v))
 			}
+		} else if v, err := strconv.ParseBool(value); err == nil {
+			// Check boolean values
+			f.Add(strings.TrimSpace(parts[0]), operator, bool(v))
 		} else {
 			f.Add(strings.TrimSpace(parts[0]), operator, value)
 		}

--- a/tests/auto/users/tests/users_create.yaml
+++ b/tests/auto/users/tests/users_create.yaml
@@ -9,3 +9,13 @@ tests:
                 body.userName: testuser1
                 method: POST
                 path: /user/$C8Y_TENANT/users
+    users_create_Create a user using a template:
+        command: |
+            c8y users create --template "{email: 'test@me.com', userName: $.email, firstName: 'Peter'}" --sendPasswordResetEmail
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.sendPasswordResetEmail: "true"
+                method: POST
+                path: /user/$C8Y_TENANT/users

--- a/tests/auto/users/tests/users_update.yaml
+++ b/tests/auto/users/tests/users_update.yaml
@@ -7,3 +7,11 @@ tests:
                 body.firstName: Simon
                 method: PUT
                 path: /user/$C8Y_TENANT/users/myuser
+    users_update_Update the email field in each user to match the id (if the id includes the @ sign):
+        command: '$TEST_SHELL -c ''c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"'''
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                method: PUT
+                path: /user/$C8Y_TENANT/users/{id}

--- a/tests/manual/common/filter/filter_options.yml
+++ b/tests/manual/common/filter/filter_options.yml
@@ -4,8 +4,6 @@ config:
     C8Y_SETTINGS_DEFAULTS_CACHE: true
     C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
     C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
-    C8Y_SETTINGS_DEFAULTS_OUTPUT: csv
-
 
 tests:
   It can filter properties with newline characters using wildcards:
@@ -23,3 +21,19 @@ tests:
     stdout:
       exactly: |
         {"failureReason":"Some complex\nreason\nwith\nmultiple lines","id":"1"}
+
+  It can filter boolean properties:
+    command: |
+      c8y util repeat 2 | c8y template execute --template "{value: if input.index == 1 then true else false}" | c8y util show --filter "value eq true" -o json
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":true}
+
+  It can filter boolean properties (false):
+    command: |
+      c8y util repeat 2 | c8y template execute --template "{value: if input.index == 1 then true else false}" | c8y util show --filter "value = false" -o json
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":false}

--- a/tests/manual/users/create/users_create.yaml
+++ b/tests/manual/users/create/users_create.yaml
@@ -1,0 +1,13 @@
+
+tests:
+    Create a users using a template:
+        command: |
+          c8y users create --template "{email: 'test@me.com', userName: $.email}" --data "firstName=Peter" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /user/$C8Y_TENANT/users
+                body.userName: test@me.com
+                body.email: test@me.com
+                body.firstName: Peter

--- a/tests/manual/users/update/users_update.yaml
+++ b/tests/manual/users/update/users_update.yaml
@@ -1,0 +1,12 @@
+
+tests:
+    Update the email field using a template:
+        command: |
+          c8y template execute --template "{id: 'test@me.com'}" | c8y users update --template "{email: input.value.id}" --data "firstName=Peter" --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: PUT
+                path: /user/$C8Y_TENANT/users/test@me.com
+                body.email: test@me.com
+                body.firstName: Peter


### PR DESCRIPTION
* feat: c8y users create/update: support template and data flags
    ```sh
    # Create a user using a template
    c8y users create --template "{email: 'test@me.com', userName: $.email, firstName: 'Peter'}" --sendPasswordResetEmail

    # Update the email field in each user to match the id (if the id includes the @ sign)
    c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"
    ```
* fix: filter flag now supports filtering by Boolean values
    ```sh
    echo "{\"value\": true}" | c8y util show --filter "value eq true"
    ```
