### PR TITLE
Feat/alarm filter 10.11

### DIFF
--- a/api/spec/json/alarms.json
+++ b/api/spec/json/alarms.json
@@ -121,6 +121,26 @@
           "name": "withSourceDevices",
           "type": "boolean",
           "description": "When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined."
+        },
+        {
+          "name": "createdFrom",
+          "type": "datetime",
+          "description": "Start date or date and time of the alarm creation. Version >= 10.11"
+        },
+        {
+          "name": "createdTo",
+          "type": "datetime",
+          "description": "End date or date and time of the alarm creation. Version >= 10.11"
+        },
+        {
+          "name": "lastUpdatedFrom",
+          "type": "datetime",
+          "description": "Start date or date and time of the last update made. Version >= 10.11"
+        },
+        {
+          "name": "lastUpdatedTo",
+          "type": "datetime",
+          "description": "End date or date and time of the last update made. Version >= 10.11"
         }
       ]
     },
@@ -295,6 +315,16 @@
             "ACKNOWLEDGED",
             "CLEARED"
           ]
+        },
+        {
+          "name": "createdFrom",
+          "type": "datetime",
+          "description": "Start date or date and time of the alarm creation. Version >= 10.11"
+        },
+        {
+          "name": "createdTo",
+          "type": "datetime",
+          "description": "End date or date and time of the alarm creation. Version >= 10.11"
         },
         {
           "name": "data",
@@ -562,6 +592,16 @@
           "name": "dateTo",
           "type": "datetime",
           "description": "End date or date and time of alarm occurrence."
+        },
+        {
+          "name": "createdFrom",
+          "type": "datetime",
+          "description": "Start date or date and time of the alarm creation. Version >= 10.11"
+        },
+        {
+          "name": "createdTo",
+          "type": "datetime",
+          "description": "End date or date and time of the alarm creation. Version >= 10.11"
         },
         {
           "name": "type",

--- a/api/spec/yaml/alarms.yaml
+++ b/api/spec/yaml/alarms.yaml
@@ -90,22 +90,21 @@ endpoints:
         description: When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.
 
       # API Version >= 10.11
-      # createFrom, createdTo, lastUpdateFrom, lastUpdatedTo
-      # - name: createdFrom
-      #   type: datetime
-      #   description: Start date or date and time of the alarm creation. Version >= 10.11
+      - name: createdFrom
+        type: datetime
+        description: Start date or date and time of the alarm creation. Version >= 10.11
 
-      # - name: createdTo
-      #   type: datetime
-      #   description: End date or date and time of the alarm creation. Version >= 10.11
+      - name: createdTo
+        type: datetime
+        description: End date or date and time of the alarm creation. Version >= 10.11
 
-      # - name: lastUpdatedFrom
-      #   type: datetime
-      #   description: Start date or date and time of the last update made. Version >= 10.11
+      - name: lastUpdatedFrom
+        type: datetime
+        description: Start date or date and time of the last update made. Version >= 10.11
 
-      # - name: lastUpdatedTo
-      #   type: datetime
-      #   description: End date or date and time of the last update made. Version >= 10.11
+      - name: lastUpdatedTo
+        type: datetime
+        description: End date or date and time of the last update made. Version >= 10.11
 
   - name: newAlarm
     method: POST
@@ -228,13 +227,13 @@ endpoints:
       
       # API Version >= 10.11
       # createFrom, createdTo
-      # - name: createdFrom
-      #   type: datetime
-      #   description: Start date or date and time of the alarm creation. Version >= 10.11
+      - name: createdFrom
+        type: datetime
+        description: Start date or date and time of the alarm creation. Version >= 10.11
 
-      # - name: createdTo
-      #   type: datetime
-      #   description: End date or date and time of the alarm creation. Version >= 10.11
+      - name: createdTo
+        type: datetime
+        description: End date or date and time of the alarm creation. Version >= 10.11
 
       - name: data
         type: json
@@ -420,13 +419,13 @@ endpoints:
       
       # API Version >= 10.11
       # createFrom, createdTo
-      # - name: createdFrom
-      #   type: datetime
-      #   description: Start date or date and time of the alarm creation. Version >= 10.11
+      - name: createdFrom
+        type: datetime
+        description: Start date or date and time of the alarm creation. Version >= 10.11
 
-      # - name: createdTo
-      #   type: datetime
-      #   description: End date or date and time of the alarm creation. Version >= 10.11
+      - name: createdTo
+        type: datetime
+        description: End date or date and time of the alarm creation. Version >= 10.11
 
       - name: type
         type: string

--- a/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
@@ -51,6 +51,8 @@ Remove alarms on the device which are active and created in the last 10 minutes
 	cmd.Flags().StringSlice("device", []string{""}, "Source device id. (accepts pipeline)")
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of alarm occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of alarm occurrence.")
+	cmd.Flags().String("createdFrom", "", "Start date or date and time of the alarm creation. Version >= 10.11")
+	cmd.Flags().String("createdTo", "", "End date or date and time of the alarm creation. Version >= 10.11")
 	cmd.Flags().String("type", "", "Alarm type.")
 	cmd.Flags().StringSlice("status", []string{""}, "Comma separated alarm statuses, for example ACTIVE,CLEARED.")
 	cmd.Flags().String("severity", "", "Alarm severity, for example CRITICAL, MAJOR, MINOR or WARNING.")
@@ -104,6 +106,8 @@ func (n *DeleteCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 		c8yfetcher.WithDeviceByNameFirstMatch(client, args, "device", "source"),
 		flags.WithEncodedRelativeTimestamp("dateFrom", "dateFrom", ""),
 		flags.WithEncodedRelativeTimestamp("dateTo", "dateTo", ""),
+		flags.WithEncodedRelativeTimestamp("createdFrom", "createdFrom", ""),
+		flags.WithEncodedRelativeTimestamp("createdTo", "createdTo", ""),
 		flags.WithStringValue("type", "type"),
 		flags.WithStringSliceCSV("status", "status", ""),
 		flags.WithStringValue("severity", "severity"),

--- a/pkg/cmd/alarms/list/list.auto.go
+++ b/pkg/cmd/alarms/list/list.auto.go
@@ -61,6 +61,10 @@ Get collection of active and acknowledged alarms in the last 1d
 	cmd.Flags().Bool("resolved", false, "When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.")
 	cmd.Flags().Bool("withSourceAssets", false, "When set to true also alarms for related source devices will be included in the request. When this parameter is provided a source must be specified.")
 	cmd.Flags().Bool("withSourceDevices", false, "When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.")
+	cmd.Flags().String("createdFrom", "", "Start date or date and time of the alarm creation. Version >= 10.11")
+	cmd.Flags().String("createdTo", "", "End date or date and time of the alarm creation. Version >= 10.11")
+	cmd.Flags().String("lastUpdatedFrom", "", "Start date or date and time of the last update made. Version >= 10.11")
+	cmd.Flags().String("lastUpdatedTo", "", "End date or date and time of the last update made. Version >= 10.11")
 
 	completion.WithOptions(
 		cmd,
@@ -114,6 +118,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("resolved", "resolved", ""),
 		flags.WithBoolValue("withSourceAssets", "withSourceAssets", ""),
 		flags.WithBoolValue("withSourceDevices", "withSourceDevices", ""),
+		flags.WithEncodedRelativeTimestamp("createdFrom", "createdFrom", ""),
+		flags.WithEncodedRelativeTimestamp("createdTo", "createdTo", ""),
+		flags.WithEncodedRelativeTimestamp("lastUpdatedFrom", "lastUpdatedFrom", ""),
+		flags.WithEncodedRelativeTimestamp("lastUpdatedTo", "lastUpdatedTo", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/alarms/updatecollection/updateCollection.auto.go
+++ b/pkg/cmd/alarms/updatecollection/updateCollection.auto.go
@@ -52,6 +52,8 @@ Update the status of all active alarms on a device to ACKNOWLEDGED
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of alarm occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of alarm occurrence.")
 	cmd.Flags().String("newStatus", "", "New status to be applied to all of the matching alarms")
+	cmd.Flags().String("createdFrom", "", "Start date or date and time of the alarm creation. Version >= 10.11")
+	cmd.Flags().String("createdTo", "", "End date or date and time of the alarm creation. Version >= 10.11")
 
 	completion.WithOptions(
 		cmd,
@@ -148,6 +150,8 @@ func (n *UpdateCollectionCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("newStatus", "status"),
+		flags.WithRelativeTimestamp("createdFrom", "createdFrom", ""),
+		flags.WithRelativeTimestamp("createdTo", "createdTo", ""),
 		cmdutil.WithTemplateValue(cfg),
 		flags.WithTemplateVariablesValue(),
 		flags.WithRequiredProperties("status"),

--- a/tests/manual/inventory/001_wait.sh
+++ b/tests/manual/inventory/001_wait.sh
@@ -13,6 +13,6 @@ c8y inventory wait \
     --id $mo_id \
     --fragments "myTemp" \
     --interval 500ms \
-    --duration 5s \
+    --duration 10s \
     --select id,myTemp \
     --output json

--- a/tests/manual/inventory/002_wait.sh
+++ b/tests/manual/inventory/002_wait.sh
@@ -13,6 +13,6 @@ c8y inventory wait \
     --id $mo_id \
     --fragments '!myCustom.value' \
     --interval 500ms \
-    --duration 5s \
+    --duration 10s \
     --select "myCustom.**" \
     --output json

--- a/tools/PSc8y/Public/Get-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Get-AlarmCollection.ps1
@@ -78,7 +78,27 @@ Get active alarms from a device (using pipeline)
         # When set to true also alarms for related source devices will be removed. When this parameter is provided also source must be defined.
         [Parameter()]
         [switch]
-        $WithSourceDevices
+        $WithSourceDevices,
+
+        # Start date or date and time of the alarm creation. Version >= 10.11
+        [Parameter()]
+        [string]
+        $CreatedFrom,
+
+        # End date or date and time of the alarm creation. Version >= 10.11
+        [Parameter()]
+        [string]
+        $CreatedTo,
+
+        # Start date or date and time of the last update made. Version >= 10.11
+        [Parameter()]
+        [string]
+        $LastUpdatedFrom,
+
+        # End date or date and time of the last update made. Version >= 10.11
+        [Parameter()]
+        [string]
+        $LastUpdatedTo
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Remove-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Remove-AlarmCollection.ps1
@@ -48,6 +48,16 @@ Remove alarms on the device which are active and created in the last 10 minutes 
         [string]
         $DateTo,
 
+        # Start date or date and time of the alarm creation. Version >= 10.11
+        [Parameter()]
+        [string]
+        $CreatedFrom,
+
+        # End date or date and time of the alarm creation. Version >= 10.11
+        [Parameter()]
+        [string]
+        $CreatedTo,
+
         # Alarm type.
         [Parameter()]
         [string]

--- a/tools/PSc8y/Public/Update-AlarmCollection.ps1
+++ b/tools/PSc8y/Public/Update-AlarmCollection.ps1
@@ -64,7 +64,17 @@ Update the status of all active alarms on a device to ACKNOWLEDGED (using pipeli
         [Parameter()]
         [ValidateSet('ACTIVE','ACKNOWLEDGED','CLEARED')]
         [string]
-        $NewStatus
+        $NewStatus,
+
+        # Start date or date and time of the alarm creation. Version >= 10.11
+        [Parameter()]
+        [string]
+        $CreatedFrom,
+
+        # End date or date and time of the alarm creation. Version >= 10.11
+        [Parameter()]
+        [string]
+        $CreatedTo
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Update", "Template"


### PR DESCRIPTION
### Improvements

#### `c8y alarms list`

Added the following flags:

* `createdFrom` - Start date or date and time of the alarm creation. Version >= 10.11
* `createdTo` - End date or date and time of the alarm creation. Version >= 10.11
* `lastUpdatedFrom` - Start date or date and time of the last update made. Version >= 10.11
* `lastUpdatedTo` - End date or date and time of the last update made. Version >= 10.11


#### `c8y alarms updateCollection`

Added the following flags:

* `createdFrom` - Start date or date and time of the alarm creation. Version >= 10.11
* `createdTo` - End date or date and time of the alarm creation. Version >= 10.11


#### `c8y alarms deleteCollection`

Added the following flags:

* `createdFrom` - Start date or date and time of the alarm creation. Version >= 10.11
* `createdTo` - End date or date and time of the alarm creation. Version >= 10.11
