### PR TITLE
Feat/client filter date operator

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/filtering.md
+++ b/docs/go-c8y-cli/docs/concepts/filtering.md
@@ -30,10 +30,10 @@ The `filter` parameter uses a query language which supports the following operat
 |lengte|match length greater than or equal to value of (string/array/map)|`--filter "name lengte 10"` or `--filter "childAdditions.references lengte 1"`|
 |lenlt|match length less than value of (string/array/map)|`--filter "name lenlt 10"` or `--filter "childAdditions.references lenlt 1"`|
 |lenlte|match length less than or equal to value of (string/array/map)|`--filter "name lenlte 10"` or `--filter "childAdditions.references lenlte 1"`|
-|datelt|match date less than (older) to value of (datetime|relative)|`--filter "creationTime datelt 2022-01-02T12:00"`|
-|datelte (or 'olderthan')|match date less than (older) or equal to value of (datetime|relative)|`--filter "creationTime datelte 2022-01-02T12:00"`|
-|dategt|match date greater than (newer) to value of (datetime|relative)|`--filter "creationTime dategt 2022-01-02T12:00"`|
-|dategte (or 'newerthan')|match date greater than (newer) or equal to value of (datetime|relative)|`--filter "creationTime dategte 2022-01-02T12:00"`|
+|datelt|match date less than (older) to value of (datetime/relative)|`--filter "creationTime datelt 2022-01-02T12:00"`|
+|datelte (or 'olderthan')|match date less than (older) or equal to value of (datetime/relative)|`--filter "creationTime datelte 2022-01-02T12:00"`|
+|dategt|match date greater than (newer) to value of (datetime/relative)|`--filter "creationTime dategt 2022-01-02T12:00"`|
+|dategte (or 'newerthan')|match date greater than (newer) or equal to value of (datetime/relative)|`--filter "creationTime dategte 2022-01-02T12:00"`|
 
 ## Examples
 

--- a/docs/go-c8y-cli/docs/concepts/filtering.md
+++ b/docs/go-c8y-cli/docs/concepts/filtering.md
@@ -121,7 +121,7 @@ A date string can be used and it will be converted to your local timezone. i.e. 
 ```bash
 c8y inventory list \
     --pageSize 2000 \
-    --filter "creationTime newerthan -2h" \   
+    --filter "creationTime newerthan -2h" \
     --select id,creationTime
 ```
 

--- a/docs/go-c8y-cli/docs/concepts/filtering.md
+++ b/docs/go-c8y-cli/docs/concepts/filtering.md
@@ -30,9 +30,18 @@ The `filter` parameter uses a query language which supports the following operat
 |lengte|match length greater than or equal to value of (string/array/map)|`--filter "name lengte 10"` or `--filter "childAdditions.references lengte 1"`|
 |lenlt|match length less than value of (string/array/map)|`--filter "name lenlt 10"` or `--filter "childAdditions.references lenlt 1"`|
 |lenlte|match length less than or equal to value of (string/array/map)|`--filter "name lenlte 10"` or `--filter "childAdditions.references lenlte 1"`|
-
+|datelt|match date less than (older) to value of (datetime|relative)|`--filter "creationTime datelt 2022-01-02T12:00"`|
+|datelte (or 'olderthan')|match date less than (older) or equal to value of (datetime|relative)|`--filter "creationTime datelte 2022-01-02T12:00"`|
+|dategt|match date greater than (newer) to value of (datetime|relative)|`--filter "creationTime dategt 2022-01-02T12:00"`|
+|dategte (or 'newerthan')|match date greater than (newer) or equal to value of (datetime|relative)|`--filter "creationTime dategte 2022-01-02T12:00"`|
 
 ## Examples
+
+:::caution
+It is highly recommended to use server side filtering where you can (e.g. inventory query api). Server side filtering is much more efficient and it reduces the amount of data that the server needs to transfer to the client.
+
+But if you have a very specific use-case which can't be solved via server API then this section is for you. Remember you an also use `jq` and `grep` if can't find the right client side filtering operator.
+:::
 
 ### Filtering application with name that start with "co*"
 
@@ -48,4 +57,80 @@ c8y applications list --pageSize 100 --filter "name like co*"
 | id         | name         | key                          | type        | availability |
 |------------|--------------|------------------------------|-------------|--------------|
 | 8          | cockpit      | cockpit-application-key      | HOSTED      | MARKET       |
+```
+
+
+### Filtering application with name that start with "co*"
+
+<CodeExample>
+
+```bash
+c8y inventory list --pageSize 100 --filter "lastUpdated newerthan -10d"
+```
+
+</CodeExample>
+
+```csv title="output"
+| id         | name         | key                          | type        | availability |
+|------------|--------------|------------------------------|-------------|--------------|
+| 8          | cockpit      | cockpit-application-key      | HOSTED      | MARKET       |
+```
+
+### Filtering list of inventory (client side) by lastUpdated date between a given range
+
+A date string can be used and it will be converted to your local timezone. i.e. "2022-01-18" -> "2022-01-18T00:00:00Z" when running on a machine using UTC time.
+
+<CodeExample>
+
+```bash
+c8y inventory list \
+    --pageSize 20 \
+    --filter "lastUpdated newerthan 2022-01-18" \
+    --filter "lastUpdated olderthan 2022-01-18 15:00" \
+    --select id,lastUpdated
+```
+
+</CodeExample>
+
+```csv title="output"
+| id         | lastUpdated                   |
+|------------|-------------------------------|
+| 4207       | 2022-01-18T08:20:59.301Z      |
+| 4209       | 2022-01-18T08:21:00.204Z      |
+| 3211       | 2022-01-18T08:21:01.394Z      |
+| 2702       | 2022-01-18T09:29:23.990Z      |
+| 4115       | 2022-01-18T09:29:26.280Z      |
+| 4116       | 2022-01-18T09:29:28.761Z      |
+| 4150       | 2022-01-18T09:45:14.382Z      |
+| 2721       | 2022-01-18T09:45:16.703Z      |
+| 4153       | 2022-01-18T09:45:19.232Z      |
+| 4190       | 2022-01-18T11:26:46.037Z      |
+| 4751       | 2022-01-18T11:26:48.982Z      |
+| 2739       | 2022-01-18T11:26:52.188Z      |
+| 4767       | 2022-01-18T14:55:24.515Z      |
+| 2758       | 2022-01-18T14:55:26.860Z      |
+| 2759       | 2022-01-18T14:55:29.349Z      |
+```
+
+### Filtering list of inventory (client side) by creationTime date using relative timestamp
+
+A date string can be used and it will be converted to your local timezone. i.e. "2022-01-18" -> "2022-01-18T00:00:00Z" when running on a machine using UTC time.
+
+<CodeExample>
+
+```bash
+c8y inventory list \
+    --pageSize 2000 \
+    --filter "creationTime newerthan -2h" \   
+    --select id,creationTime
+```
+
+</CodeExample>
+
+```csv title="output"
+| id         | creationTime                  |
+|------------|-------------------------------|
+| 53758      | 2022-02-16T18:37:26.682Z      |
+| 53791      | 2022-02-16T18:49:35.689Z      |
+| 55624      | 2022-02-16T18:59:43.222Z      |
 ```

--- a/docs/go-c8y-cli/docs/concepts/filtering.md
+++ b/docs/go-c8y-cli/docs/concepts/filtering.md
@@ -60,22 +60,6 @@ c8y applications list --pageSize 100 --filter "name like co*"
 ```
 
 
-### Filtering application with name that start with "co*"
-
-<CodeExample>
-
-```bash
-c8y inventory list --pageSize 100 --filter "lastUpdated newerthan -10d"
-```
-
-</CodeExample>
-
-```csv title="output"
-| id         | name         | key                          | type        | availability |
-|------------|--------------|------------------------------|-------------|--------------|
-| 8          | cockpit      | cockpit-application-key      | HOSTED      | MARKET       |
-```
-
 ### Filtering list of inventory (client side) by lastUpdated date between a given range
 
 A date string can be used and it will be converted to your local timezone. i.e. "2022-01-18" -> "2022-01-18T00:00:00Z" when running on a machine using UTC time.
@@ -112,9 +96,9 @@ c8y inventory list \
 | 2759       | 2022-01-18T14:55:29.349Z      |
 ```
 
-### Filtering list of inventory (client side) by creationTime date using relative timestamp
+### Filtering list of inventory (client side) by creationTime date using a relative timestamp
 
-A date string can be used and it will be converted to your local timezone. i.e. "2022-01-18" -> "2022-01-18T00:00:00Z" when running on a machine using UTC time.
+Filter a list of inventory items and filter the managed objects which were created in the last 2 hours.
 
 <CodeExample>
 

--- a/tests/manual/common/filter/filter_dates.yml
+++ b/tests/manual/common/filter/filter_dates.yml
@@ -1,0 +1,145 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_OUTPUT: json
+
+tests:
+  It can filter dates which are newer than a reference dategt - match:
+    command: |
+      echo "2020-01-01T12:15:02Z\n2020-01-01T12:15:01Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value dategt 2020-01-01T12:15:00Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:02Z"}
+        {"value":"2020-01-01T12:15:01Z"}
+  
+  It can filter dates which are newer than a reference dategt - no match:
+    command: |
+      echo "2020-01-01T12:15:02Z\n2020-01-01T12:15:01Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value dategt 2020-01-01T12:15:01Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:02Z"}
+
+  It can filter dates which are newer than a reference dategt - relative match:
+    command: |
+      c8y template execute --template "{value: _.Now('-1d') }" |
+        c8y util show --filter "value dategt -25h"
+    exit-code: 0
+    stdout:
+      line-count: 1
+
+  It can filter dates which are newer than a reference dategte - match:
+    command: |
+      echo "2020-01-01T12:15:02Z\n2020-01-01T12:15:01Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value dategte 2020-01-01T12:15:01Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:02Z"}
+        {"value":"2020-01-01T12:15:01Z"}
+  
+  It can filter dates which are newer than a reference dategte - no match:
+    command: |
+      echo "2020-01-01T12:15:02Z\n2020-01-01T12:15:01Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value dategte 2020-01-01T12:15:02Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:02Z"}
+
+  It can filter dates which are newer than a reference newerthan (datelte alias) - no match:
+    command: |
+      echo "2020-01-01T12:15:02Z\n2020-01-01T12:15:01Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value newerthan 2020-01-01T12:15:02Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:02Z"}
+
+
+  It can filter dates which are older than a reference datelt - match:
+    command: |
+      echo "2020-01-01T12:17:02Z\n2020-01-01T12:15:00Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value datelt 2020-01-01T12:18:00Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:17:02Z"}
+        {"value":"2020-01-01T12:15:00Z"}
+
+  It can filter dates which are older than a reference datelt - no match:
+    command: |
+      echo "2020-01-01T12:17:02Z\n2020-01-01T12:15:00Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value datelt 2020-01-01T12:16:00Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:00Z"}
+
+  It can filter dates which are older than a reference datelt - relative:
+    command: |
+      c8y template execute --template "{value: _.Now('-1d') }" |
+        c8y util show --filter "value datelt -23h"
+    exit-code: 0
+    stdout:
+      line-count: 1
+
+  It can filter dates which are older than a reference datelte - match:
+    command: |
+      echo "2020-01-01T12:17:02Z\n2020-01-01T12:15:00Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value datelte 2020-01-01T12:17:02Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:17:02Z"}
+        {"value":"2020-01-01T12:15:00Z"}
+
+  It can filter dates which are older than a reference olderthan (datelte alias) - match:
+    command: |
+      echo "2020-01-01T12:17:02Z\n2020-01-01T12:15:00Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value olderthan 2020-01-01T12:17:02Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:17:02Z"}
+        {"value":"2020-01-01T12:15:00Z"}
+
+  It can filter dates which are older than a reference datelte - no match:
+    command: |
+      echo "2020-01-01T12:17:02Z\n2020-01-01T12:15:00Z" |
+        c8y template execute --template "{value: input.value}" |
+        c8y util show --filter "value datelte 2020-01-01T12:15:00Z" --select value
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T12:15:00Z"}
+
+
+  It can filter by dates across timezones:
+    command: |
+      # match
+      c8y template execute --template "{value: '2020-01-01T14:15:01Z'}" |
+        c8y util show --filter "value dategt 2020-01-01T10:15:00+02:00"
+
+      # no match
+      c8y template execute --template "{value: '2020-01-01T14:15:01Z'}" |
+        c8y util show --filter "value dategt 2020-01-01T16:15:01+02:00"
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"value":"2020-01-01T14:15:01Z"}


### PR DESCRIPTION
### Filter: Add date and relative date client side filtering

Add new operations to compare dates which is timezone aware and supports relative dates.

|Operator|Description|Example|
|--------|-----------|-------|
|datelt|match date less than (older) to value of (datetime/relative)|`--filter "creationTime datelt 2022-01-02T12:00"`|
|datelte (or 'olderthan')|match date less than (older) or equal to value of (datetime/relative)|`--filter "creationTime datelte 2022-01-02T12:00"`|
|dategt|match date greater than (newer) to value of (datetime/relative)|`--filter "creationTime dategt 2022-01-02T12:00"`|
|dategte (or 'newerthan')|match date greater than (newer) or equal to value of (datetime/relative)|`--filter "creationTime dategte 2022-01-02T12:00"`|

**Examples**

```bash
# filter by relative date
c8y inventory list \
    --pageSize 2000 \
    --filter "creationTime newerthan -2h" \
    --select id,creationTime

# filter by date range
c8y inventory list \
    --pageSize 20 \
    --filter "lastUpdated newerthan 2022-01-18" \
    --filter "lastUpdated olderthan 2022-01-18 15:00" \
    --select id,lastUpdated
```