### PR TITLE
fix: removed unused flags from c8y users list

### DIFF
--- a/api/spec/json/users.json
+++ b/api/spec/json/users.json
@@ -129,21 +129,6 @@
           "name": "withSubusersCount",
           "type": "boolean",
           "description": "if set to 'true', then each of returned users will contain additional field 'subusersCount' - number of direct subusers (users with corresponding 'owner')."
-        },
-        {
-          "name": "withApps",
-          "type": "boolean",
-          "description": "Include applications related to the user"
-        },
-        {
-          "name": "withGroups",
-          "type": "boolean",
-          "description": "Include group information"
-        },
-        {
-          "name": "withRoles",
-          "type": "boolean",
-          "description": "Include role information"
         }
       ]
     },

--- a/api/spec/yaml/users.yaml
+++ b/api/spec/yaml/users.yaml
@@ -98,18 +98,6 @@ endpoints:
         type: boolean
         description: if set to 'true', then each of returned users will contain additional field 'subusersCount' - number of direct subusers (users with corresponding 'owner').
 
-      - name: withApps
-        type: boolean
-        description: Include applications related to the user
-
-      - name: withGroups
-        type: boolean
-        description: Include group information
-
-      - name: withRoles
-        type: boolean
-        description: Include role information
-
 
   - name: newUser
     description: Create user

--- a/pkg/cmd/users/list/list.auto.go
+++ b/pkg/cmd/users/list/list.auto.go
@@ -51,9 +51,6 @@ Get a list of users
 	cmd.Flags().String("owner", "", "exact username")
 	cmd.Flags().Bool("onlyDevices", false, "If set to 'true', result will contain only users created during bootstrap process (starting with 'device_'). If flag is absent (or false) the result will not contain 'device_' users.")
 	cmd.Flags().Bool("withSubusersCount", false, "if set to 'true', then each of returned users will contain additional field 'subusersCount' - number of direct subusers (users with corresponding 'owner').")
-	cmd.Flags().Bool("withApps", false, "Include applications related to the user")
-	cmd.Flags().Bool("withGroups", false, "Include group information")
-	cmd.Flags().Bool("withRoles", false, "Include role information")
 
 	completion.WithOptions(
 		cmd,
@@ -101,9 +98,6 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("owner", "owner"),
 		flags.WithBoolValue("onlyDevices", "onlyDevices", ""),
 		flags.WithBoolValue("withSubusersCount", "withSubusersCount", ""),
-		flags.WithBoolValue("withApps", "withApps", ""),
-		flags.WithBoolValue("withGroups", "withGroups", ""),
-		flags.WithBoolValue("withRoles", "withRoles", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tools/PSc8y/Public/Get-UserCollection.ps1
+++ b/tools/PSc8y/Public/Get-UserCollection.ps1
@@ -47,21 +47,6 @@ Get a list of users
         [switch]
         $WithSubusersCount,
 
-        # Include applications related to the user
-        [Parameter()]
-        [switch]
-        $WithApps,
-
-        # Include group information
-        [Parameter()]
-        [switch]
-        $WithGroups,
-
-        # Include role information
-        [Parameter()]
-        [switch]
-        $WithRoles,
-
         # Tenant
         [Parameter()]
         [object]


### PR DESCRIPTION
### `c8y users list` - removed unused query parameters

Remove unused query parameters which were ignored by Cumulocity

* withApps
* withGroups
* withRoles
