### PR TITLE
fix: support multiple values in --id flags by using csv format

### DIFF
--- a/pkg/c8ywaiter/inventory.go
+++ b/pkg/c8ywaiter/inventory.go
@@ -66,15 +66,18 @@ func (s *InventoryState) formatFragments() []string {
 // Check check if inventory has the given fragments (or absence of fragments)
 func (s *InventoryState) Check(m interface{}) (done bool, err error) {
 	if mo, ok := m.(*c8y.ManagedObject); ok {
+		moId := s.ID
 
 		if mo == nil {
 			err := cmderrors.NewAssertionError(&cmderrors.AssertionError{
 				Type:    cmderrors.ManagedObjectFragments,
 				Wanted:  s.formatFragments(),
 				Got:     "",
-				Context: struct{ ID string }{ID: mo.ID},
+				Context: struct{ ID string }{ID: moId},
 			})
 			return false, err
+		} else if mo.ID != "" {
+			moId = mo.ID
 		}
 
 		done := true
@@ -127,7 +130,7 @@ func (s *InventoryState) Check(m interface{}) (done bool, err error) {
 				Type:    cmderrors.ManagedObjectFragments,
 				Wanted:  s.formatFragments(),
 				Got:     got,
-				Context: struct{ ID string }{ID: mo.ID},
+				Context: struct{ ID string }{ID: moId},
 			})
 		}
 	}
@@ -160,7 +163,7 @@ type managedObjectResponse struct {
 func (s *InventoryExistance) Check(m interface{}) (done bool, err error) {
 	if result, ok := m.(*managedObjectResponse); ok {
 		var exists, notFound bool
-		var moID string
+		moID := s.ID
 
 		if result.Response != nil {
 			exists = result.Response.StatusCode >= 200 && result.Response.StatusCode <= 399

--- a/pkg/cmd/devices/assert/factory/factory.manual.go
+++ b/pkg/cmd/devices/assert/factory/factory.manual.go
@@ -24,7 +24,7 @@ type StateChecker interface {
 }
 
 func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker) *cobra.Command {
-	cmd.Flags().String("id", "", "Inventory id (required) (accepts pipeline)")
+	cmd.Flags().StringSlice("id", []string{""}, "Inventory id (required) (accepts pipeline)")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
 	cmd.Flags().Int64("retries", 0, "Number of retries before giving up per id")
@@ -84,7 +84,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			cmd,
 			path,
 			inputIterators,
-			flags.WithStringValue("id", "id"),
+			c8yfetcher.WithIDSlice(args, "id", "id"),
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/inventory/assert/factory/factory.manual.go
+++ b/pkg/cmd/inventory/assert/factory/factory.manual.go
@@ -23,7 +23,7 @@ type StateChecker interface {
 }
 
 func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker) *cobra.Command {
-	cmd.Flags().String("id", "", "Inventory id (required) (accepts pipeline)")
+	cmd.Flags().StringSlice("id", []string{""}, "Inventory id (required) (accepts pipeline)")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
 	cmd.Flags().Int64("retries", 0, "Number of retries before giving up per id")
@@ -83,7 +83,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			cmd,
 			path,
 			inputIterators,
-			flags.WithStringValue("id", "id"),
+			c8yfetcher.WithIDSlice(args, "id", "id"),
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/operations/wait/wait.manual.go
+++ b/pkg/cmd/operations/wait/wait.manual.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/c8yfetcher"
 	"github.com/reubenmiller/go-c8y-cli/pkg/c8ywaiter"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmderrors"
@@ -49,7 +50,7 @@ func NewCmdWait(f *cmdutil.Factory) *CmdWait {
 
 	cmd.SilenceUsage = true
 
-	cmd.Flags().String("id", "", "Operation id (required) (accepts pipeline)")
+	cmd.Flags().StringSlice("id", []string{""}, "Operation id (required) (accepts pipeline)")
 	cmd.Flags().StringSliceVar(&ccmd.ExpectedStatus, "status", []string{"SUCCESSFUL"}, "Status to wait for. If multiple values are given, then it will be applied as an OR operation")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	flags.WithOptions(
@@ -93,7 +94,7 @@ func (n *CmdWait) RunE(cmd *cobra.Command, args []string) error {
 		cmd,
 		path,
 		inputIterators,
-		flags.WithStringValue("id", "id"),
+		c8yfetcher.WithIDSlice(args, "id", "id"),
 	)
 	if err != nil {
 		return err

--- a/tests/manual/devices/assert/exists/devices_assert_exists.yaml
+++ b/tests/manual/devices/assert/exists/devices_assert_exists.yaml
@@ -13,6 +13,22 @@ tests:
         command:  c8y devices assert exists --device 1 --strict --dry
         exit-code: 112
 
+    It accepts multiple ids using comma separated values:
+        command: |
+            c8y inventory assert exists --id 1,2 --strict --dry --dryFormat json \
+            | c8y util show --select path
+        exit-code: 0
+        stderr:
+            line-count: 2
+            contains:
+                - "assertionError: managedObject - wanted: Found, got: NotFound, context: {ID:1}"
+                - "assertionError: managedObject - wanted: Found, got: NotFound, context: {ID:2}"
+        stdout:
+            line-count: 2
+            json:
+                ..0.path: /inventory/managedObjects/1
+                ..1.path: /inventory/managedObjects/2
+
     It filters a single id that does not exist (using pipeline):
         command: echo "1" | c8y devices assert exists --not
         exit-code: 0

--- a/tests/manual/devices/assert/fragments/devices_assert_fragments.yaml
+++ b/tests/manual/devices/assert/fragments/devices_assert_fragments.yaml
@@ -1,20 +1,11 @@
 tests:
-    It fails the negated assertion when using dry mode (strict mode):
-        command:  c8y inventory assert fragments --id 1 --fragments name --strict --dry
+    It fails the assertion when using dry mode (strict mode):
+        command:  c8y devices assert fragments --device 1 --fragments name --strict --dry
         exit-code: 112
-
-    It returns an error if the fragment value does not match:
-        command: >
-            manual/inventory/assert/fragments/001_assert.sh
-        exit-code: 112
-        stderr:
-            contains:
-                - 'wanted: [name=example01]'
-                - 'got: [name=device01]'
 
     It accepts multiple ids using comma separated values:
         command: |
-            c8y inventory assert fragments --id 1,2 --fragments name --strict --dry --dryFormat json \
+            c8y devices assert fragments --device 1,2 --fragments name --strict --dry --dryFormat json \
             | c8y util show --select path
         exit-code: 0
         stderr:

--- a/tests/manual/inventory/assert/exists/inventory_assert_exists.yaml
+++ b/tests/manual/inventory/assert/exists/inventory_assert_exists.yaml
@@ -13,6 +13,22 @@ tests:
         command:  c8y inventory assert exists --id 1 --strict --dry
         exit-code: 112
 
+    It accepts multiple ids using comma separated values:
+        command: |
+            c8y inventory assert exists --id 1,2 --strict --dry --dryFormat json \
+            | c8y util show --select path
+        exit-code: 0
+        stderr:
+            line-count: 2
+            contains:
+                - "assertionError: managedObject - wanted: Found, got: NotFound, context: {ID:1}"
+                - "assertionError: managedObject - wanted: Found, got: NotFound, context: {ID:2}"
+        stdout:
+            line-count: 2
+            json:
+                ..0.path: /inventory/managedObjects/1
+                ..1.path: /inventory/managedObjects/2
+
     It filters a single id that does not exist (using pipeline):
         command: echo "1" | c8y inventory assert exists --not
         exit-code: 0

--- a/tests/manual/inventory/wait.yaml
+++ b/tests/manual/inventory/wait.yaml
@@ -13,3 +13,14 @@ tests:
         stdout:
             line-count: 1
             exactly: '{}'
+
+    It accepts multiple ids provided as arguments:
+        command: |
+            c8y inventory wait --id 1,2 --dry --dryFormat json \
+            | c8y util show --select path
+        exit-code: 0
+        stdout:
+            line-count: 2
+            json:
+                ..0.path: /inventory/managedObjects/1
+                ..1.path: /inventory/managedObjects/2

--- a/tests/manual/operations/wait/operations_wait.yaml
+++ b/tests/manual/operations/wait/operations_wait.yaml
@@ -1,0 +1,11 @@
+tests:
+    It accepts multiple ids provided as arguments:
+        command: |
+            c8y operations wait --id 1,2 --dry --dryFormat json \
+            | c8y util show --select path
+        exit-code: 0
+        stdout:
+            line-count: 2
+            json:
+                ..0.path: /devicecontrol/operations/1
+                ..1.path: /devicecontrol/operations/2


### PR DESCRIPTION

## Add support for multiple values in the id flag. Multiple values will behave in the same way if they were provided via the pipeline.

* `c8y inventory assert exists --id 1,2`
* `c8y inventory wait --id 1,2`
* `c8y inventor assert fragments --id 1,2`
* `c8y operations wait --id 1,2`

**Example**

```sh
# Wait for c8y_Mobile fragment to exist on two managed objects (ids=1 and 2)
c8y inventory wait --id 1,2 --fragments c8y_Mobile

# Equivalent to using pipeline
echo -e "1\n2" | c8y inventory wait --fragments c8y_Mobile
```
