### PR TITLE
Issue 115/hostedapplication - Limit hosted applications to tenant scope

### DIFF
--- a/api/spec/json/applications.json
+++ b/api/spec/json/applications.json
@@ -561,7 +561,7 @@
       "pathParameters": [
         {
           "name": "id",
-          "type": "application",
+          "type": "hostedapplication",
           "pipeline": true,
           "required": true,
           "description": "Application id"
@@ -616,7 +616,7 @@
       "pathParameters": [
         {
           "name": "application",
-          "type": "application",
+          "type": "hostedapplication",
           "pipeline": false,
           "required": true,
           "description": "Application id"

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -79,6 +79,7 @@
       "enum": [
         "application",
         "applicationname",
+        "hostedapplication",
         "boolean",
         "booleanDefault",
         "optional_fragment",

--- a/api/spec/yaml/applications.yaml
+++ b/api/spec/yaml/applications.yaml
@@ -420,7 +420,7 @@ endpoints:
           command: c8y applications listApplicationBinaries --id 12345
     pathParameters:
       - name: id
-        type: application
+        type: hostedapplication
         pipeline: true
         required: true
         description: Application id
@@ -461,7 +461,7 @@ endpoints:
           command: c8y applications deleteApplicationBinary --application 12345 --binaryId 9876
     pathParameters:
       - name: application
-        type: application
+        type: hostedapplication
         pipeline: false
         required: true
         description: Application id

--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -631,6 +631,14 @@ func WithApplicationByNameFirstMatch(client *c8y.Client, args []string, opts ...
 	}
 }
 
+// WithHostedApplicationByNameFirstMatch add reference by name matching for hosted (web) applications via cli args. Only the first match will be used
+func WithHostedApplicationByNameFirstMatch(client *c8y.Client, args []string, opts ...string) flags.GetOption {
+	return func(cmd *cobra.Command, inputIterators *flags.RequestInputIterators) (string, interface{}, error) {
+		opt := WithReferenceByNameFirstMatch(client, NewHostedApplicationFetcher(client), args, opts...)
+		return opt(cmd, inputIterators)
+	}
+}
+
 // WithMicroserviceByNameFirstMatch add reference by name matching for microservices via cli args. Only the first match will be used
 func WithMicroserviceByNameFirstMatch(client *c8y.Client, args []string, opts ...string) flags.GetOption {
 	return func(cmd *cobra.Command, inputIterators *flags.RequestInputIterators) (string, interface{}, error) {

--- a/pkg/c8yfetcher/hostedApplicationFetcher.go
+++ b/pkg/c8yfetcher/hostedApplicationFetcher.go
@@ -66,6 +66,18 @@ func (f *HostedApplicationFetcher) getByName(name string) ([]fetcherResultSet, e
 
 	for i, app := range col.Applications {
 		if app.Type == "HOSTED" && pattern.MatchString(app.Name) {
+
+			// Ignore applications which don't match the owner
+			// so that it can overwrite existing applications such as cockpit and devicemanagement.
+			// Otherwise it will always match the in-built apps
+			if f.client.TenantName != "" {
+				if app.Owner != nil && app.Owner.Tenant != nil && app.Owner.Tenant.ID != "" {
+					if app.Owner.Tenant.ID != f.client.TenantName {
+						continue
+					}
+				}
+			}
+
 			results = append(results, fetcherResultSet{
 				ID:    app.ID,
 				Name:  app.Name,

--- a/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
+++ b/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
@@ -60,7 +60,7 @@ func NewCmdCreateHostedApplication(f *cmdutil.Factory) *CmdCreateHostedApplicati
 
 	cmd.SilenceUsage = true
 
-	cmd.Flags().StringVar(&ccmd.file, "file", "", "File or Folder of the web application. It should contains a index.html file in the root folder/ or zip file")
+	cmd.Flags().StringVar(&ccmd.file, "file", "", "File or Folder of the web application. It should contain a index.html file in the root folder/ or zip file")
 	cmd.Flags().StringVar(&ccmd.name, "name", "", "Name of application")
 	cmd.Flags().StringVar(&ccmd.key, "key", "", "Shared secret of application. Defaults to the name")
 	cmd.Flags().StringVar(&ccmd.availability, "availability", "", "Access level for other tenants. Possible values are : MARKET, PRIVATE (default)")

--- a/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
+++ b/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
@@ -52,7 +52,7 @@ Remove an application binary related to a Hosted (web) application
 
 	completion.WithOptions(
 		cmd,
-		completion.WithApplication("application", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithHostedApplication("application", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
@@ -144,7 +144,7 @@ func (n *DeleteApplicationBinaryCmd) RunE(cmd *cobra.Command, args []string) err
 		cmd,
 		path,
 		inputIterators,
-		c8yfetcher.WithApplicationByNameFirstMatch(client, args, "application", "application"),
+		c8yfetcher.WithHostedApplicationByNameFirstMatch(client, args, "application", "application"),
 		c8yfetcher.WithIDSlice(args, "binaryId", "binaryId"),
 	)
 	if err != nil {

--- a/pkg/cmd/applications/listapplicationbinaries/listApplicationBinaries.auto.go
+++ b/pkg/cmd/applications/listapplicationbinaries/listApplicationBinaries.auto.go
@@ -51,7 +51,7 @@ List all of the binaries related to a Hosted (web) application
 
 	completion.WithOptions(
 		cmd,
-		completion.WithApplication("id", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithHostedApplication("id", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
@@ -146,7 +146,7 @@ func (n *ListApplicationBinariesCmd) RunE(cmd *cobra.Command, args []string) err
 		cmd,
 		path,
 		inputIterators,
-		c8yfetcher.WithApplicationByNameFirstMatch(client, args, "id", "id"),
+		c8yfetcher.WithHostedApplicationByNameFirstMatch(client, args, "id", "id"),
 	)
 	if err != nil {
 		return err

--- a/pkg/completion/application.go
+++ b/pkg/completion/application.go
@@ -68,6 +68,16 @@ func WithHostedApplication(flagName string, clientFunc func() (*c8y.Client, erro
 				if !strings.EqualFold(item.Type, "HOSTED") {
 					continue
 				}
+
+				// Ignore if not hosted in the current application
+				if client.TenantName != "" {
+					if item.Owner != nil && item.Owner.Tenant != nil && item.Owner.Tenant.ID != "" {
+						if item.Owner.Tenant.ID != client.TenantName {
+							continue
+						}
+					}
+				}
+
 				if toComplete == "" || MatchString(pattern, item.Name) || MatchString(pattern, item.ID) {
 					values = append(values, fmt.Sprintf("%s\t%s | id: %s", item.Name, item.Type, item.ID))
 				}

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -104,7 +104,7 @@
                 }
             }
 
-            if ($iArg.Type -notmatch "device\b|agent\b|group|devicegroup|self|application|software\b|softwareName\b|softwareversion\b|softwareversionName\b|firmware\b|firmwareName\b|firmwareversion\b|firmwareversionName\b|firmwarepatch\b|firmwarepatchName\b|configuration\b|deviceprofile\b|microservice|\[\]id|\[\]devicerequest") {
+            if ($iArg.Type -notmatch "device\b|agent\b|group|devicegroup|self|application|hostedapplication|software\b|softwareName\b|softwareversion\b|softwareversionName\b|firmware\b|firmwareName\b|firmwareversion\b|firmwareversionName\b|firmwarepatch\b|firmwarepatchName\b|configuration\b|deviceprofile\b|microservice|\[\]id|\[\]devicerequest") {
                 if ($RESTMethod -match "POST") {
                     # Add override capability to piped arguments, so the user can still override piped data with the argument
                     [void] $RESTBodyBuilderOptions.AppendLine("flags.WithOverrideValue(`"$($iarg.Name)`", `"$PipelineVariableProperty`"),")
@@ -154,7 +154,8 @@
         # Add Completions based on type
         $ArgType = $iArg.type
         switch -Regex ($ArgType) {
-            "application|applicationname" { [void] $CompletionBuilderOptions.AppendLine("completion.WithApplication(`"$($iArg.Name)`", func() (*c8y.Client, error) { return ccmd.factory.Client()}),") }
+            "^application|applicationname" { [void] $CompletionBuilderOptions.AppendLine("completion.WithApplication(`"$($iArg.Name)`", func() (*c8y.Client, error) { return ccmd.factory.Client()}),") }
+            "hostedapplication" { [void] $CompletionBuilderOptions.AppendLine("completion.WithHostedApplication(`"$($iArg.Name)`", func() (*c8y.Client, error) { return ccmd.factory.Client()}),") }
             "microservice\b" { [void] $CompletionBuilderOptions.AppendLine("completion.WithMicroservice(`"$($iArg.Name)`", func() (*c8y.Client, error) { return ccmd.factory.Client()}),") }
             "microserviceinstance" { [void] $CompletionBuilderOptions.AppendLine("completion.WithMicroserviceInstance(`"$($iArg.Name)`", `"id`", func() (*c8y.Client, error) { return ccmd.factory.Client()}),") }
             "role" { [void] $CompletionBuilderOptions.AppendLine("completion.WithUserRole(`"$($iArg.Name)`", func() (*c8y.Client, error) { return ccmd.factory.Client()}),") }
@@ -910,7 +911,7 @@ Function Get-C8yGoArgs {
             }
         }
 
-        {$_ -in "application", "applicationname"} {
+        {$_ -in "application", "applicationname", "hostedapplication"} {
             $SetFlag = if ($UseOption) {
                 'cmd.Flags().StringP("{0}", "{1}", "{2}", "{3}")' -f $Name, $OptionName, $Default, $Description
             } else {

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -84,6 +84,9 @@
         # application
         "application" = "c8yfetcher.WithApplicationByNameFirstMatch(client, args, `"${prop}`", `"${queryParam}`"),"
 
+        # hostedapplication (web app)
+        "hostedapplication" = "c8yfetcher.WithHostedApplicationByNameFirstMatch(client, args, `"${prop}`", `"${queryParam}`"),"
+
         # applicationname
         "applicationname" = "flags.WithStringValue(`"${prop}`", `"${queryParam}`"),"
 

--- a/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
+++ b/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
@@ -567,6 +567,7 @@ Function Get-IteratorFunction {
         "[]userself" { "(PSc8y\Expand-User $Variable)" }
         "[]user" { "(PSc8y\Expand-User $Variable)" }
         "application" { "(PSc8y\Expand-Application $Variable)" }
+        "hostedapplication" { "(PSc8y\Expand-Application $Variable)" }
         "microservice" { "(PSc8y\Expand-Microservice $Variable)" }
         "device" { "(PSc8y\Expand-Device $Variable)" }
         "event" { "(PSc8y\Expand-Event $Variable)" }

--- a/scripts/build-powershell/New-C8yPowershellArguments.ps1
+++ b/scripts/build-powershell/New-C8yPowershellArguments.ps1
@@ -78,6 +78,7 @@
         "[]userself" { "object[]"; break }
         "application" { "object[]"; break }
         "applicationname" { "string"; break }
+        "hostedapplication" { "object[]"; break }
         "boolean" { "switch"; break }
         "booleanDefault" { "switch"; break }
         "optional_fragment" { "switch"; break }

--- a/tests/manual/applications/createHostedApplication/applications_createHostedApplication.yaml
+++ b/tests/manual/applications/createHostedApplication/applications_createHostedApplication.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+    C8Y_SETTINGS_DEFAULTS_OUTPUT: json
+
+tests:
+    Create hosted (web) application overriding an existing application:
+        command: |
+          c8y applications createHostedApplication --name devicemanagement --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: POST
+                path: /application/applications
+                body.name: devicemanagement
+                body.contextPath: devicemanagement
+                body.key: devicemanagement-application-key
+                body.type: HOSTED
+                body.resourcesUrl: /


### PR DESCRIPTION
* Looking up an hosted web application should only match an application where the `owner.tenant.id` matches the current tenant id.
* c8y applications createHostedApplication should also accept a pipeline variable for the name (which can also be the id if the user wants to explicitly 

#### Affected commands
* `c8y applications createHostedApplication`
* `c8y applications deleteApplicationBinary`
* `c8y applications listApplicationBinaries`

