### PR TITLE
fix: fix display of error message which causes the output to be duplicated

### DIFF
--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -323,7 +323,6 @@ func (lh *LoginHandler) login() {
 								lh.C8Yclient.TFACode = input
 
 								if err := lh.C8Yclient.LoginUsingOAuth2(ctx, option.InitRequest); err != nil {
-									lh.Logger.Errorf("OAuth2 failed. %s", err)
 									return err
 								}
 								lh.TFACode = input


### PR DESCRIPTION
Skip logging error to console during validation as it interferes with the rendering of the text input.

**Before**

```
✗ Enter Two-Factor code: 2992511█
12022-03-06T23:28:35.636+0100	ERROR	OAuth2 failed. POST https://example.c8y.com/tenant/oauth?tenant_id=t2700: 401 general/internalError Invalid credentials! : Incorrect TFA TOTP code for
✗ Enter Two-Factor code: 29925111█
12022-03-06T23:28:35.845+0100	ERROR	OAuth2 failed. POST https://example.c8y.com/tenant/oauth?tenant_id=t2700: 401 general/internalError Invalid credentials! : Incorrect TFA TOTP code for
✗ Enter Two-Factor code: 299251111█
12022-03-06T23:28:36.100+0100	ERROR	OAuth2 failed. POST https://example.c8y.com/tenant/oauth?tenant_id=t2700: 401 general/internalError Invalid credentials! : For input string: "29925111
✗ Enter Two-Factor code: 2992511111█
12022-03-06T23:28:36.478+0100	ERROR	OAuth2 failed. POST https://example.c8y.com/tenant/oauth?tenant_id=t2700: 401 general/internalError Invalid credentials! : For input string: "29925111
✗ Enter Two-Factor code: 29925111111█
12022-03-06T23:28:36.947+0100	ERROR	OAuth2 failed. POST https://example.c8y.com/tenant/oauth?tenant_id=t2700: 401 general/internalError Invalid credentials! : For input string: "29925111
✗ Enter Two-Factor code: 299251111111█
```

**After**

```sh
2022-03-06T22:30:44.173Z        ERROR   OAuth2 failed. Invalid credentials! : For input string: "undefined"
Session details:
Host=example.c8y.com, username=exampleuser
✗ Enter Two-Factor code: 123456789█

```