### PR TITLE
Feat/open application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ tools/shell/completion/output/
 .env
 *.env
 .task/checksum
+.bin/

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	moul.io/http2curl/v2 v2.3.0
 )
 
+require github.com/cli/browser v1.1.0
+
 require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 h1:kHaBemcxl8o/pQ5VM1
 github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cli/browser v1.1.0 h1:xOZBfkfY9L9vMBgqb1YwRirGu6QFaQ5dP/vXt5ENSOY=
+github.com/cli/browser v1.1.0/go.mod h1:HKMQAt9t12kov91Mn7RfZxyJQQgWgyS/3SZswlZ5iTI=
 github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
 github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -705,6 +707,7 @@ golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/cmd/applications/open/open.manual.go
+++ b/pkg/cmd/applications/open/open.manual.go
@@ -1,0 +1,175 @@
+package open
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/c8yfetcher"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmderrors"
+	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/pkg/flags"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+// OpenCmd command
+type OpenCmd struct {
+	*subcommand.SubCommand
+
+	factory *cmdutil.Factory
+}
+
+// NewOpenCmd creates a command to Get application
+func NewOpenCmd(f *cmdutil.Factory) *OpenCmd {
+	ccmd := &OpenCmd{
+		factory: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "open",
+		Short: "Open application in a web browser",
+		Long:  `Open application in a web browser`,
+		Example: heredoc.Doc(`
+$ c8y applications open --application cockpit
+Open the cockpit application in a local web browser
+
+$ c8y devices list | c8y applications open --application devicemanagement --page control
+Open a multiple web browser tabs in the devicemanagement application, one for each device found
+        `),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+		RunE: ccmd.RunE,
+	}
+
+	cmd.SilenceUsage = true
+
+	cmd.Flags().String("application", "devicemanagement", "Application name, defaults to")
+	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject which is the source of this event. (accepts pipeline)")
+	cmd.Flags().String("page", "device-info", "Device management page to open. Only valid for a specific device")
+	cmd.Flags().String("path", "", "Custom path template which can reference values such as: {application}, {device}, {page}")
+
+	completion.WithOptions(
+		cmd,
+		completion.WithHostedApplication("application", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithValidateSet("page", "device-info", "measurements", "alarms", "control", "availability", "events", "identity"),
+	)
+
+	flags.WithOptions(
+		cmd,
+
+		flags.WithExtendedPipelineSupport("device", "device", false, "deviceId", "source.id", "managedObject.id", "id"),
+	)
+
+	cmdutil.DisableAuthCheck(cmd)
+
+	// Required flags
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+// RunE executes the command
+func (n *OpenCmd) RunE(cmd *cobra.Command, args []string) error {
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return err
+	}
+	client, err := n.factory.Client()
+	if err != nil {
+		return err
+	}
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
+	if err != nil {
+		return err
+	}
+
+	// query parameters
+	query := flags.NewQueryTemplate()
+	err = flags.WithQueryParameters(
+		cmd,
+		query,
+		inputIterators,
+		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+	)
+	if err != nil {
+		return cmderrors.NewUserError(err)
+	}
+
+	commonOptions, err := cfg.GetOutputCommonOptions(cmd)
+	if err != nil {
+		return cmderrors.NewUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+	}
+	commonOptions.AddQueryParameters(query)
+
+	application, err := cmd.Flags().GetString("application")
+	if err != nil {
+		return err
+	}
+
+	pathTemplate := ""
+	switch application {
+	case "devicemanagement":
+		pathTemplate = "/app/{application}/index.html#/device/{device}/{page}"
+
+	case "cockpit":
+		fallthrough
+	case "administration":
+		pathTemplate = "/app/{application}/index.html"
+	}
+
+	if cmd.Flags().Changed("page") {
+		customPath, err := cmd.Flags().GetString("page")
+		if err != nil {
+			return err
+		}
+		pathTemplate = customPath
+	}
+
+	// path parameters
+	path := flags.NewStringTemplate(pathTemplate)
+	err = flags.WithPathParameters(
+		cmd,
+		path,
+		inputIterators,
+		flags.WithStringValue("page", "page"),
+		flags.WithStringValue("application", "application"),
+		c8yfetcher.WithDeviceByNameFirstMatch(client, args, "device", "device"),
+	)
+	if err != nil {
+		return err
+	}
+
+	bounded := path.IsBound()
+	for {
+		url, _, err := path.GetNext()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		req, err := client.NewRequest("GET", string(url), "", nil)
+
+		if err != nil {
+			return err
+		}
+
+		if cfg.DryRun() {
+			fmt.Fprintf(n.factory.IOStreams.Out, "open %s in browser", req.URL.String())
+		} else {
+			if err := n.factory.Browser.Browse(req.URL.String()); err != nil {
+				return err
+			}
+		}
+
+		if !bounded {
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/factory/factory.go
+++ b/pkg/cmd/factory/factory.go
@@ -21,7 +21,7 @@ func New(appVersion string, buildBranch string, configFunc func() (*config.Confi
 		c8yExecutable = exe
 	}
 
-	return &cmdutil.Factory{
+	f := &cmdutil.Factory{
 		IOStreams:      io,
 		Config:         configFunc,
 		Client:         clientFunc,
@@ -33,4 +33,26 @@ func New(appVersion string, buildBranch string, configFunc func() (*config.Confi
 		BuildVersion:   appVersion,
 		BuildBranch:    buildBranch,
 	}
+	f.Browser = browser(f)
+	return f
+}
+
+func browser(f *cmdutil.Factory) cmdutil.Browser {
+	io := f.IOStreams
+	return cmdutil.NewBrowser(browserLauncher(f), io.Out, io.ErrOut)
+}
+
+// Browser precedence
+// 1. browser from config
+// 2. BROWSER
+func browserLauncher(f *cmdutil.Factory) string {
+	cfg, err := f.Config()
+	if err == nil {
+
+		if cfgBrowser := cfg.Browser(); cfgBrowser != "" {
+			return cfgBrowser
+		}
+	}
+
+	return os.Getenv("BROWSER")
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	apiCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/api"
 	applicationsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/applications"
 	applicationsCreateHostedCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/applications/createhostedapplication"
+	applicationsOpenCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/applications/open"
 	auditrecordsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/auditrecords"
 	binariesCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/binaries"
 	bulkoperationsCmd "github.com/reubenmiller/go-c8y-cli/pkg/cmd/bulkoperations"
@@ -381,6 +382,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	// applications
 	applications := applicationsCmd.NewSubCommand(f).GetCommand()
 	applications.AddCommand(applicationsCreateHostedCmd.NewCmdCreateHostedApplication(f).GetCommand())
+	applications.AddCommand(applicationsOpenCmd.NewOpenCmd(f).GetCommand())
 	cmd.AddCommand(applications)
 
 	// smart groups

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -26,8 +26,13 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+type Browser interface {
+	Browse(string) error
+}
+
 type Factory struct {
 	IOStreams      *iostreams.IOStreams
+	Browser        Browser
 	Client         func() (*c8y.Client, error)
 	Config         func() (*config.Config, error)
 	Logger         func() (*logger.Logger, error)

--- a/pkg/cmdutil/web_browser.go
+++ b/pkg/cmdutil/web_browser.go
@@ -1,0 +1,83 @@
+package cmdutil
+
+import (
+	"io"
+	"os/exec"
+
+	"github.com/cli/browser"
+	"github.com/cli/safeexec"
+	"github.com/google/shlex"
+)
+
+func NewBrowser(launcher string, stdout, stderr io.Writer) Browser {
+	return &webBrowser{
+		launcher: launcher,
+		stdout:   stdout,
+		stderr:   stderr,
+	}
+}
+
+type webBrowser struct {
+	launcher string
+	stdout   io.Writer
+	stderr   io.Writer
+}
+
+func (b *webBrowser) Browse(url string) error {
+	if b.launcher != "" {
+		launcherArgs, err := shlex.Split(b.launcher)
+		if err != nil {
+			return err
+		}
+		launcherExe, err := safeexec.LookPath(launcherArgs[0])
+		if err != nil {
+			return err
+		}
+		args := append(launcherArgs[1:], url)
+		cmd := exec.Command(launcherExe, args...)
+		cmd.Stdout = b.stdout
+		cmd.Stderr = b.stderr
+		return cmd.Run()
+	}
+
+	return browser.OpenURL(url)
+}
+
+type TestBrowser struct {
+	urls []string
+}
+
+func (b *TestBrowser) Browse(url string) error {
+	b.urls = append(b.urls, url)
+	return nil
+}
+
+func (b *TestBrowser) BrowsedURL() string {
+	if len(b.urls) > 0 {
+		return b.urls[0]
+	}
+	return ""
+}
+
+type _testing interface {
+	Errorf(string, ...interface{})
+	Helper()
+}
+
+func (b *TestBrowser) Verify(t _testing, url string) {
+	t.Helper()
+	if url != "" {
+		switch len(b.urls) {
+		case 0:
+			t.Errorf("expected browser to open URL %q, but it was never invoked", url)
+		case 1:
+			if url != b.urls[0] {
+				t.Errorf("expected browser to open URL %q, got %q", url, b.urls[0])
+			}
+		default:
+			t.Errorf("expected browser to open one URL, but was invoked %d times", len(b.urls))
+		}
+	} else if len(b.urls) > 0 {
+		t.Errorf("expected no browser to open, but was invoked %d times: %v", len(b.urls), b.urls)
+	}
+}

--- a/pkg/completion/application.go
+++ b/pkg/completion/application.go
@@ -43,6 +43,38 @@ func WithApplication(flagName string, clientFunc func() (*c8y.Client, error)) Op
 	}
 }
 
+// WithApplicationContext application context completion
+func WithApplicationContext(flagName string, clientFunc func() (*c8y.Client, error)) Option {
+	return func(cmd *cobra.Command) *cobra.Command {
+		_ = cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			client, err := clientFunc()
+			if err != nil {
+				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
+			}
+			items, _, err := client.Application.GetApplications(
+				context.Background(),
+				&c8y.ApplicationOptions{
+					PaginationOptions: *c8y.NewPaginationOptions(2000),
+				},
+			)
+
+			if err != nil {
+				values := []string{fmt.Sprintf("error. %s", err)}
+				return values, cobra.ShellCompDirectiveError
+			}
+			values := []string{}
+			pattern := "*" + toComplete + "*"
+			for _, item := range items.Applications {
+				if toComplete == "" || MatchString(pattern, item.ContextPath) || MatchString(pattern, item.Name) || MatchString(pattern, item.ID) {
+					values = append(values, fmt.Sprintf("%s\t%s | type: %s  id: %s", item.ContextPath, item.Name, item.Type, item.ID))
+				}
+			}
+			return values, cobra.ShellCompDirectiveNoFileComp
+		})
+		return cmd
+	}
+}
+
 // WithHostedApplication hosted application completion
 func WithHostedApplication(flagName string, clientFunc func() (*c8y.Client, error)) Option {
 	return func(cmd *cobra.Command) *cobra.Command {

--- a/pkg/completion/flags.go
+++ b/pkg/completion/flags.go
@@ -28,6 +28,15 @@ func WithValidateSet(flagName string, values ...string) Option {
 	}
 }
 
+func WithCustomValidateSet(flagName string, customFunc func() []string) Option {
+	return func(cmd *cobra.Command) *cobra.Command {
+		_ = cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return customFunc(), cobra.ShellCompDirectiveDefault
+		})
+		return cmd
+	}
+}
+
 // WithLazyRequired marks a flag as required but does not enforce it.
 func WithLazyRequired(flagName string, values ...string) Option {
 	return func(cmd *cobra.Command) *cobra.Command {

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -281,6 +281,9 @@ const (
 
 	// SettingsDefaultsInsecure allow insecure SSL connections
 	SettingsDefaultsInsecure = "settings.defaults.insecure"
+
+	// SettingsBrowser default browser
+	SettingsBrowser = "settings.browser"
 )
 
 var (
@@ -1298,6 +1301,11 @@ func (c *Config) CacheKeyIncludeAuth() bool {
 // SkipSSLVerify skip SSL verify
 func (c *Config) SkipSSLVerify() bool {
 	return c.viper.GetBool(SettingsDefaultsInsecure)
+}
+
+// Browser get default web browser
+func (c *Config) Browser() string {
+	return c.viper.GetString(SettingsBrowser)
 }
 
 // GetJSONSelect get json properties to be selected from the output. Only the given properties will be returned

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -408,6 +408,8 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsCacheKeyAuth, true),
 		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
+
+		WithBindEnv(SettingsBrowser, ""),
 	)
 
 	if err != nil {
@@ -836,6 +838,11 @@ func (c *Config) IsEncryptionEnabled() bool {
 // GetString returns a string from the configuration
 func (c *Config) GetString(key string) string {
 	return c.viper.GetString(key)
+}
+
+// GetStringSlice returns a slice of strings
+func (c *Config) GetStringSlice(key string) []string {
+	return c.viper.GetStringSlice(key)
 }
 
 // GetDefaultUsername returns the default username

--- a/pkg/flags/stringtemplate.go
+++ b/pkg/flags/stringtemplate.go
@@ -13,6 +13,7 @@ import (
 type StringTemplate struct {
 	template          string
 	templateVariables map[string]interface{}
+	allowEmptyValues  bool
 }
 
 // NewStringTemplate returns a new string template
@@ -24,9 +25,18 @@ func NewStringTemplate(template string) *StringTemplate {
 	}
 }
 
+// SetTemplate updates the string template
+func (b *StringTemplate) SetTemplate(template string) {
+	b.template = template
+}
+
 // SetVariable sets a give path variable which will be evalulated when fetching the next value
 func (b *StringTemplate) SetVariable(name string, value interface{}) {
 	b.templateVariables[name] = value
+}
+
+func (b *StringTemplate) SetAllowEmptyValues(value bool) {
+	b.allowEmptyValues = value
 }
 
 // GetTemplate return the string template
@@ -87,7 +97,7 @@ func (b *StringTemplate) Execute(ignoreIterators bool, template ...string) (outp
 		default:
 			currentValue = fmt.Sprintf("%v", v)
 		}
-		if currentValue != "" {
+		if b.allowEmptyValues || currentValue != "" {
 			output = strings.ReplaceAll(output, "{"+key+"}", currentValue)
 		}
 	}

--- a/tests/manual/applications/open/open.yaml
+++ b/tests/manual/applications/open/open.yaml
@@ -1,32 +1,53 @@
+config:
+  env:
+    C8Y_HOST: https://c8y.example.com/
+
 tests:
     It opens a web browser to the url for a specific device via pipeline:
         command: >
           echo "12345" | c8y applications open --application devicemanagement --page control --noBrowser
         exit-code: 0
         stdout:
-            contains:
-              - /apps/devicemanagement/index.html#/device/12345/control
+            exactly: https://c8y.example.com/apps/devicemanagement/index.html#/device/12345/control
 
     It opens a web browser to the cockpit application:
         command: >
           c8y applications open --application cockpit --noBrowser
         exit-code: 0
         stdout:
-            contains:
-              - /apps/cockpit/index.html
+            exactly: https://c8y.example.com/apps/cockpit/index.html
 
     It opens a web browser to the administration application:
         command: >
           c8y applications open --application administration --noBrowser
         exit-code: 0
         stdout:
-            contains:
-              - /apps/administration/index.html
+            exactly: https://c8y.example.com/apps/administration/index.html
 
     It opens a web browser to a custom path:
         command: >
           echo "12345" | c8y applications open --application devicemanagement --path "/apps/{application}/index.html#/device/{device}/custom_page" --noBrowser
         exit-code: 0
         stdout:
-            contains:
-              - /apps/devicemanagement/index.html#/device/12345/custom_page
+            exactly: https://c8y.example.com/apps/devicemanagement/index.html#/device/12345/custom_page
+
+    It opens a devicemanagment page without a device:
+        command: >
+          c8y applications open --application devicemanagement --noBrowser
+        exit-code: 0
+        stdout:
+            exactly: https://c8y.example.com/apps/devicemanagement/index.html#/
+
+    It opens a devicemanagment on a custom page without a device:
+        command: >
+          c8y applications open --application devicemanagement --page device --noBrowser
+        exit-code: 0
+        stdout:
+            exactly: https://c8y.example.com/apps/devicemanagement/index.html#/device
+
+    It opens a devicemanagment page with a device and custom page:
+        command: >
+          echo "12345" | c8y applications open --application devicemanagement --page control --noBrowser
+        exit-code: 0
+        stdout:
+            exactly: https://c8y.example.com/apps/devicemanagement/index.html#/device/12345/control

--- a/tests/manual/applications/open/open.yaml
+++ b/tests/manual/applications/open/open.yaml
@@ -1,0 +1,32 @@
+tests:
+    It opens a web browser to the url for a specific device via pipeline:
+        command: >
+          echo "12345" | c8y applications open --application devicemanagement --page control --noBrowser
+        exit-code: 0
+        stdout:
+            contains:
+              - /apps/devicemanagement/index.html#/device/12345/control
+
+    It opens a web browser to the cockpit application:
+        command: >
+          c8y applications open --application cockpit --noBrowser
+        exit-code: 0
+        stdout:
+            contains:
+              - /apps/cockpit/index.html
+
+    It opens a web browser to the administration application:
+        command: >
+          c8y applications open --application administration --noBrowser
+        exit-code: 0
+        stdout:
+            contains:
+              - /apps/administration/index.html
+
+    It opens a web browser to a custom path:
+        command: >
+          echo "12345" | c8y applications open --application devicemanagement --path "/apps/{application}/index.html#/device/{device}/custom_page" --noBrowser
+        exit-code: 0
+        stdout:
+            contains:
+              - /apps/devicemanagement/index.html#/device/12345/custom_page


### PR DESCRIPTION
New command to support opening a Cumulocity application in the user's default web browser.

### Examples

```sh
$ c8y applications open --application cockpit
Open the cockpit application in a local web browser

$ c8y devices list | c8y applications open --application devicemanagement --page control
Open a multiple web browser tabs in the devicemanagement application, one for each device found

$ c8y devicegroups list | c8y applications open --path "/apps/cockpit/index.html#/group/{device}/subassets"
Open a multiple web browser tabs for a list of device groups in the cockpit application
```

### Full Help

```
% c8y applications open --help
Open application in a web browser

Usage:
  c8y applications open [flags]

Examples:
$ c8y applications open --application cockpit
Open the cockpit application in a local web browser

$ c8y devices list | c8y applications open --application devicemanagement --page control
Open a multiple web browser tabs in the devicemanagement application, one for each device found

$ c8y devicegroups list | c8y applications open --path "/apps/cockpit/index.html#/group/{device}/subassets"
Open a multiple web browser tabs for a list of device groups in the cockpit application


Flags:
      --application string   Application name (default "devicemanagement")
      --device strings       Device to be opened up to. Only valid if the template references {device}. (accepts pipeline)
  -h, --help                 help for open
      --noBrowser            Print destination URL instead of opening the browser
      --page string          Device management page to open. Only valid for a specific device (default "device-info")
      --path string          Custom path template which can reference values such as: {application}, {device}, {page}
```