### PR TITLE
Feat/device list filter extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,9 +43,7 @@
 		},
 		"powershell.pester.useLegacyCodeLens": false,
 		"extensions.ignoreRecommendations": true,
-		"go.testEnvVars": {
-			"C8Y_SESSION": ""
-		},
+		"go.testEnvFile": "${workspaceFolder}/.env",
 		"go.delveConfig": {
 			"dlvLoadConfig": {
 				"maxStringLen": 1024,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,7 @@
 {
     "go.inferGopath": false,
     "powershell.codeFormatting.addWhitespaceAroundPipe": true,
-    "go.testEnvVars": {
-        "C8Y_SESSION": "/workspaces/go-c8y-cli/.cumulocity/test.runner.ciuser.json",
-    },
+    "go.testEnvFile": "${workspaceFolder}/.env",
     "cSpell.ignorePaths": [
         "**/package-lock.json",
         "**/node_modules/**",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,9 +4,27 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Build",
+            "label": "Build (incl. generate)",
             "type": "shell",
             "command": "task build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "never",
+                "focus": false,
+                "panel": "dedicated",
+                "showReuseMessage": true,
+                "clear": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Build-fast (w/o generate)",
+            "type": "shell",
+            "command": "task build-fast",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,6 +180,11 @@ tasks:
     sources:
       - api/spec/json/*.json
       - scripts/**/*.ps1
+      - tools/PSc8y/Public-manual/*.ps1
+      - tools/PSc8y/Private/*.ps1
+      - tools/PSc8y/completions/*.ps1
+      - tools/PSc8y/utilities/*.ps1
+      - tools/PSc8y/tools/*.ps1
     generates:
       - tools/PSc8y/**/*.ps1
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,6 +150,11 @@ tasks:
   # ---------------------------------------------------------------
   # Build
   # ---------------------------------------------------------------
+  build-fast:
+    desc: Build Fast
+    cmds:
+      - go build -o .bin/c8y cmd/c8y/main.go
+
   build:
     desc: Build
     cmds:

--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -22,6 +22,12 @@ func EqualJSON(t *testing.T, got []byte, want string) {
 	}
 }
 
+func Equal[T comparable](t *testing.T, wanted T, got T) {
+	if wanted != got {
+		t.Errorf(`Error. wanted=%v, got=%v`, wanted, got)
+	}
+}
+
 func OK(t *testing.T, err error) {
 	if err != nil {
 		t.Errorf(`Error. wanted=nil, got=%s`, err)

--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -22,7 +22,7 @@ func EqualJSON(t *testing.T, got []byte, want string) {
 	}
 }
 
-func Equal[T comparable](t *testing.T, wanted T, got T) {
+func Equal[T comparable](t *testing.T, got T, wanted T) {
 	if wanted != got {
 		t.Errorf(`Error. wanted=%v, got=%v`, wanted, got)
 	}

--- a/pkg/c8yfetcher/hostedApplicationFetcher.go
+++ b/pkg/c8yfetcher/hostedApplicationFetcher.go
@@ -93,10 +93,10 @@ func (f *HostedApplicationFetcher) getByName(name string) ([]fetcherResultSet, e
 // FindHostedApplications returns hosted applications given either an id or search text
 // @values: An array of ids, or names (with wildcards)
 // @lookupID: Lookup the data if an id is given. If a non-id text is given, the result will always be looked up.
-func FindHostedApplications(client *c8y.Client, values []string, lookupID bool) ([]entityReference, error) {
+func FindHostedApplications(client *c8y.Client, values []string, lookupID bool, format string) ([]entityReference, error) {
 	f := NewHostedApplicationFetcher(client)
 
-	formattedValues, err := lookupEntity(f, values, lookupID)
+	formattedValues, err := lookupEntity(f, values, lookupID, format)
 
 	if err != nil {
 		return nil, err

--- a/pkg/c8yfetcher/microserviceFetcher.go
+++ b/pkg/c8yfetcher/microserviceFetcher.go
@@ -81,10 +81,10 @@ func (f *MicroserviceFetcher) getByName(name string) ([]fetcherResultSet, error)
 // findMicroservices returns microservices given either an id or search text
 // @values: An array of ids, or names (with wildcards)
 // @lookupID: Lookup the data if an id is given. If a non-id text is given, the result will always be looked up.
-func FindMicroservices(client *c8y.Client, values []string, lookupID bool) ([]entityReference, error) {
+func FindMicroservices(client *c8y.Client, values []string, lookupID bool, format string) ([]entityReference, error) {
 	f := NewMicroserviceFetcher(client)
 
-	formattedValues, err := lookupEntity(f, values, lookupID)
+	formattedValues, err := lookupEntity(f, values, lookupID, format)
 
 	if err != nil {
 		return nil, err

--- a/pkg/c8yquerycmd/querycmd.go
+++ b/pkg/c8yquerycmd/querycmd.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewInventoryQueryRunner(cmd *cobra.Command, args []string, f *cmdutil.Factory, opts ...flags.C8YQueryOption) func() error {
+func NewInventoryQueryRunner(cmd *cobra.Command, args []string, f *cmdutil.Factory, opts ...flags.GetOption) func() error {
 	return func() error {
 		cfg, err := f.Config()
 		if err != nil {
@@ -35,6 +35,7 @@ func NewInventoryQueryRunner(cmd *cobra.Command, args []string, f *cmdutil.Facto
 
 		c8yQueryParts, err := flags.WithC8YQueryOptions(
 			cmd,
+			inputIterators,
 			opts...,
 		)
 

--- a/pkg/cmd/agents/list/list.manual.go
+++ b/pkg/cmd/agents/list/list.manual.go
@@ -90,11 +90,12 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 
 	c8yQueryParts, err := flags.WithC8YQueryOptions(
 		cmd,
-		flags.WithC8YQueryFixedString("(has(com_cumulocity_model_Agent))"),
-		flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-		flags.WithC8YQueryFormat("type", "(type eq '%s')"),
-		flags.WithC8YQueryFormat("fragmentType", "has(%s)"),
-		flags.WithC8YQueryFormat("owner", "(owner eq '%s')"),
+		inputIterators,
+		flags.WithStaticStringValue("agent", "(has(com_cumulocity_model_Agent))"),
+		flags.WithStringValue("name", "name", "(name eq '%s')"),
+		flags.WithStringValue("type", "type", "(type eq '%s')"),
+		flags.WithStringValue("fragmentType", "fragmentType", "has(%s)"),
+		flags.WithStringValue("owner", "owner", "(owner eq '%s')"),
 	)
 
 	if err != nil {

--- a/pkg/cmd/agents/list/list.manual.go
+++ b/pkg/cmd/agents/list/list.manual.go
@@ -2,10 +2,12 @@ package list
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/c8yfetcher"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
@@ -48,12 +50,15 @@ func NewCmdAgentList(f *cmdutil.Factory) *CmdAgentList {
 	cmd.Flags().String("type", "", "Filter by type")
 	cmd.Flags().String("fragmentType", "", "Filter by fragment type")
 	cmd.Flags().String("owner", "", "Filter by owner")
-	cmd.Flags().String("query", "", "Additional query filter (accepts pipeline)")
-	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
+	cmd.Flags().String("availability", "", "Filter by c8y_Availability.status")
+	cmd.Flags().String("lastMessageDateTo", "", "Filter c8y_Availability.lastMessage to a specific date")
+	cmd.Flags().String("lastMessageDateFrom", "", "Filter c8y_Availability.lastMessage from a specific date")
+	cmd.Flags().String("group", "", "Filter by group inclusion")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	flags.WithOptions(
 		cmd,
+		flags.WithCommonCumulocityQueryOptions(),
 		flags.WithExtendedPipelineSupport("query", "query", false, "c8y_DeviceQueryString"),
 	)
 
@@ -96,6 +101,10 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("type", "type", "(type eq '%s')"),
 		flags.WithStringValue("fragmentType", "fragmentType", "has(%s)"),
 		flags.WithStringValue("owner", "owner", "(owner eq '%s')"),
+		c8yfetcher.WithDeviceGroupByNameFirstMatch(client, args, "group", "group", "bygroupid(%s)"),
+		flags.WithStringValue("availability", "availability", "(c8y_Availability.status eq '%s')"),
+		flags.WithRelativeTimestamp("lastMessageDateTo", "lastMessageDateTo", "(c8y_Availability.lastMessage le '%s')"),
+		flags.WithRelativeTimestamp("lastMessageDateFrom", "lastMessageDateFrom", "(c8y_Availability.lastMessage ge '%s')"),
 	)
 
 	if err != nil {
@@ -105,7 +114,13 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 	// Compile query
 	// replace all spaces with "+" due to url encoding
 	filter := url.QueryEscape(strings.Join(c8yQueryParts, " and "))
-	orderBy := url.QueryEscape("name")
+	orderBy := "name"
+
+	if v, err := cmd.Flags().GetString("orderBy"); err == nil {
+		if v != "" {
+			orderBy = url.QueryEscape(v)
+		}
+	}
 	query.SetVariable("q", fmt.Sprintf("$filter=%s+$orderby=%s", filter, orderBy))
 
 	err = flags.WithQueryParameters(
@@ -131,6 +146,18 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 		return cmderrors.NewSystemError("Invalid query parameter")
 	}
 
+	// headers
+	headers := http.Header{}
+	err = flags.WithHeaders(
+		cmd,
+		headers,
+		inputIterators,
+		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetHeader(), nil }, "header"),
+	)
+	if err != nil {
+		return cmderrors.NewUserError(err)
+	}
+
 	// path parameters
 	path := flags.NewStringTemplate("inventory/managedObjects")
 	err = flags.WithPathParameters(
@@ -146,6 +173,7 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 		Method:       "GET",
 		Path:         path.GetTemplate(),
 		Query:        queryValue,
+		Header:       headers,
 		DryRun:       cfg.ShouldUseDryRun(cmd.CommandPath()),
 		IgnoreAccept: cfg.IgnoreAcceptHeader(),
 	}

--- a/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
+++ b/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
@@ -189,7 +189,7 @@ func (n *CmdCreateHostedApplication) RunE(cmd *cobra.Command, args []string) err
 	// TODO: Use the default name value from n.Name rather then reading it from the args again.
 	log.Infof("application name: %s", appDetails.Name)
 	if appDetails.Name != "" {
-		refs, err := c8yfetcher.FindHostedApplications(client, []string{appDetails.Name}, true)
+		refs, err := c8yfetcher.FindHostedApplications(client, []string{appDetails.Name}, true, "")
 
 		if err != nil {
 			return fmt.Errorf("Failed to find hosted application. %s", err)

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -459,11 +459,11 @@ func Test_DebugStdinCommand(t *testing.T) {
 	cmd := setupTest()
 	stdin := fakestdin.NewStdIn()
 	defer stdin.Restore()
-	stdin.Write(`` + "\n")
+	// stdin.Write(`` + "\n")
 	// stdin.Write(`{"source":{"id":"1111"}}` + "\n")
 
 	cmdtext := `
-	cache clean --dry --age 1s
+	events deleteCollection --type my_CustomType --dateFrom "-10d" --dry
 	`
 	cmdErr := ExecuteCmd(cmd, strings.TrimSpace(cmdtext))
 

--- a/pkg/cmd/configuration/list/list.manual.go
+++ b/pkg/cmd/configuration/list/list.manual.go
@@ -38,11 +38,11 @@ Get a list of configuration files
 				cmd,
 				args,
 				ccmd.factory,
-				flags.WithC8YQueryFixedString("(type eq 'c8y_ConfigurationDump')"),
-				flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-				flags.WithC8YQueryFormat("configurationType", "(configurationType eq '%s')"),
-				flags.WithC8YQueryFormat("deviceType", "(c8y_Filter.type eq '%s')"),
-				flags.WithC8YQueryFormat("description", "(description eq '%s')"),
+				flags.WithStaticStringValue("config", "(type eq 'c8y_ConfigurationDump')"),
+				flags.WithStringValue("name", "name", "(name eq '%s')"),
+				flags.WithStringValue("configurationType", "configurationType", "(configurationType eq '%s')"),
+				flags.WithStringValue("deviceType", "deviceType", "(c8y_Filter.type eq '%s')"),
+				flags.WithStringValue("description", "description", "(description eq '%s')"),
 			)
 			return handler()
 		},

--- a/pkg/cmd/devicegroups/list/list.manual.go
+++ b/pkg/cmd/devicegroups/list/list.manual.go
@@ -90,12 +90,13 @@ func (n *CmdList) getDeviceGroupCollection(cmd *cobra.Command, args []string) er
 
 	c8yQueryParts, err := flags.WithC8YQueryOptions(
 		cmd,
-		flags.WithC8YQueryFixedString("(has(c8y_IsDeviceGroup))"),
-		flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-		flags.WithC8YQueryFormat("type", "(type eq '%s')"),
-		flags.WithC8YQueryFormat("fragmentType", "has(%s)"),
-		flags.WithC8YQueryFormat("owner", "(owner eq '%s')"),
-		flags.WithC8YQueryBool("excludeRootGroup", "not(type eq 'c8y_DeviceGroup')"),
+		inputIterators,
+		flags.WithStaticStringValue("devicegroup", "(has(c8y_IsDeviceGroup))"),
+		flags.WithStringValue("name", "name", "(name eq '%s')"),
+		flags.WithStringValue("type", "type", "(type eq '%s')"),
+		flags.WithStringValue("fragmentType", "fragmentType", "has(%s)"),
+		flags.WithStringValue("owner", "owner", "(owner eq '%s')"),
+		flags.WithBoolValue("excludeRootGroup", "excludeRootGroup", "not(type eq 'c8y_DeviceGroup')"),
 	)
 
 	if err != nil {

--- a/pkg/cmd/devices/list/list.manual.go
+++ b/pkg/cmd/devices/list/list.manual.go
@@ -106,11 +106,11 @@ func (n *CmdDevicesList) RunE(cmd *cobra.Command, args []string) error {
 	c8yQueryParts, err := flags.WithC8YQueryOptions(
 		cmd,
 		inputIterators,
-		c8yfetcher.WithDeviceGroupByNameFirstMatch(client, args, "group", "group", "bygroupid(%s)"),
 		flags.WithStringValue("name", "name", "(name eq '%s')"),
 		flags.WithStringValue("type", "type", "(type eq '%s')"),
 		flags.WithStringValue("fragmentType", "fragmentType", "has(%s)"),
 		flags.WithStringValue("owner", "owner", "(owner eq '%s')"),
+		c8yfetcher.WithDeviceGroupByNameFirstMatch(client, args, "group", "group", "bygroupid(%s)"),
 		flags.WithStringValue("availability", "availability", "(c8y_Availability.status eq '%s')"),
 		flags.WithRelativeTimestamp("lastMessageDateTo", "lastMessageDateTo", "(c8y_Availability.lastMessage le '%s')"),
 		flags.WithRelativeTimestamp("lastMessageDateFrom", "lastMessageDateFrom", "(c8y_Availability.lastMessage ge '%s')"),

--- a/pkg/cmd/devices/list/list.manual.go
+++ b/pkg/cmd/devices/list/list.manual.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/pkg/c8yfetcher"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/pkg/completion"
 	"github.com/reubenmiller/go-c8y-cli/pkg/flags"
 	"github.com/reubenmiller/go-c8y-cli/pkg/mapbuilder"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -51,12 +53,22 @@ func NewCmdDevicesList(f *cmdutil.Factory) *CmdDevicesList {
 	cmd.Flags().Bool("agents", false, "Only include agents.")
 	cmd.Flags().String("fragmentType", "", "Filter by fragment type")
 	cmd.Flags().String("owner", "", "Filter by owner")
+	cmd.Flags().String("availability", "", "Filter by c8y_Availability.status")
+	cmd.Flags().String("lastMessageDateTo", "", "Filter c8y_Availability.lastMessage to a specific date")
+	cmd.Flags().String("lastMessageDateFrom", "", "Filter c8y_Availability.lastMessage from a specific date")
+	cmd.Flags().String("group", "", "Filter by group inclusion")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	flags.WithOptions(
 		cmd,
 		flags.WithCommonCumulocityQueryOptions(),
 		flags.WithExtendedPipelineSupport("query", "query", false, "c8y_DeviceQueryString"),
+	)
+
+	completion.WithOptions(
+		cmd,
+		completion.WithValidateSet("availability", "AVAILABLE", "UNAVAILABLE", "MAINTENANCE"),
+		completion.WithDeviceGroup("group", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	// Required flags
@@ -93,11 +105,16 @@ func (n *CmdDevicesList) RunE(cmd *cobra.Command, args []string) error {
 
 	c8yQueryParts, err := flags.WithC8YQueryOptions(
 		cmd,
-		flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-		flags.WithC8YQueryFormat("type", "(type eq '%s')"),
-		flags.WithC8YQueryFormat("fragmentType", "has(%s)"),
-		flags.WithC8YQueryFormat("owner", "(owner eq '%s')"),
-		flags.WithC8YQueryBool("agents", "has(com_cumulocity_model_Agent)"),
+		inputIterators,
+		c8yfetcher.WithDeviceGroupByNameFirstMatch(client, args, "group", "group", "bygroupid(%s)"),
+		flags.WithStringValue("name", "name", "(name eq '%s')"),
+		flags.WithStringValue("type", "type", "(type eq '%s')"),
+		flags.WithStringValue("fragmentType", "fragmentType", "has(%s)"),
+		flags.WithStringValue("owner", "owner", "(owner eq '%s')"),
+		flags.WithStringValue("availability", "availability", "(c8y_Availability.status eq '%s')"),
+		flags.WithRelativeTimestamp("lastMessageDateTo", "lastMessageDateTo", "(c8y_Availability.lastMessage le '%s')"),
+		flags.WithRelativeTimestamp("lastMessageDateFrom", "lastMessageDateFrom", "(c8y_Availability.lastMessage ge '%s')"),
+		flags.WithDefaultBoolValue("agents", "agents", "has(com_cumulocity_model_Agent)"),
 	)
 
 	if err != nil {

--- a/pkg/cmd/firmware/list/list.manual.go
+++ b/pkg/cmd/firmware/list/list.manual.go
@@ -38,10 +38,10 @@ Get a list of firmware packages
 				cmd,
 				args,
 				ccmd.factory,
-				flags.WithC8YQueryFixedString("(type eq 'c8y_Firmware')"),
-				flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-				flags.WithC8YQueryFormat("deviceType", "(c8y_Filter.type eq '%s')"),
-				flags.WithC8YQueryFormat("description", "(description eq '%s')"),
+				flags.WithStaticStringValue("dummy", "(type eq 'c8y_Firmware')"),
+				flags.WithStringValue("name", "name", "(name eq '%s')"),
+				flags.WithStringValue("deviceType", "deviceType", "(c8y_Filter.type eq '%s')"),
+				flags.WithStringValue("description", "description", "(description eq '%s')"),
 			)
 			return handler()
 		},

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -209,7 +209,7 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 
 	if applicationName != "" {
 
-		refs, err := c8yfetcher.FindMicroservices(client, []string{applicationName}, true)
+		refs, err := c8yfetcher.FindMicroservices(client, []string{applicationName}, true, "")
 
 		if err != nil {
 			return cmderrors.NewUserError(err)

--- a/pkg/cmd/smartgroups/list/list.manual.go
+++ b/pkg/cmd/smartgroups/list/list.manual.go
@@ -102,13 +102,14 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 
 	c8yQueryParts, err := flags.WithC8YQueryOptions(
 		cmd,
-		flags.WithC8YQueryFixedString("(type eq 'c8y_DynamicGroup')"),
-		flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-		flags.WithC8YQueryFormat("deviceQuery", "(c8y_DeviceQueryString eq '%s')"),
-		flags.WithC8YQueryFormat("fragmentType", "has(%s)"),
-		flags.WithC8YQueryFormat("owner", "(owner eq '%s')"),
-		flags.WithC8YQueryBool("onlyInvisible", "has(c8y_IsDynamicGroup.invisible)"),
-		flags.WithC8YQueryBool("onlyVisible", "not(has(c8y_IsDynamicGroup.invisible))"),
+		inputIterators,
+		flags.WithStaticStringValue("smartgroup", "(type eq 'c8y_DynamicGroup')"),
+		flags.WithStringValue("name", "name", "(name eq '%s')"),
+		flags.WithStringValue("deviceQuery", "deviceQuery", "(c8y_DeviceQueryString eq '%s')"),
+		flags.WithStringValue("fragmentType", "fragmentType", "has(%s)"),
+		flags.WithStringValue("owner", "owner", "(owner eq '%s')"),
+		flags.WithBoolValue("onlyInvisible", "onlyInvisible", "has(c8y_IsDynamicGroup.invisible)"),
+		flags.WithBoolValue("onlyVisible", "onlyVisible", "not(has(c8y_IsDynamicGroup.invisible))"),
 	)
 
 	if err != nil {

--- a/pkg/cmd/software/list/list.manual.go
+++ b/pkg/cmd/software/list/list.manual.go
@@ -41,10 +41,10 @@ Get a list of software packages starting with "python3"
 				cmd,
 				args,
 				ccmd.factory,
-				flags.WithC8YQueryFixedString("(type eq 'c8y_Software')"),
-				flags.WithC8YQueryFormat("name", "(name eq '%s')"),
-				flags.WithC8YQueryFormat("deviceType", "(c8y_Filter.type eq '%s')"),
-				flags.WithC8YQueryFormat("description", "(description eq '%s')"),
+				flags.WithStaticStringValue("dummy", "(type eq 'c8y_Software')"),
+				flags.WithStringValue("name", "name", "(name eq '%s')"),
+				flags.WithStringValue("deviceType", "deviceType", "(c8y_Filter.type eq '%s')"),
+				flags.WithStringValue("description", "description", "(description eq '%s')"),
 			)
 			return handler()
 		},

--- a/pkg/flags/c8yQuery.go
+++ b/pkg/flags/c8yQuery.go
@@ -60,13 +60,16 @@ func BuildCumulocityQuery(cmd *cobra.Command, fixedParts []string, orderBy strin
 			existingOrderBy = []byte(orderBy)
 		}
 
-		if len(b) > 0 {
-			queryParts = append(queryParts, string(b))
-		}
-
-		if v, err := cmd.Flags().GetString("queryTemplate"); err == nil && v != "" {
-			for i := range queryParts {
-				queryParts[i] = fmt.Sprintf(v, queryParts[i])
+		if tmpl, err := cmd.Flags().GetString("queryTemplate"); err == nil && tmpl != "" {
+			if len(b) > 0 {
+				queryParts = append(queryParts, fmt.Sprintf(tmpl, b))
+			} else {
+				queryParts = append(queryParts, tmpl)
+			}
+		} else {
+			if len(b) > 0 {
+				// Template is not defined so use value as is
+				queryParts = append(queryParts, string(b))
 			}
 		}
 
@@ -82,25 +85,5 @@ func BuildCumulocityQuery(cmd *cobra.Command, fixedParts []string, orderBy strin
 			outputQuery = append(outputQuery, []byte(fmt.Sprintf(" $orderby=%s", existingOrderBy))...)
 		}
 		return outputQuery
-		// if len(query) == 0 {
-		// 	return []byte(fmt.Sprintf("$filter=%s $orderby=%s", query, orderBy))
-		// }
-		// return []byte(fmt.Sprintf("$filter=%s $orderby=%s", query, orderBy))
 	}
 }
-
-// flags.WithCustomStringValue(func(b []byte) []byte {
-
-// 	queryParts := c8yQueryParts[:]
-// 	queryParts = append(queryParts, "("+string(b)+")")
-
-// 	if v, err := cmd.Flags().GetString("queryTemplate"); err == nil && v != "" {
-// 		for i := range queryParts {
-// 			queryParts[i] = fmt.Sprintf(v, queryParts[i])
-// 		}
-// 	}
-// 	query := strings.Join(queryParts, " and ")
-// 	return []byte(fmt.Sprintf("$filter=(%s) $orderby=%s", query, orderBy))
-// }, func() string {
-// 	return "q"
-// }, "query")

--- a/pkg/flags/c8yQuery_test.go
+++ b/pkg/flags/c8yQuery_test.go
@@ -37,5 +37,5 @@ func Test_RelativeTimeIteratorWithFormatter(t *testing.T) {
 	assert.OK(t, err)
 
 	output := strings.Join(c8yQueryParts, " and ")
-	assert.Equal(t, "(has(com_cumulocity_model_Agent)) and (name eq 'value1') and has(value2)", output)
+	assert.Equal(t, output, "(has(com_cumulocity_model_Agent)) and (name eq 'value1') and has(value2)")
 }

--- a/pkg/flags/c8yQuery_test.go
+++ b/pkg/flags/c8yQuery_test.go
@@ -1,0 +1,41 @@
+package flags
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/assert"
+	"github.com/spf13/cobra"
+)
+
+func Test_RelativeTimeIteratorWithFormatter(t *testing.T) {
+
+	cmd := &cobra.Command{
+		Use: "dummy",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	cmd.Flags().String("name1", "", "")
+	cmd.Flags().String("name2", "", "")
+	cmd.Flags().Bool("bool1", false, "")
+	cmd.Flags().Bool("bool2", false, "")
+	cmd.SetArgs([]string{"dummy", "--name1", "value1", "--bool2"})
+	cmd.Execute()
+
+	c8yQueryParts, err := WithC8YQueryOptions(
+		cmd,
+		nil,
+		WithStaticStringValue("agent", "(has(com_cumulocity_model_Agent))"),
+		WithStringValue("name1", "name", "(name eq '%s')"),
+		WithStringValue("name2", "name", "(name eq '%s')"),
+		WithBoolValue("bool1", "bool", "has(value1)"),
+		WithBoolValue("bool2", "bool", "has(value2)"),
+	)
+
+	assert.OK(t, err)
+
+	output := strings.Join(c8yQueryParts, " and ")
+	assert.Equal(t, "(has(com_cumulocity_model_Agent)) and (name eq 'value1') and has(value2)", output)
+}

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -309,30 +309,6 @@ func WithStringValue(opts ...string) GetOption {
 	}
 }
 
-// WithOptionalStringValue adds a string value from cli arguments if the value is defined
-func WithOptionalStringValue(opts ...string) GetOption {
-	return func(cmd *cobra.Command, inputIterators *RequestInputIterators) (string, interface{}, error) {
-
-		src, dst, format := UnpackGetterOptions("%s", opts...)
-
-		if inputIterators != nil && inputIterators.PipeOptions != nil {
-			if inputIterators.PipeOptions.Name == src {
-				return WithPipelineIterator(inputIterators.PipeOptions)(cmd, inputIterators)
-			}
-		}
-
-		value, err := cmd.Flags().GetString(src)
-		if err != nil {
-			return dst, value, err
-		}
-		if value == "" {
-			// dont assign the value anywhere
-			dst = ""
-		}
-		return dst, applyFormatter(format, value), err
-	}
-}
-
 func WithVersion(fallbackSrc string, opts ...string) GetOption {
 	return func(cmd *cobra.Command, inputIterators *RequestInputIterators) (string, interface{}, error) {
 
@@ -668,7 +644,7 @@ func WithEncodedRelativeTimestamp(opts ...string) GetOption {
 // WithRelativeDate adds a date (only, no time) (string) value from cli arguments
 func WithRelativeDate(encode bool, opts ...string) GetOption {
 	return func(cmd *cobra.Command, inputIterators *RequestInputIterators) (string, interface{}, error) {
-		src, dst, _ := UnpackGetterOptions("", opts...)
+		src, dst, format := UnpackGetterOptions("", opts...)
 		value, err := cmd.Flags().GetString(src)
 
 		if err != nil {
@@ -686,7 +662,7 @@ func WithRelativeDate(encode bool, opts ...string) GetOption {
 		}
 
 		// mark iterator as unbound, so it will not increment the input iterators
-		return dst, iterator.NewRelativeDateIterator(value, encode, "2006-01-02"), err
+		return dst, iterator.NewRelativeDateIterator(value, encode, "2006-01-02", format), err
 	}
 }
 

--- a/pkg/iterator/slice.go
+++ b/pkg/iterator/slice.go
@@ -1,6 +1,7 @@
 package iterator
 
 import (
+	"fmt"
 	"io"
 	"sync/atomic"
 )
@@ -9,6 +10,7 @@ import (
 type SliceIterator struct {
 	currentIndex int64 // access atomically (must be defined at the top)
 	values       []string
+	format       string
 }
 
 // GetNext will count through the values and return them one by one
@@ -18,7 +20,11 @@ func (i *SliceIterator) GetNext() (line []byte, input interface{}, err error) {
 	if nextIndex > int64(len(i.values)) {
 		err = io.EOF
 	} else {
-		line = []byte(i.values[nextIndex-1])
+		value := i.values[nextIndex-1]
+		if i.format != "" {
+			value = fmt.Sprintf(i.format, value)
+		}
+		line = []byte(value)
 	}
 	return line, line, err
 }
@@ -35,10 +41,14 @@ func (i *SliceIterator) IsBound() bool {
 
 // NewSliceIterator creates a repeater which returns the slice items
 // before returns io.EOF
-func NewSliceIterator(values []string) *SliceIterator {
-	return &SliceIterator{
+func NewSliceIterator(values []string, format ...string) *SliceIterator {
+	iter := &SliceIterator{
 		values: values,
 	}
+	if len(format) > 0 {
+		iter.format = format[0]
+	}
+	return iter
 }
 
 // InfiniteSliceIterator is iterates over a given array and once the last element is return, it

--- a/pkg/iterator/time.go
+++ b/pkg/iterator/time.go
@@ -1,19 +1,35 @@
 package iterator
 
-import "github.com/reubenmiller/go-c8y-cli/pkg/timestamp"
+import (
+	"fmt"
+
+	"github.com/reubenmiller/go-c8y-cli/pkg/timestamp"
+)
 
 // NewRelativeTimeIterator returns a relative time iterator which can generate timestamps based on time.Now when the value is retrieved
-func NewRelativeTimeIterator(relative string, encode bool) *FuncIterator {
+func NewRelativeTimeIterator(relative string, encode bool, format ...string) *FuncIterator {
 	next := func(i int64) (string, error) {
-		return timestamp.TryGetTimestamp(relative, encode)
+		value, err := timestamp.TryGetTimestamp(relative, encode)
+		if len(format) > 0 {
+			if format[0] != "" {
+				value = fmt.Sprintf(format[0], value)
+			}
+		}
+		return value, err
 	}
 	return NewFuncIterator(next, 0)
 }
 
 // NewRelativeDateIterator returns a relative date iterator which can generate dates based on time.Now when the value is retrieved
-func NewRelativeDateIterator(relative string, encode bool, layout string) *FuncIterator {
+func NewRelativeDateIterator(relative string, encode bool, layout string, format ...string) *FuncIterator {
 	next := func(i int64) (string, error) {
-		return timestamp.TryGetDate(relative, encode, layout)
+		value, err := timestamp.TryGetDate(relative, encode, layout)
+		if len(format) > 0 {
+			if format[0] != "" {
+				value = fmt.Sprintf(format[0], value)
+			}
+		}
+		return value, err
 	}
 	return NewFuncIterator(next, 0)
 }

--- a/pkg/iterator/time_test.go
+++ b/pkg/iterator/time_test.go
@@ -2,6 +2,7 @@ package iterator
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,4 +27,23 @@ func Test_RelativeTimeIterator(t *testing.T) {
 
 	assert.OK(t, err1)
 	assert.OK(t, err2)
+}
+
+func Test_RelativeTimeIteratorWithFormatter(t *testing.T) {
+
+	iter := NewRelativeTimeIterator("0s", false, "value gt '%s'")
+
+	v1, _, err1 := iter.GetNext()
+	assert.OK(t, err1)
+
+	value := string(v1)
+
+	parts := strings.Split(value, " ")
+
+	if len(parts) != 3 {
+		t.Errorf("Format should have 3 parts")
+	}
+
+	assert.True(t, parts[0] == "value")
+	assert.True(t, parts[1] == "gt")
 }

--- a/scripts/build-powershell/build.ps1
+++ b/scripts/build-powershell/build.ps1
@@ -17,6 +17,9 @@ foreach ($iFile in $SpecFiles) {
     New-C8yPowershellApi $iFile.FullName -OutputDir "$BaseDir/Public"
 }
 
+Write-Verbose "Building completions"
+Import-Module "$PSScriptRoot/../../tools/PSc8y/tools/build.completions.ps1" -Force
+
 #
 # Build the c8y cli binaries for each environment
 #

--- a/tests/manual/agents/list/agents_list.yaml
+++ b/tests/manual/agents/list/agents_list.yaml
@@ -10,25 +10,16 @@ config:
 tests:
   It can build an inventory query via piped input:
     command: |
-      echo "type1" | c8y devices list --queryTemplate "type eq '%s'" --dry |
+      echo "type1" | c8y agents list --queryTemplate "type eq '%s'" --dry |
         c8y util show --select pathEncoded
     exit-code: 0
     stdout:
       exactly: |
-        /inventory/managedObjects?q=%24filter%3Dtype+eq+%27type1%27+%24orderby%3Dname
-  
-  It can build an inventory query via piped input and optional value:
-    command: |
-      echo "type1" | c8y devices list --queryTemplate "type eq '%s'" --agents --dry |
-        c8y util show --select pathEncoded
-    exit-code: 0
-    stdout:
-      exactly: |
-        /inventory/managedObjects?q=%24filter%3Dhas%28com_cumulocity_model_Agent%29+and+type+eq+%27type1%27+%24orderby%3Dname
+        /inventory/managedObjects?q=%24filter%3D%28has%28com_cumulocity_model_Agent%29%29+and+type+eq+%27type1%27+%24orderby%3Dname
 
-  It filters devices by availability:
+  It filters agents by availability:
     command: |
-      c8y devices list --group 12345 --availability AVAILABLE --lastMessageDateTo -10d --lastMessageDateFrom -5d --dry |
+      c8y agents list --group 12345 --availability AVAILABLE --lastMessageDateTo -10d --lastMessageDateFrom -5d --dry |
         c8y util show --select query
     exit-code: 0
     stdout:

--- a/tests/manual/firmware/patches/crud.sh
+++ b/tests/manual/firmware/patches/crud.sh
@@ -4,6 +4,16 @@ set -ex
 
 export C8Y_SETTINGS_DEFAULTS_DRY=false
 
+createdir () {
+    # Cross-platform compatible
+    local name="${1:-"c8y-temp"}"
+    tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t "$name")
+    echo "$tmpdir"
+}
+
+export TEMP_DIR=$(createdir)
+trap "rm -Rf $TEMP_DIR" EXIT
+
 FIRMWARE=${1:-""}
 VERSION=${2:-0.8.0}
 PATCH=${2:-0.8.1}
@@ -26,9 +36,8 @@ PATCH1_ID=$( c8y firmware get --id $FIRMWARE_ID | c8y firmware patches create --
 #
 # create patch from file (get details from package name)
 #
-package_file=$(mktemp /tmp/package-XXXXXX-10.2.3.deb)
+package_file="$TEMP_DIR/package-XXXXXX-10.2.3.deb"
 echo "dummy file" > "$package_file"
-trap "rm -f $package_file" EXIT
 
 PATCH2_ID=$( c8y firmware patches create --firmware "$FIRMWARE" --file "$package_file" --dependencyVersion "$VERSION" --select "id,c8y_Patch.dependency,c8y_Firmware.version" --output csv )
 echo "$PATCH2_ID" | grep "^[0-9]\+,$VERSION,10.2.3$"

--- a/tests/manual/firmware/versions/crud.sh
+++ b/tests/manual/firmware/versions/crud.sh
@@ -4,6 +4,16 @@ set -e
 
 export C8Y_SETTINGS_DEFAULTS_DRY=false
 
+createdir () {
+    # Cross-platform compatible
+    local name="${1:-"c8y-temp"}"
+    tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t "$name")
+    echo "$tmpdir"
+}
+
+export TEMP_DIR=$(createdir)
+trap "rm -Rf $TEMP_DIR" EXIT
+
 NAME=${1:-""}
 VERSION=${2:-0.8.6}
 
@@ -19,9 +29,8 @@ ID=$( c8y firmware create --name "$NAME" | c8y firmware versions create --versio
 #
 # create version by file (get details from package name)
 #
-package_file=$(mktemp /tmp/package-XXXXXX-10.2.3.deb)
+package_file="$TEMP_DIR/package-XXXXXX-10.2.3.deb"
 echo "dummy file" > "$package_file"
-trap "rm -f $package_file" EXIT
 
 VERSION2_ID=$( c8y firmware versions create --firmware "$NAME" --file "$package_file" --select "id,c8y_Firmware.version" --output csv )
 echo "$VERSION2_ID" | grep "^[0-9]\+,10.2.3$"

--- a/tests/manual/pipeline/pipeline_handling.yaml
+++ b/tests/manual/pipeline/pipeline_handling.yaml
@@ -1,7 +1,7 @@
 tests:
     It handles piped input without ending with newline:
         command: |
-            echo -n '0' | c8y devices get --dry
+            printf "0" | c8y devices get --dry
         exit-code: 0
         stdout:
             line-count: 1

--- a/tests/manual/software/crud.sh
+++ b/tests/manual/software/crud.sh
@@ -4,6 +4,16 @@ set -ex
 
 export C8Y_SETTINGS_DEFAULTS_DRY=false
 
+createdir () {
+    # Cross-platform compatible
+    local name="${1:-"c8y-temp"}"
+    tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t "$name")
+    echo "$tmpdir"
+}
+
+export TEMP_DIR=$(createdir)
+trap "rm -Rf $TEMP_DIR" EXIT
+
 NAME=${1:-""}
 VERSION=${2:-0.8.6}
 
@@ -27,9 +37,8 @@ c8y software update --id "$NAME" --description "New description" --select descri
 #
 # create version by file (get details from package name)
 #
-package_file=$(mktemp /tmp/package-XXXXXX-10.2.3.deb)
+package_file="$TEMP_DIR/package-XXXXXX-10.2.3.deb"
 echo "dummy file" > "$package_file"
-trap "rm -f $package_file" EXIT
 
 VERSION2_ID=$( c8y software versions create --software "$NAME" --file "$package_file" --select "id,c8y_Software.version" --output csv )
 echo "$VERSION2_ID" | grep "^[0-9]\+,10.2.3$"

--- a/tools/PSc8y/Public-manual/Get-AgentCollection.ps1
+++ b/tools/PSc8y/Public-manual/Get-AgentCollection.ps1
@@ -49,10 +49,41 @@ Get a list of agents which have been updated more recently than 2020-01-01
         [string]
         $Owner,
 
+        # Availability.
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("AVAILABLE", "UNAVAILABLE", "MAINTENANCE")]
+        [string]
+        $Availability,
+
+        # LastMessageDateFrom - c8y_Availability.lastMessage filter
+        [Parameter(Mandatory = $false)]
+        [string]
+        $LastMessageDateFrom,
+
+        # LastMessageDateTo - c8y_Availability.lastMessage filter
+        [Parameter(Mandatory = $false)]
+        [string]
+        $LastMessageDateTo,
+
+        # Group.
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Group,
+
         # Query.
         [Parameter(Mandatory = $false)]
         [string]
         $Query,
+
+        # QueryTemplate.
+        [Parameter(Mandatory = $false)]
+        [string]
+        $QueryTemplate,
+
+        # Order results by a specific field. i.e. "name", "_id desc" or "creationTime.date asc".
+        [Parameter(Mandatory = $false)]
+        [string]
+        $OrderBy,
 
         # include a flat list of all parents and grandparents of the given object
         [Parameter()]

--- a/tools/PSc8y/Public-manual/Get-DeviceCollection.ps1
+++ b/tools/PSc8y/Public-manual/Get-DeviceCollection.ps1
@@ -50,10 +50,36 @@ Get a list of devices which have been updated more recently than 2020-01-01
         [string]
         $Owner,
 
+        # Availability.
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("AVAILABLE", "UNAVAILABLE", "MAINTENANCE")]
+        [string]
+        $Availability,
+
+        # LastMessageDateFrom - c8y_Availability.lastMessage filter
+        [Parameter(Mandatory = $false)]
+        [string]
+        $LastMessageDateFrom,
+
+        # LastMessageDateTo - c8y_Availability.lastMessage filter
+        [Parameter(Mandatory = $false)]
+        [string]
+        $LastMessageDateTo,
+
+        # Group.
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Group,
+
         # Query.
         [Parameter(Mandatory = $false)]
         [string]
         $Query,
+
+        # QueryTemplate.
+        [Parameter(Mandatory = $false)]
+        [string]
+        $QueryTemplate,
 
         # Order results by a specific field. i.e. "name", "_id desc" or "creationTime.date asc".
         [Parameter(Mandatory = $false)]

--- a/tools/PSc8y/completions/agent.ps1
+++ b/tools/PSc8y/completions/agent.ps1
@@ -6,7 +6,7 @@ $script:CompleteAgent = {
         $searchFor = $wordToComplete
     }
 
-    Get-AgentCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue `
+    Get-AgentCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.name -like "$searchFor*" } `
     | Sort-Object { $_.name } `
     | ForEach-Object {

--- a/tools/PSc8y/completions/application.ps1
+++ b/tools/PSc8y/completions/application.ps1
@@ -6,7 +6,7 @@ $script:CompleteApplication = {
         $searchFor = $wordToComplete
     }
 
-    Get-ApplicationCollection -PageSize 100 -WarningAction SilentlyContinue `
+    Get-ApplicationCollection -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.id -like "$searchFor*" -or $_.name -like "$searchFor*" } `
     | ForEach-Object {
         $value = $_.name

--- a/tools/PSc8y/completions/device.ps1
+++ b/tools/PSc8y/completions/device.ps1
@@ -6,7 +6,7 @@ $script:CompleteDevice = {
         $searchFor = $wordToComplete
     }
 
-    Get-DeviceCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue `
+    Get-DeviceCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.name -like "$searchFor*" } `
     | Sort-Object { $_.name } `
     | ForEach-Object {

--- a/tools/PSc8y/completions/devicegroup.ps1
+++ b/tools/PSc8y/completions/devicegroup.ps1
@@ -6,7 +6,7 @@ $script:CompleteDeviceGroup = {
         $searchFor = $wordToComplete
     }
 
-    Get-DeviceGroupCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue `
+    Get-DeviceGroupCollection -Name "$searchFor*" -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.name -like "$searchFor*" } `
     | Sort-Object { $_.name } `
     | ForEach-Object {

--- a/tools/PSc8y/completions/measurement.ps1
+++ b/tools/PSc8y/completions/measurement.ps1
@@ -12,7 +12,7 @@ $script:CompleteMeasurementFragmentType = {
 
     $device = $fakeBoundParameters["Device"]
 
-    Get-SupportedMeasurements -Device:$device -WarningAction SilentlyContinue `
+    Get-SupportedMeasurements -Device:$device -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_ -like "$searchFor*" } `
     | Sort-Object { $_ } `
     | ForEach-Object {
@@ -40,7 +40,7 @@ $script:CompleteMeasurementSeries = {
     $device = $fakeBoundParameters["Device"]
     $valueFragmentType = $fakeBoundParameters["valueFragmentType"]
     
-    Get-SupportedSeries -Device:$device -WarningAction SilentlyContinue `
+    Get-SupportedSeries -Device:$device -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_ -like "$valueFragmentType.*" } `
     | Where-Object { $_ -like "*.$searchFor*" } `
     | ForEach-Object { "$_".Split(".")[-1] } `
@@ -69,7 +69,7 @@ $script:CompleteMeasurementFullSeries = {
 
     $device = $fakeBoundParameters["Device"]
     
-    Get-SupportedSeries -Device:$device -WarningAction SilentlyContinue `
+    Get-SupportedSeries -Device:$device -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_ -like "$searchFor*" } `
     | Sort-Object { $_ } `
     | ForEach-Object {

--- a/tools/PSc8y/completions/microservice.ps1
+++ b/tools/PSc8y/completions/microservice.ps1
@@ -6,7 +6,7 @@ $script:CompleteMicroservice = {
         $searchFor = $wordToComplete
     }
 
-    Get-ApplicationCollection -PageSize 100 -WarningAction SilentlyContinue `
+    Get-ApplicationCollection -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.type -eq "MICROSERVICE" } `
     | Where-Object { $_.id -like "$searchFor*" -or $_.name -like "$searchFor*" } `
     | ForEach-Object {

--- a/tools/PSc8y/completions/role.ps1
+++ b/tools/PSc8y/completions/role.ps1
@@ -6,7 +6,7 @@ $script:CompleteRole = {
         $searchFor = $wordToComplete
     }
 
-    Get-RoleCollection -PageSize 100 `
+    Get-RoleCollection -PageSize 100 -AsPSObject `
     | Select-Object -ExpandProperty id `
     | Where-Object { $_ -like "$searchFor*" } `
     | ForEach-Object {

--- a/tools/PSc8y/completions/tenant.ps1
+++ b/tools/PSc8y/completions/tenant.ps1
@@ -6,7 +6,7 @@ $script:CompleteTenant = {
         $searchFor = $wordToComplete
     }
 
-    Get-TenantCollection -PageSize 100 -WarningAction SilentlyContinue `
+    Get-TenantCollection -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.id -like "$searchFor*" } `
     | ForEach-Object {
         $id = $_.id

--- a/tools/PSc8y/completions/tenantoption.ps1
+++ b/tools/PSc8y/completions/tenantoption.ps1
@@ -6,7 +6,7 @@ $script:CompleteTenantOptionCategory = {
         $searchFor = $wordToComplete
     }
 
-    Get-TenantOptionCollection -PageSize 100 -WarningAction SilentlyContinue `
+    Get-TenantOptionCollection -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.category -like "$searchFor*" } `
     | Select-Object -Unique -ExpandProperty category `
     | ForEach-Object {
@@ -27,7 +27,7 @@ $script:CompleteTenantOptionKey = {
         $searchFor = $wordToComplete
     }
 
-    $options = Get-TenantOptionForCategory -Category $fakeBoundParameters["category"] -PageSize 100 -WarningAction SilentlyContinue
+    $options = Get-TenantOptionForCategory -Category $fakeBoundParameters["category"] -PageSize 100 -WarningAction SilentlyContinue -AsPSObject
     
     if ($options -is [hashtable]) {
         $keys = $options.keys

--- a/tools/PSc8y/completions/user.ps1
+++ b/tools/PSc8y/completions/user.ps1
@@ -6,7 +6,7 @@ $script:CompleteUser = {
         $searchFor = $wordToComplete
     }
 
-    Get-UserCollection -PageSize 1000 -WarningAction SilentlyContinue `
+    Get-UserCollection -PageSize 1000 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.id -like "$searchFor*" -or $_.email -like "$searchFor*" } `
     | ForEach-Object {
         [System.Management.Automation.CompletionResult]::new(

--- a/tools/PSc8y/completions/usergroup.ps1
+++ b/tools/PSc8y/completions/usergroup.ps1
@@ -6,7 +6,7 @@ $script:CompleteUserGroup = {
         $searchFor = $wordToComplete
     }
 
-    Get-UserGroupCollection -PageSize 100 -WarningAction SilentlyContinue `
+    Get-UserGroupCollection -PageSize 100 -WarningAction SilentlyContinue -AsPSObject `
     | Where-Object { $_.id -like "$searchFor*" -or $_.name -like "$searchFor*" } `
     | ForEach-Object {
         $value = $_.name

--- a/tools/PSc8y/tools/build.completions.ps1
+++ b/tools/PSc8y/tools/build.completions.ps1
@@ -30,10 +30,19 @@ param(
 
     # User
     @{ name = "*-User"; ParameterName = "Id"; completion = '$script:CompleteUser' }
+    @{ name = "*-UserTOTPSecret"; ParameterName = "Id"; completion = '$script:CompleteUser' }
     @{ name = "*"; ParameterName = "User"; completion = '$script:CompleteUser' }
 
     # DeviceGroup
     @{ name = "*-DeviceGroup*"; ParameterName = "Id"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*"; ParameterName = "NewChildGroup"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "Remove-GroupFromGroup"; ParameterName = "Id"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "Remove-GroupFromGroup"; ParameterName = "Child"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*AssetToGroup"; ParameterName = "Group"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*ChildGroupToGroup"; ParameterName = "Group"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*DeviceToGroup"; ParameterName = "Group"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*DeviceFromGroup"; ParameterName = "Group"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*GroupFromGroup"; ParameterName = "Group"; completion = '$script:CompleteDeviceGroup' }
 
     # Measurement
     @{ name = "*-Measurement*"; ParameterName = "ValueFragmentType"; completion = '$script:CompleteMeasurementFragmentType' }
@@ -45,13 +54,17 @@ param(
     @{ name = "Add-RoleToGroup"; ParameterName = "Group"; completion = '$script:CompleteUserGroup' }
 
     # Add
-    @{ name = "*AssetToGroup"; ParameterName = "*Group*"; completion = '$script:CompleteDeviceGroup' }
+    @{ name = "*AssetToGroup"; ParameterName = "Group"; completion = '$script:CompleteDeviceGroup' }
 
     # Device
-    @{ name = "*"; ParameterName = "*Device*"; completion = '$CompleteDevice' }
+    @{ name = "*"; ParameterName = "Device"; completion = '$script:CompleteDevice' }
+    @{ name = "*-DeviceRequiredAvailability"; ParameterName = "Id"; completion = '$script:CompleteDevice' }
+    @{ name = "*"; ParameterName = "NewChildDevice"; completion = '$script:CompleteDevice' }
+    @{ name = "*"; ParameterName = "ChildDevice"; completion = '$script:CompleteDevice' }
+
 
     # Agent
-    @{ name = "*"; ParameterName = "*Agent*"; completion = '$CompleteAgent' }
+    @{ name = "*"; ParameterName = "Agent"; completion = '$script:CompleteAgent' }
 
     # Tenant
     @{ name = "*"; ParameterName = "Tenant"; completion = '$script:CompleteTenant' }

--- a/tools/PSc8y/utilities/register-completions.ps1
+++ b/tools/PSc8y/utilities/register-completions.ps1
@@ -57,10 +57,17 @@ $CommandsWithUserId = @(
 )
 Register-ArgumentCompleter -CommandName $CommandsWithUserId -ParameterName Id -ScriptBlock $script:CompleteUser
 
+$CommandsWithUserTOTPSecretId = @(
+    "Remove-UserTOTPSecret"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithUserTOTPSecretId -ParameterName Id -ScriptBlock $script:CompleteUser
+
 $CommandsWithUser = @(
     "Add-RoleToUser",
     "Add-UserToGroup",
+    "Get-ApplicationCollection",
     "Get-AuditRecordCollection",
+    "Get-MicroserviceCollection",
     "Get-RoleReferenceCollectionFromUser",
     "New-AuditRecord",
     "Remove-RoleFromUser",
@@ -70,10 +77,47 @@ Register-ArgumentCompleter -CommandName $CommandsWithUser -ParameterName User -S
 
 $CommandsWithDeviceGroupId = @(
     "Get-DeviceGroup",
+    "Get-DeviceGroupChildAssetCollection",
     "Remove-DeviceGroup",
     "Update-DeviceGroup"
 )
 Register-ArgumentCompleter -CommandName $CommandsWithDeviceGroupId -ParameterName Id -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithNewChildGroup = @(
+    "Add-AssetToGroup",
+    "Add-ChildGroupToGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithNewChildGroup -ParameterName NewChildGroup -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithRemoveGroupFromGroupId = @(
+    "Remove-GroupFromGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithRemoveGroupFromGroupId -ParameterName Id -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithRemoveGroupFromGroupChild = @(
+    "Remove-GroupFromGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithRemoveGroupFromGroupChild -ParameterName Child -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithAssetToGroupGroup = @(
+    "Add-AssetToGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithAssetToGroupGroup -ParameterName Group -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithChildGroupToGroupGroup = @(
+    "Add-ChildGroupToGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithChildGroupToGroupGroup -ParameterName Group -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithDeviceToGroupGroup = @(
+    "Add-DeviceToGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithDeviceToGroupGroup -ParameterName Group -ScriptBlock $script:CompleteDeviceGroup
+
+$CommandsWithDeviceFromGroupGroup = @(
+    "Remove-DeviceFromGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithDeviceFromGroupGroup -ParameterName Group -ScriptBlock $script:CompleteDeviceGroup
 
 $CommandsWithMeasurementValueFragmentType = @(
     "Get-MeasurementCollection"
@@ -103,17 +147,16 @@ Register-ArgumentCompleter -CommandName $CommandsWithAddRoleToGroupGroup -Parame
 $CommandsWithAssetToGroupGroup = @(
     "Add-AssetToGroup"
 )
-Register-ArgumentCompleter -CommandName $CommandsWithAssetToGroupGroup -ParameterName *Group* -ScriptBlock $script:CompleteDeviceGroup
+Register-ArgumentCompleter -CommandName $CommandsWithAssetToGroupGroup -ParameterName Group -ScriptBlock $script:CompleteDeviceGroup
 
 $CommandsWithDevice = @(
-    "Add-AssetToGroup",
     "Add-ChildDeviceToDevice",
-    "Add-DeviceToGroup",
     "Get-AlarmCollection",
-    "Get-ChildAssetCollection",
+    "Get-AlarmCount",
     "Get-ChildDeviceCollection",
     "Get-ChildDeviceReference",
     "Get-DeviceParent",
+    "Get-DeviceStatisticsCollection",
     "Get-EventCollection",
     "Get-ExternalIdCollection",
     "Get-MeasurementCollection",
@@ -121,26 +164,24 @@ $CommandsWithDevice = @(
     "Get-OperationCollection",
     "Get-SupportedMeasurements",
     "Get-SupportedSeries",
-    "Get-UserCollection",
+    "Install-FirmwareVersion",
+    "Install-SoftwareVersion",
     "New-Alarm",
     "New-Event",
     "New-ExternalId",
     "New-Measurement",
     "New-Operation",
     "New-TestAlarm",
-    "New-TestDeviceGroup",
     "New-TestEvent",
     "New-TestMeasurement",
     "New-TestOperation",
     "Open-Website",
     "Remove-AlarmCollection",
-    "Remove-AssetFromGroup",
     "Remove-ChildDeviceFromDevice",
-    "Remove-DeviceFromGroup",
     "Remove-EventCollection",
     "Remove-MeasurementCollection",
     "Remove-OperationCollection",
-    "Set-DeviceRequiredAvailability",
+    "Remove-SoftwareVersion",
     "Update-AlarmCollection",
     "Watch-Alarm",
     "Watch-Event",
@@ -149,15 +190,30 @@ $CommandsWithDevice = @(
     "Watch-NotificationChannel",
     "Watch-Operation"
 )
-Register-ArgumentCompleter -CommandName $CommandsWithDevice -ParameterName *Device* -ScriptBlock $CompleteDevice
+Register-ArgumentCompleter -CommandName $CommandsWithDevice -ParameterName Device -ScriptBlock $script:CompleteDevice
+
+$CommandsWithDeviceRequiredAvailabilityId = @(
+    "Set-DeviceRequiredAvailability"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithDeviceRequiredAvailabilityId -ParameterName Id -ScriptBlock $script:CompleteDevice
+
+$CommandsWithNewChildDevice = @(
+    "Add-AssetToGroup",
+    "Add-DeviceToGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithNewChildDevice -ParameterName NewChildDevice -ScriptBlock $script:CompleteDevice
+
+$CommandsWithChildDevice = @(
+    "Remove-ChildDeviceFromDevice",
+    "Remove-DeviceFromGroup"
+)
+Register-ArgumentCompleter -CommandName $CommandsWithChildDevice -ParameterName ChildDevice -ScriptBlock $script:CompleteDevice
 
 $CommandsWithAgent = @(
-    "Get-DeviceCollection",
     "Get-OperationCollection",
-    "New-TestDevice",
     "Remove-OperationCollection"
 )
-Register-ArgumentCompleter -CommandName $CommandsWithAgent -ParameterName *Agent* -ScriptBlock $CompleteAgent
+Register-ArgumentCompleter -CommandName $CommandsWithAgent -ParameterName Agent -ScriptBlock $script:CompleteAgent
 
 $CommandsWithTenant = @(
     "Add-RoleToGroup",
@@ -168,6 +224,7 @@ $CommandsWithTenant = @(
     "Enable-Application",
     "Enable-Microservice",
     "Get-ApplicationReferenceCollection",
+    "Get-DeviceStatisticsCollection",
     "Get-RoleReferenceCollectionFromGroup",
     "Get-RoleReferenceCollectionFromUser",
     "Get-User",
@@ -186,6 +243,7 @@ $CommandsWithTenant = @(
     "Remove-User",
     "Remove-UserFromGroup",
     "Remove-UserGroup",
+    "Remove-UserTOTPSecret",
     "Reset-UserPassword",
     "Update-User",
     "Update-UserGroup"

--- a/tools/shell/.zshrc
+++ b/tools/shell/.zshrc
@@ -16,3 +16,5 @@ compinit -i
 
 export LANG=C.UTF-8
 export LC_ALL=C.UTF-8
+
+export PATH=.bin:$PATH


### PR DESCRIPTION
## New Commands

### c8y devices list

* New flags
  * `availability <string>` : Filter by c8y_Availability.status
  * `lastMessageDateFrom <datetime|relativedatetime>` : Filter by c8y_Availability.lastMessage date
  * `lastMessageDateTo <datetime|relativedatetime>` : Filter by c8y_Availability.lastMessage date
  * `group <id|name>` : Filter by group inclusion (using `bygroupid` query operator)
* Fixed handling of the `queryTemplate`. It is now only applied to the given `query` value instead of each query element

### c8y agents list

* New flags
  * `availability <string>` : Filter by c8y_Availability.status
  * `lastMessageDateFrom <datetime|relativedatetime>` : Filter by c8y_Availability.lastMessage date
  * `lastMessageDateTo <datetime|relativedatetime>` : Filter by c8y_Availability.lastMessage date
  * `group <id|name>` : Filter by group inclusion (using `bygroupid` query operator)
  * `orderBy` : Sort the query results by a specific property
* Fixed handling of the `queryTemplate`. It is now only applied to the given `query` value instead of each query element

## Fixes

### PSc8y

* Fix broken tab completion of parameter value (e.g. device lookup etc.)

## Development

* Fixed incompatibilities when running tests on MacOS due to differences with `mktemp` command between MacOS and Linux