### PR TITLE
Fix: assert text - no output when using table output format

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,8 +60,6 @@ tasks:
     desc: Update the powershell docs
     cmds:
       - pwsh -File ./scripts/build-powershell/build-docs.ps1 -Recreate -OutputFolder "docs/go-c8y-cli/docs/cli/psc8y"
-    deps:
-      - build
   
   docs-c8y:
     desc: create c8y documentation

--- a/tests/manual/assert/text/assert_text.yaml
+++ b/tests/manual/assert/text/assert_text.yaml
@@ -29,6 +29,9 @@ tests:
     command: |
       echo '{"name":"device01"}' | c8y assert text --exact '{"name":"device01"}'
     exit-code: 0
+    stdout:
+      exactly: |
+        {"name":"device01"}
 
   It matches input against a exact text (no match):
     command: |
@@ -39,6 +42,19 @@ tests:
     command: |
       echo '{"name":"device01"}' | c8y assert text --regex '\{"name":"device\d+"\}'
     exit-code: 0
+    stdout:
+      exactly: |
+        {"name":"device01"}
+
+  It matches json input against a regex pattern with table output (match):
+    command: |
+      echo '{"name":"device01"}\n{"name":"agent02"}' | c8y assert text --regex "device" -o table
+    exit-code: 0
+    stdout:
+      # first two lines are headers
+      line-count: 3
+      contains:
+        - device01
 
   It matches input against a regex pattern is case sensitive (no match):
     command: |


### PR DESCRIPTION
### Fixes

* `c8y assert text` - Fix empty output when viewing in table format