### PR TITLE
Fix/required parameters

### DIFF
--- a/pkg/cmd/inventory/find/find.manual.go
+++ b/pkg/cmd/inventory/find/find.manual.go
@@ -61,9 +61,6 @@ func NewCmdFind(f *cmdutil.Factory) *CmdFind {
 		flags.WithExtendedPipelineSupport("query", "query", true, "c8y_DeviceQueryString"),
 	)
 
-	// Required flags
-	_ = cmd.MarkFlagRequired("query")
-
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
 	return ccmd

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -93,10 +93,7 @@ Create or update a microservice using an explicit name
 		f.WithTemplateFlag(cmd),
 	)
 
-	// Required flags
-	_ = cmd.MarkFlagRequired("file")
-
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("file")
 
 	return ccmd
 }

--- a/pkg/cmd/microservices/serviceuser/create/create.manual.go
+++ b/pkg/cmd/microservices/serviceuser/create/create.manual.go
@@ -53,10 +53,7 @@ Create new application service user
 		flags.WithData(),
 	)
 
-	// Required flags
-	_ = cmd.MarkFlagRequired("name")
-
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("name")
 
 	return ccmd
 }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -144,11 +144,6 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 			$ c8y devices list --type "myDevice" | c8y devices update --data "myValue=1"
 			$ c8y operations list --device myDeviceName
 		`),
-		Annotations: map[string]string{
-			"help:feedback": heredoc.Doc(`
-				Open an issue using 'c8y issue create -R github.com/cli/cli'
-			`),
-		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			disableEncryptionCheck := !cmdutil.IsConfigEncryptionCheckEnabled(cmd)
 			if err := ccmd.Configure(disableEncryptionCheck); err != nil {

--- a/pkg/cmd/sessions/clone/clone.manual.go
+++ b/pkg/cmd/sessions/clone/clone.manual.go
@@ -67,10 +67,9 @@ func NewCmdCloneSession(f *cmdutil.Factory) *CmdClone {
 			"dev\tDevelopment mode (no restrictions)",
 		),
 	)
-	_ = cmd.MarkFlagRequired("newName")
 	cmd.SilenceUsage = true
 
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("newName")
 
 	return ccmd
 }

--- a/pkg/cmd/sessions/decrypttext/decryptText.manual.go
+++ b/pkg/cmd/sessions/decrypttext/decryptText.manual.go
@@ -46,10 +46,7 @@ Encrypt the text "Hello World", the text will be encrypted using the given passp
 	cmd.Flags().String("text", "", "Encrypted text. (required)")
 	cmd.Flags().StringVar(&ccmd.passphrase, "passphrase", "", "Passphrase use for encoding your files")
 
-	// Required flags
-	_ = cmd.MarkFlagRequired("text")
-
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("text")
 
 	return ccmd
 }

--- a/pkg/cmd/sessions/encrypttext/encryptText.manual.go
+++ b/pkg/cmd/sessions/encrypttext/encryptText.manual.go
@@ -49,10 +49,7 @@ Password: {encrypted}ec5b837a03408ffb731307584eac40ac047989a002951e4b7139fa60189
 	cmd.Flags().StringVar(&ccmd.passphrase, "passphrase", "", "Passphrase use for encrypting the text")
 	cmd.Flags().BoolVar(&ccmd.raw, "raw", false, "Only return the encrypted text and nothing else")
 
-	// Required flags
-	_ = cmd.MarkFlagRequired("text")
-
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("text")
 
 	return ccmd
 }

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -67,8 +67,6 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 	cmd.Flags().StringVar(&ccmd.Shell, "shell", defaultShell, "Shell type to return the environment variables")
 	cmd.Flags().BoolVar(&ccmd.ClearToken, "clear", false, "Clear any existing tokens")
 
-	_ = cmd.MarkFlagRequired("shell")
-
 	completion.WithOptions(
 		cmd,
 		completion.WithValidateSet("shell", "auto", "bash", "zsh", "fish", "powershell"),

--- a/pkg/cmd/subcommand/subcommand.go
+++ b/pkg/cmd/subcommand/subcommand.go
@@ -2,12 +2,14 @@ package subcommand
 
 import (
 	"github.com/reubenmiller/go-c8y-cli/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/pkg/flags"
 	"github.com/spf13/cobra"
 )
 
 // SubCommand base command containing common command functions
 type SubCommand struct {
-	cmd *cobra.Command
+	cmd           *cobra.Command
+	requiredFlags []string
 }
 
 // GetCommand get the cobra command
@@ -20,7 +22,39 @@ func (c *SubCommand) GetCommand() *cobra.Command {
 	return c.cmd
 }
 
+func (c *SubCommand) SetRequiredFlags(v ...string) *SubCommand {
+	c.requiredFlags = v
+	return c
+}
+
+func (c *SubCommand) CheckRequiredFlags() error {
+	for _, name := range c.requiredFlags {
+		if !c.cmd.Flags().Changed(name) {
+			return &flags.ParameterError{
+				Name: name,
+				Err:  flags.ErrParameterMissing,
+			}
+		}
+	}
+	return nil
+}
+
 // SubCommand create new sub command
 func NewSubCommand(cmd *cobra.Command) *SubCommand {
-	return &SubCommand{cmd: cmd}
+	subcmd := &SubCommand{cmd: cmd}
+
+	// Wrap RunE so that the custom required flags can be called each time
+	// This is required due to the hack for the tab completion which prioritizes required
+	// parameter before other local parameters. Otherwise the user is not presented with the list of options.
+	if cmd.RunE != nil {
+		origRunE := cmd.RunE
+		cmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if err := subcmd.CheckRequiredFlags(); err != nil {
+				return err
+			}
+			return origRunE(cmd, args)
+		}
+	}
+
+	return subcmd
 }

--- a/pkg/cmd/template/execute/execute.manual.go
+++ b/pkg/cmd/template/execute/execute.manual.go
@@ -63,11 +63,8 @@ Pass external json data into the template, and reference it via the "input.value
 		flags.WithExtendedPipelineSupport("input", "input", false),
 	)
 
-	// Required flags
-	_ = cmd.MarkFlagRequired(flags.FlagDataTemplateName)
-
 	cmdutil.DisableAuthCheck(cmd)
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags(flags.FlagDataTemplateName)
 
 	return ccmd
 }

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -75,7 +75,8 @@ type Validate func(string) error
 // Prompt used to provide various interactive prompts which can be used
 // within the cli
 type Prompt struct {
-	Logger *logger.Logger
+	Logger         *logger.Logger
+	ShowValueAfter bool
 }
 
 // NewPrompt returns a new Prompt which can be used to prompt the user for
@@ -134,7 +135,7 @@ func (p *Prompt) Password(label string, message string) (string, error) {
 	}
 	validate := func(input string) error {
 		if input == "" {
-			return fmt.Errorf("Empty password")
+			return fmt.Errorf("password is required")
 		}
 		return nil
 	}
@@ -180,8 +181,8 @@ func (p *Prompt) Username(label string, defaultValue string) (string, error) {
 		label = "Enter username/email"
 	}
 	validate := func(input string) error {
-		if input == "" {
-			return fmt.Errorf("Empty username")
+		if strings.TrimSpace(input) == "" {
+			return fmt.Errorf("value is required")
 		}
 		return nil
 	}
@@ -189,7 +190,7 @@ func (p *Prompt) Username(label string, defaultValue string) (string, error) {
 		Stdin:       os.Stdin,
 		Stdout:      os.Stderr,
 		Default:     defaultValue,
-		HideEntered: true,
+		HideEntered: false,
 		Label:       label,
 		Validate:    validate,
 	}
@@ -202,7 +203,7 @@ func (p *Prompt) TOTPCode(host, username string, code string, client *c8y.Client
 
 	validateTOTP := func(input string) error {
 		if len(strings.ReplaceAll(input, " ", "")) < 6 {
-			return fmt.Errorf("Missing TFA code")
+			return fmt.Errorf("missing TFA code")
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(15000)*time.Millisecond)
@@ -230,5 +231,28 @@ func (p *Prompt) TOTPCode(host, username string, code string, client *c8y.Client
 		Validate:    validateTOTP,
 	}
 
+	return prompt.Run()
+}
+
+func (p *Prompt) Input(label string, defaultValue string, required bool, hideEntered bool) (string, error) {
+	if label == "" {
+		label = "Enter value"
+	}
+	validate := func(input string) error {
+		if required {
+			if input == "" {
+				return fmt.Errorf("value is required")
+			}
+		}
+		return nil
+	}
+	prompt := promptui.Prompt{
+		Stdin:       os.Stdin,
+		Stdout:      os.Stderr,
+		Default:     defaultValue,
+		HideEntered: hideEntered,
+		Label:       label,
+		Validate:    validate,
+	}
 	return prompt.Run()
 }

--- a/tests/manual/sessions/create/session_create.yaml
+++ b/tests/manual/sessions/create/session_create.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+tests:
+  It prints an error if the host is missing in non-interactive mode:
+    command: |
+      c8y sessions create < /dev/null
+    exit-code: 100
+    stderr:
+      contains:
+        - 'commandError: Missing required parameter. host'

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -259,3 +259,11 @@ tests:
       exit-code: 0
       stdout:
           match-pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|\+.+)$
+
+  It throws an error if the template flag is not provided:
+    command: |
+      c8y template execute
+    exit-code: 100
+    stderr:
+      contains:
+        - 'commandError: Missing required parameter. template'


### PR DESCRIPTION
### Fixes

Parameters marked as required were not being enforced. Now the user will be shown an error if the required parameter is not provided by the user.

Affected commands
* `c8y inventory find`
* `c8y microservices create`
* `c8y microservices serviceuser create`
* `c8y sessions clone`
* `c8y sessions create`
* `c8y sessions decryptText`
* `c8y sessions encryptText`
* `c8y sessions set`
* `c8y template execute`
