### PR TITLE
Feat/filter by creationtime

### DIFF
--- a/pkg/cmd/agents/list/list.manual.go
+++ b/pkg/cmd/agents/list/list.manual.go
@@ -38,6 +38,12 @@ func NewCmdAgentList(f *cmdutil.Factory) *CmdAgentList {
 			$ echo "name eq 'sensor*'" | c8y agents list
 			Get a collection of agents with names starting with "sensor" using a piped inventory query (or could be piped from a file)
 
+			$ c8y agents list --creationTimeDateFrom -7d
+			Get agents which where registered longer than 7 days ago
+
+			$ c8y agents list --creationTimeDateTo -1d
+			Get agents which where registered in the last day
+
 			$ c8y agents list --name "my example agent" --select type --output csv | c8y agents list --queryTemplate "type eq '%s'"
 			Find an agent by name, then find other agents which the same type
 		`),

--- a/pkg/cmd/agents/list/list.manual.go
+++ b/pkg/cmd/agents/list/list.manual.go
@@ -53,6 +53,8 @@ func NewCmdAgentList(f *cmdutil.Factory) *CmdAgentList {
 	cmd.Flags().String("availability", "", "Filter by c8y_Availability.status")
 	cmd.Flags().String("lastMessageDateTo", "", "Filter c8y_Availability.lastMessage to a specific date")
 	cmd.Flags().String("lastMessageDateFrom", "", "Filter c8y_Availability.lastMessage from a specific date")
+	cmd.Flags().String("creationTimeDateTo", "", "Filter creationTime.date to a specific date")
+	cmd.Flags().String("creationTimeDateFrom", "", "Filter creationTime.date from a specific date")
 	cmd.Flags().String("group", "", "Filter by group inclusion")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
@@ -105,6 +107,8 @@ func (n *CmdAgentList) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("availability", "availability", "(c8y_Availability.status eq '%s')"),
 		flags.WithRelativeTimestamp("lastMessageDateTo", "lastMessageDateTo", "(c8y_Availability.lastMessage le '%s')"),
 		flags.WithRelativeTimestamp("lastMessageDateFrom", "lastMessageDateFrom", "(c8y_Availability.lastMessage ge '%s')"),
+		flags.WithRelativeTimestamp("creationTimeDateTo", "creationTimeDateTo", "creationTime.date le '%s'"),
+		flags.WithRelativeTimestamp("creationTimeDateFrom", "creationTimeDateFrom", "creationTime.date ge '%s'"),
 	)
 
 	if err != nil {

--- a/pkg/cmd/devices/list/list.manual.go
+++ b/pkg/cmd/devices/list/list.manual.go
@@ -40,6 +40,12 @@ func NewCmdDevicesList(f *cmdutil.Factory) *CmdDevicesList {
 		$ c8y devices list --query "name eq '*sensor*' and creationTime.date gt '2021-04-02T00:00:00'"
 		Get devices which names containing 'sensor' and were created after 2021-04-02
 
+		$ c8y devices list --creationTimeDateFrom -7d
+		Get devices which where registered longer than 7 days ago
+
+		$ c8y devices list --creationTimeDateTo -1d
+		Get devices which where registered in the last day
+
 		$ echo -e "c8y_MacOS\nc8y_Linux" | c8y devices list --queryTemplate "type eq '%s'"
 		Get devices with type 'c8y_MacOS' then devices with type 'c8y_Linux' (using pipeline)
 		`),

--- a/pkg/cmd/devices/list/list.manual.go
+++ b/pkg/cmd/devices/list/list.manual.go
@@ -56,6 +56,8 @@ func NewCmdDevicesList(f *cmdutil.Factory) *CmdDevicesList {
 	cmd.Flags().String("availability", "", "Filter by c8y_Availability.status")
 	cmd.Flags().String("lastMessageDateTo", "", "Filter c8y_Availability.lastMessage to a specific date")
 	cmd.Flags().String("lastMessageDateFrom", "", "Filter c8y_Availability.lastMessage from a specific date")
+	cmd.Flags().String("creationTimeDateTo", "", "Filter creationTime.date to a specific date")
+	cmd.Flags().String("creationTimeDateFrom", "", "Filter creationTime.date from a specific date")
 	cmd.Flags().String("group", "", "Filter by group inclusion")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
@@ -114,6 +116,8 @@ func (n *CmdDevicesList) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("availability", "availability", "(c8y_Availability.status eq '%s')"),
 		flags.WithRelativeTimestamp("lastMessageDateTo", "lastMessageDateTo", "(c8y_Availability.lastMessage le '%s')"),
 		flags.WithRelativeTimestamp("lastMessageDateFrom", "lastMessageDateFrom", "(c8y_Availability.lastMessage ge '%s')"),
+		flags.WithRelativeTimestamp("creationTimeDateTo", "creationTimeDateTo", "creationTime.date le '%s'"),
+		flags.WithRelativeTimestamp("creationTimeDateFrom", "creationTimeDateFrom", "creationTime.date ge '%s'"),
 		flags.WithDefaultBoolValue("agents", "agents", "has(com_cumulocity_model_Agent)"),
 	)
 

--- a/tests/manual/agents/list/agents_list.yaml
+++ b/tests/manual/agents/list/agents_list.yaml
@@ -40,3 +40,21 @@ tests:
         - c8y_Availability.status eq 'AVAILABLE'
         - c8y_Availability.lastMessage le '
         - c8y_Availability.lastMessage ge '
+
+  It filters agents by creationTime to:
+    command: |
+      c8y agents list --creationTimeDateTo -10d --dry |
+        c8y util show --select query
+    exit-code: 0
+    stdout:
+      contains:
+        - creationTime.date le '
+  
+  It filters agents by creationTime from:
+    command: |
+      c8y agents list --creationTimeDateFrom -5d --dry |
+        c8y util show --select query
+    exit-code: 0
+    stdout:
+      contains:
+        - creationTime.date ge '

--- a/tests/manual/devices/list/devices_list.yaml
+++ b/tests/manual/devices/list/devices_list.yaml
@@ -88,3 +88,21 @@ tests:
         - c8y_Availability.status eq 'AVAILABLE'
         - c8y_Availability.lastMessage le '
         - c8y_Availability.lastMessage ge '
+
+  It filters devices by creationTime to:
+    command: |
+      c8y devices list --creationTimeDateTo -10d --dry |
+        c8y util show --select query
+    exit-code: 0
+    stdout:
+      contains:
+        - creationTime.date le '
+  
+  It filters devices by creationTime from:
+    command: |
+      c8y devices list --creationTimeDateFrom -5d --dry |
+        c8y util show --select query
+    exit-code: 0
+    stdout:
+      contains:
+        - creationTime.date ge '


### PR DESCRIPTION
## `c8y devices list` and `c8y agents list`

Added support for relative datetime filtering on creationTime for `c8y devices list` and `c8y agents list`.

* creationTimeDateFrom string - Filter creationTime.date from a specific date
* creationTimeDateTo string - Filter creationTime.date to a specific date

**Examples**
```sh
$ c8y devices list --creationTimeDateFrom -7d
Get devices which where registered longer than 7 days ago

$ c8y devices list --creationTimeDateTo -1d
Get devices which where registered in the last day
```
