### PR TITLE
feat: support setting the output file raw name based on select variables

### DIFF
--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -669,7 +671,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 	// write response to file instead of to stdout
 	if resp != nil && respError == nil && commonOptions.OutputFileRaw != "" {
 		if resp.StatusCode != 0 {
-			// check if it is a dummy reseponse (i.e. no status code)
+			// check if it is a dummy response (i.e. no status code)
 			newline := strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "json")
 			fullFilePath, err := r.saveResponseToFile(resp, commonOptions.OutputFileRaw, false, newline)
 
@@ -885,6 +887,40 @@ func (r *RequestHandler) guessDataProperty(resp *c8y.Response) string {
 // if filename
 func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string, append bool, newline bool) (string, error) {
 
+	// Support simple variable substitution to be able to set the output file name dynamically to download a collection of files
+	if strings.Contains(filename, "{") && strings.Contains(filename, "}") {
+		if strings.Contains(filename, "{filename}") {
+			if _, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition")); err == nil {
+				if name, ok := params["filename"]; ok {
+					filename = strings.ReplaceAll(filename, "{filename}", name)
+				}
+			}
+		}
+
+		if strings.Contains(filename, "{basename}") {
+			if resp.Request != nil {
+				filename = strings.ReplaceAll(filename, "{basename}", path.Base(resp.Request.URL.Path))
+			}
+		}
+
+		if strings.Contains(filename, "{id}") {
+			if resp.Request != nil {
+				r.Logger.Infof("Request: %s", resp.Request.URL.Path)
+
+				urlParts := strings.Split(resp.Request.URL.Path, "/")
+				for _, part := range urlParts {
+					if part != "" && c8y.IsID(part) {
+						r.Logger.Debugf("Found id like value. Substituting {id} for %s", part)
+						filename = strings.ReplaceAll(filename, "{id}", part)
+						break
+					}
+				}
+			} else {
+				r.Logger.Infof("Request is nill")
+			}
+		}
+	}
+
 	var out *os.File
 	var err error
 	if append {
@@ -903,7 +939,7 @@ func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string,
 	_, err = io.Copy(out, resp.Body)
 
 	if newline {
-		// add trailing newline so that json lines are seperated by lines
+		// add trailing newline so that json lines are separated by lines
 		fmt.Fprintf(out, "\n")
 	}
 	if err != nil {


### PR DESCRIPTION
## Flag: OutputFileRaw

Support setting the output file name based on some variables set based on the response/request.

* `{filename}` - Filename found in the Content-Disposition response header
* `{id}` - An id like value found in the request path (`/event/events/12345/binaries` => `12345`)
* `{basename}` - The last path section of the request path (`/some/nested/url/withafilename.json` => `withafilename.json`)

**Examples**

```sh
# Download a list of files and use the filename which was used when it was uploaded
c8y binaries list --pageSize 5 | c8y binaries get --outputFileRaw "{filename}"

# Download a list of managed object binaries and use the binary id and the filename. Note: 'output' directory must exist beforehand!
c8y binaries list --pageSize 5 | c8y binaries get --outputFileRaw "output/binary-{id}-{filename}"
```

Note: This does NOT include support for a complex template evaluation (like the --template flag).
