### PR TITLE
feat: dry runs skips mode checks

### DIFF
--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -53,6 +53,14 @@ func (f *Factory) CreateModeEnabled() error {
 	if err != nil {
 		return err
 	}
+
+	cfg.WithOptions(
+		config.WithBindEnv(config.SettingsDryRun, false),
+	)
+
+	if cfg.DryRun() {
+		return nil
+	}
 	return mode.ValidateCreateMode(cfg)
 }
 
@@ -62,6 +70,14 @@ func (f *Factory) UpdateModeEnabled() error {
 	if err != nil {
 		return err
 	}
+
+	cfg.WithOptions(
+		config.WithBindEnv(config.SettingsDryRun, false),
+	)
+
+	if cfg.DryRun() {
+		return nil
+	}
 	return mode.ValidateUpdateMode(cfg)
 }
 
@@ -70,6 +86,14 @@ func (f *Factory) DeleteModeEnabled() error {
 	cfg, err := f.Config()
 	if err != nil {
 		return err
+	}
+
+	cfg.WithOptions(
+		config.WithBindEnv(config.SettingsDryRun, false),
+	)
+
+	if cfg.DryRun() {
+		return nil
 	}
 	return mode.ValidateDeleteMode(cfg)
 }

--- a/tests/manual/common/disable_commands/disable_commands.yaml
+++ b/tests/manual/common/disable_commands/disable_commands.yaml
@@ -19,7 +19,7 @@ tests:
         C8Y_SETTINGS_MODE_ENABLEUPDATE: false
         C8Y_SETTINGS_MODE_ENABLEDELETE: false
     command: |
-      c8y inventory create --name "asset-data01" --dry
+      c8y inventory create --name "asset-data01"
     exit-code: 100
     stdout:
       match-pattern: ^$
@@ -47,7 +47,7 @@ tests:
         C8Y_SETTINGS_MODE_ENABLEUPDATE: false
         C8Y_SETTINGS_MODE_ENABLEDELETE: false
     command: |
-      c8y inventory update --id 0 --newName "asset-data01" --dry
+      c8y inventory update --id 0 --newName "asset-data01"
     exit-code: 100
     stdout:
       match-pattern: ^$
@@ -75,7 +75,7 @@ tests:
         C8Y_SETTINGS_MODE_ENABLEUPDATE: false
         C8Y_SETTINGS_MODE_ENABLEDELETE: false
     command: |
-      c8y inventory delete --id 0 --dry
+      c8y inventory delete --id 0
     exit-code: 100
     stdout:
       match-pattern: ^$

--- a/tests/manual/common/flags/dry/flag_dry.yaml
+++ b/tests/manual/common/flags/dry/flag_dry.yaml
@@ -132,5 +132,5 @@ tests:
         C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
         C8Y_SETTINGS_MODE_ENABLEDELETE: false
     command: |
-      c8y inventory create --dry=false
-    exit-code: 100
+      c8y inventory update --id 0 --dry=false --force
+    exit-code: 4

--- a/tests/manual/common/flags/dry/flag_dry.yaml
+++ b/tests/manual/common/flags/dry/flag_dry.yaml
@@ -133,4 +133,4 @@ tests:
         C8Y_SETTINGS_MODE_ENABLEDELETE: false
     command: |
       c8y inventory create --dry=false
-    exit-code: 100
+    exit-code: 101

--- a/tests/manual/common/flags/dry/flag_dry.yaml
+++ b/tests/manual/common/flags/dry/flag_dry.yaml
@@ -73,3 +73,64 @@ tests:
           "name": "test01"
         }
         ```
+
+  It should support dry run on create commands when create is disabled:
+    config:
+      env:
+        C8Y_SETTINGS_CI: false
+        C8Y_SETTINGS_MODE_ENABLECREATE: false
+    command: |
+      c8y inventory create --dry --dryFormat json |
+        c8y util show --select path --output csv
+    exit-code: 0
+    stdout:
+      exactly: /inventory/managedObjects
+
+  It should support dry run on update commands when update is disabled:
+    config:
+      env:
+        C8Y_SETTINGS_CI: false
+        C8Y_SETTINGS_MODE_ENABLEUPDATE: false
+    command: |
+      c8y inventory update --id 1234 --dry --dryFormat json |
+        c8y util show --select path --output csv
+    exit-code: 0
+    stdout:
+      exactly: /inventory/managedObjects/1234
+
+  It should support dry run on delete commands when delete is disabled:
+    config:
+      env:
+        C8Y_SETTINGS_CI: false
+        C8Y_SETTINGS_MODE_ENABLEDELETE: false
+    command: |
+      c8y inventory delete --id 1234 --dry --dryFormat json |
+        c8y util show --select path --output csv
+    exit-code: 0
+    stdout:
+      exactly: /inventory/managedObjects/1234
+
+  It should support dry run on delete commands when delete is disabled using environment variables:
+    config:
+      env:
+        C8Y_SETTINGS_CI: false
+        C8Y_SETTINGS_DEFAULTS_DRY: true
+        C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
+        C8Y_SETTINGS_MODE_ENABLEDELETE: false
+    command: |
+      c8y inventory delete --id 1234 |
+        c8y util show --select path --output csv
+    exit-code: 0
+    stdout:
+      exactly: /inventory/managedObjects/1234
+
+  It should support use dry flag over environment values:
+    config:
+      env:
+        C8Y_SETTINGS_CI: false
+        C8Y_SETTINGS_DEFAULTS_DRY: true
+        C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
+        C8Y_SETTINGS_MODE_ENABLEDELETE: false
+    command: |
+      c8y inventory create --dry=false
+    exit-code: 100

--- a/tests/manual/common/flags/dry/flag_dry.yaml
+++ b/tests/manual/common/flags/dry/flag_dry.yaml
@@ -133,4 +133,4 @@ tests:
         C8Y_SETTINGS_MODE_ENABLEDELETE: false
     command: |
       c8y inventory create --dry=false
-    exit-code: 101
+    exit-code: 100

--- a/tests/manual/common/flags/dry/flag_dry.yaml
+++ b/tests/manual/common/flags/dry/flag_dry.yaml
@@ -130,7 +130,7 @@ tests:
         C8Y_SETTINGS_CI: false
         C8Y_SETTINGS_DEFAULTS_DRY: true
         C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
-        C8Y_SETTINGS_MODE_ENABLEDELETE: false
+        C8Y_SETTINGS_MODE_ENABLEUPDATE: false
     command: |
       c8y inventory update --id 0 --dry=false --force
-    exit-code: 4
+    exit-code: 100


### PR DESCRIPTION
## Changes

### Flag: dry

* dry mode skips the mode checks (i.e. used to disable create, update and/or delete commands). This allows the user to use the dry mode for documentation purposes without having to enable create/update/delete commands.