### PR TITLE
Feat/cache uniq body field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
-	github.com/reubenmiller/go-c8y v0.9.1-rc.15
+	github.com/reubenmiller/go-c8y v0.10.0-rc.3
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.3.0
-	github.com/reubenmiller/go-c8y v0.10.0-rc.3
+	github.com/reubenmiller/go-c8y v0.10.0-rc.4
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -437,8 +437,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/reubenmiller/go-c8y v0.9.1-rc.15 h1:wCigsp+J2vgVuDJ4KhTRKDywz20O4kVTmS5dAmaWnB8=
-github.com/reubenmiller/go-c8y v0.9.1-rc.15/go.mod h1:aSU0AZdT/IWCn87wMveejGvwQE3FbnAkh5LEs/78xj8=
+github.com/reubenmiller/go-c8y v0.10.0-rc.3 h1:CB5cBmDHhSkbOCVSSE8Mext09Q/iBduFxKOesaGO5rY=
+github.com/reubenmiller/go-c8y v0.10.0-rc.3/go.mod h1:aSU0AZdT/IWCn87wMveejGvwQE3FbnAkh5LEs/78xj8=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/reubenmiller/go-c8y v0.10.0-rc.3 h1:CB5cBmDHhSkbOCVSSE8Mext09Q/iBduFxKOesaGO5rY=
 github.com/reubenmiller/go-c8y v0.10.0-rc.3/go.mod h1:aSU0AZdT/IWCn87wMveejGvwQE3FbnAkh5LEs/78xj8=
+github.com/reubenmiller/go-c8y v0.10.0-rc.4 h1:3apPjp45ivjFFr2PzLLM4BxSKz6OcAxBCu/wuasTWEE=
+github.com/reubenmiller/go-c8y v0.10.0-rc.4/go.mod h1:aSU0AZdT/IWCn87wMveejGvwQE3FbnAkh5LEs/78xj8=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/activitylogger/activitylogger.go
+++ b/pkg/activitylogger/activitylogger.go
@@ -145,7 +145,7 @@ func (l *ActivityLogger) LogCustom(message string) {
 }
 
 // LogRequest writes a http response to the activity log
-func (l *ActivityLogger) LogRequest(resp *http.Response, body *gjson.Result, responseTime int64) {
+func (l *ActivityLogger) LogRequest(resp *http.Response, body gjson.Result, responseTime int64) {
 	if l.options.Disabled {
 		return
 	}

--- a/pkg/c8ydata/c8ydata.go
+++ b/pkg/c8ydata/c8ydata.go
@@ -64,9 +64,9 @@ type AddChildAddition struct {
 
 func (a *AddChildAddition) Run(v interface{}) (resp interface{}, err error) {
 	if value, ok := v.(*c8y.Response); ok {
-		if value.JSON != nil {
-			moID := value.JSON.Get("id").String()
-			binaryURL := value.JSON.Get(a.URLProperty).String()
+		if len(value.Body()) > 0 {
+			moID := value.JSON("id").String()
+			binaryURL := value.JSON(a.URLProperty).String()
 
 			if moID != "" && strings.Contains(binaryURL, "/inventory/binaries/") {
 				parts := strings.Split(binaryURL, "/")

--- a/pkg/c8yfetcher/agentFetcher.manual.go
+++ b/pkg/c8yfetcher/agentFetcher.manual.go
@@ -33,7 +33,7 @@ func (f *AgentFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    mo.ID,
 		Name:  mo.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/applicationFetcher.go
+++ b/pkg/c8yfetcher/applicationFetcher.go
@@ -32,7 +32,7 @@ func (f *ApplicationFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    app.ID,
 		Name:  app.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/deviceCertificateFetcher.go
+++ b/pkg/c8yfetcher/deviceCertificateFetcher.go
@@ -46,7 +46,7 @@ func (f *DeviceCertificateFetcher) getByID(id string) ([]fetcherResultSet, error
 		ID:    cert.Fingerprint,
 		Name:  cert.Name,
 		Self:  cert.Self,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/deviceFetcher.go
+++ b/pkg/c8yfetcher/deviceFetcher.go
@@ -31,7 +31,7 @@ func (f *DeviceFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    mo.ID,
 		Name:  mo.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/deviceGroupFetcher.go
+++ b/pkg/c8yfetcher/deviceGroupFetcher.go
@@ -33,7 +33,7 @@ func (f *DeviceGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    mo.ID,
 		Name:  mo.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/deviceProfileFetcher.go
+++ b/pkg/c8yfetcher/deviceProfileFetcher.go
@@ -33,7 +33,7 @@ func (f *DeviceProfileFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    mo.ID,
 		Name:  mo.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/hostedApplicationFetcher.go
+++ b/pkg/c8yfetcher/hostedApplicationFetcher.go
@@ -33,7 +33,7 @@ func (f *HostedApplicationFetcher) getByID(id string) ([]fetcherResultSet, error
 	results[0] = fetcherResultSet{
 		ID:    app.ID,
 		Name:  app.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/managedObjectFetcher.go
+++ b/pkg/c8yfetcher/managedObjectFetcher.go
@@ -34,7 +34,7 @@ func (f *ManagedObjectFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    mo.ID,
 		Name:  mo.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/microserviceFetcher.go
+++ b/pkg/c8yfetcher/microserviceFetcher.go
@@ -33,7 +33,7 @@ func (f *MicroserviceFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    app.ID,
 		Name:  app.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/roleFetcher.go
+++ b/pkg/c8yfetcher/roleFetcher.go
@@ -45,7 +45,7 @@ func (f *RoleFetcher) getByID(id string) ([]fetcherResultSet, error) {
 		ID:    role.ID,
 		Name:  role.Name,
 		Self:  role.Self,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/smartGroupFetcher.manual.go
+++ b/pkg/c8yfetcher/smartGroupFetcher.manual.go
@@ -33,7 +33,7 @@ func (f *SmartGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    mo.ID,
 		Name:  mo.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/userFetcher.go
+++ b/pkg/c8yfetcher/userFetcher.go
@@ -33,7 +33,7 @@ func (f *UserFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    user.ID,
 		Name:  user.Username,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8yfetcher/userGroupFetcher.go
+++ b/pkg/c8yfetcher/userGroupFetcher.go
@@ -31,7 +31,7 @@ func (f *UserGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	results[0] = fetcherResultSet{
 		ID:    group.GetID(),
 		Name:  group.Name,
-		Value: *resp.JSON,
+		Value: resp.JSON(),
 	}
 	return results, nil
 }

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -396,7 +396,7 @@ func (lh *LoginHandler) verify() {
 	lh.do(func() error {
 		tenant, resp, err := lh.C8Yclient.Tenant.GetCurrentTenant(context.Background())
 
-		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		if resp != nil && resp.StatusCode() == http.StatusUnauthorized {
 
 			if v, ok := err.(*c8y.ErrorResponse); ok {
 				lh.Logger.Infof("error message from server. %s", v.Message)
@@ -473,15 +473,15 @@ func (lh *LoginHandler) setupTFA() error {
 		return err
 	}
 
-	lh.Logger.Infof("secret-raw: %s", *resp.JSONData)
+	lh.Logger.Infof("secret-raw: %s", resp.String())
 
 	secretQRURL := ""
-	if v := resp.JSON.Get("secretQrUrl"); v.Exists() {
+	if v := resp.JSON("secretQrUrl"); v.Exists() {
 		secretQRURL = v.String()
 	}
 
 	// Display TOTP secret
-	if v := resp.JSON.Get("rawSecret"); v.Exists() {
+	if v := resp.JSON("rawSecret"); v.Exists() {
 		totpURL := fmt.Sprintf("otpauth://totp/%s?secret=%s&issuer=%s", lh.C8Yclient.Username, v.String(), lh.C8Yclient.BaseURL.Host)
 		qrterminal.GenerateWithConfig(totpURL, qrterminal.Config{
 			Level:     qrterminal.M,

--- a/pkg/c8ywaiter/inventory.go
+++ b/pkg/c8ywaiter/inventory.go
@@ -166,9 +166,9 @@ func (s *InventoryExistance) Check(m interface{}) (done bool, err error) {
 		moID := s.ID
 
 		if result.Response != nil {
-			exists = result.Response.StatusCode >= 200 && result.Response.StatusCode <= 399
-			notFound = result.Response.StatusCode == http.StatusNotFound
-			urlParts := strings.Split(result.Response.Request.URL.Path, "/")
+			exists = result.Response.StatusCode() >= 200 && result.Response.StatusCode() <= 399
+			notFound = result.Response.StatusCode() == http.StatusNotFound
+			urlParts := strings.Split(result.Response.Response.Request.URL.Path, "/")
 			moID = urlParts[len(urlParts)-1]
 		}
 
@@ -217,7 +217,7 @@ func (s *InventoryExistance) Get() (interface{}, error) {
 		nil,
 	)
 
-	if resp != nil && resp.StatusCode == http.StatusNotFound {
+	if resp != nil && resp.StatusCode() == http.StatusNotFound {
 		// ignore not found errors, these are processed in the Check func
 		err = nil
 	}

--- a/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
+++ b/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
@@ -238,7 +238,7 @@ func (n *CmdCreateHostedApplication) RunE(cmd *cobra.Command, args []string) err
 				// handle error
 				n.SubCommand.GetCommand().PrintErrf("failed to upload file. %s", err)
 			} else {
-				applicationBinaryID = resp.JSON.Get("id").String()
+				applicationBinaryID = resp.JSON("id").String()
 			}
 		}
 	}
@@ -260,7 +260,7 @@ func (n *CmdCreateHostedApplication) RunE(cmd *cobra.Command, args []string) err
 		)
 
 		if err != nil {
-			if resp != nil && resp.StatusCode == 409 {
+			if resp != nil && resp.StatusCode() == 409 {
 				log.Infof("application is already enabled")
 			} else {
 				return fmt.Errorf("failed to activate application. %s", err)

--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -77,6 +77,7 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 					ExcludeAuth: !cfg.CacheKeyIncludeAuth(),
 					ExcludeHost: !cfg.CacheKeyIncludeHost(),
 					Mode:        cfg.CacheMode(),
+					BodyKeys:    cfg.CacheBodyKeys(),
 				},
 			)
 		}

--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -37,6 +37,14 @@ func GetHostFromEnvironment() string {
 	return value
 }
 
+// WithCompression sets the compression option for the http client
+func WithCompression(enable bool) c8y.ClientOption {
+	return func(tr http.RoundTripper) http.RoundTripper {
+		tr.(*http.Transport).DisableCompression = !enable
+		return tr
+	}
+}
+
 func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password string, disableEncryptionCheck bool) func() (*c8y.Client, error) {
 	return func() (*c8y.Client, error) {
 		cfg, err := f.Config()
@@ -62,7 +70,13 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 		httpClient := c8y.NewHTTPClient(
 			WithProxyDisabled(cfg.IgnoreProxy()),
 			c8y.WithInsecureSkipVerify(cfg.SkipSSLVerify()),
+			WithCompression(false),
 		)
+
+		cacheBodyPaths := cfg.CacheBodyKeys()
+		if len(cacheBodyPaths) > 0 {
+			log.Infof("Caching of body only includes paths: %s", strings.Join(cacheBodyPaths, ", "))
+		}
 
 		if cfg.CacheEnabled() && cfg.CacheTTL() > 0 {
 			cachableMethods := cfg.CacheMethods()
@@ -77,7 +91,7 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 					ExcludeAuth: !cfg.CacheKeyIncludeAuth(),
 					ExcludeHost: !cfg.CacheKeyIncludeHost(),
 					Mode:        cfg.CacheMode(),
-					BodyKeys:    cfg.CacheBodyKeys(),
+					BodyKeys:    cacheBodyPaths,
 				},
 			)
 		}

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -293,7 +293,7 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 			_, resp, err := client.Tenant.AddApplicationReference(context.Background(), client.TenantName, application.Self)
 
 			if err != nil {
-				if resp != nil && resp.StatusCode == 409 {
+				if resp != nil && resp.StatusCode() == 409 {
 					log.Infof("microservice is already enabled")
 				} else {
 					return fmt.Errorf("Failed to subscribe to application. %s", err)

--- a/pkg/cmd/microservices/serviceuser/create/create.manual.go
+++ b/pkg/cmd/microservices/serviceuser/create/create.manual.go
@@ -111,7 +111,7 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 			_, resp, err := client.Tenant.AddApplicationReference(context.Background(), tenant, application.Self)
 
 			if err != nil {
-				if resp != nil && resp.StatusCode == 409 {
+				if resp != nil && resp.StatusCode() == 409 {
 					log.Infof("microservice is already enabled")
 				} else {
 					return fmt.Errorf("Failed to subscribe to application. %s", err)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -233,7 +233,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	cmd.PersistentFlags().Bool("cache", false, "Enable cached responses")
 	cmd.PersistentFlags().Bool("noCache", false, "Force disabling of cached responses (overwrites cache setting)")
 	cmd.PersistentFlags().String("cacheTTL", "60s", "Cache time-to-live (TTL) as a duration, i.e. 60s, 2m")
-	cmd.PersistentFlags().StringSlice("cacheBody", []string{}, "Only use named body fragments in uniqness. valid for json bodies only")
+	cmd.PersistentFlags().StringSlice("cacheBodyPaths", []string{}, "Cache should limit hashing of selected paths in the json body. Empty indicates all values")
 
 	// ssl settings
 	cmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -233,6 +233,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	cmd.PersistentFlags().Bool("cache", false, "Enable cached responses")
 	cmd.PersistentFlags().Bool("noCache", false, "Force disabling of cached responses (overwrites cache setting)")
 	cmd.PersistentFlags().String("cacheTTL", "60s", "Cache time-to-live (TTL) as a duration, i.e. 60s, 2m")
+	cmd.PersistentFlags().StringSlice("cacheBody", []string{}, "Only use named body fragments in uniqness. valid for json bodies only")
 
 	// ssl settings
 	cmd.PersistentFlags().BoolP("insecure", "k", false, "Allow insecure server connections when using SSL")

--- a/pkg/cmderrors/cmderrors.go
+++ b/pkg/cmderrors/cmderrors.go
@@ -238,8 +238,8 @@ func NewServerError(r *c8y.Response, err error) CommandError {
 		if r.Response != nil {
 			cmdError.StatusCode = r.Response.StatusCode
 
-			if r.Request != nil {
-				cmdError.URL = r.Request.URL.Path
+			if r.Response.Request != nil {
+				cmdError.URL = r.Response.Request.URL.Path
 			}
 
 			if v, ok := httpStatusCodeToExitCode[cmdError.StatusCode]; ok {

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -279,6 +279,9 @@ const (
 	// SettingsCacheKeyAuth include authorization header in cache key generation
 	SettingsCacheKeyAuth = "settings.cache.keyauth"
 
+	// SettingsCacheKeyBody include only specific json body keys in cache key generation
+	SettingsCacheKeyBody = "settings.cache.keybody"
+
 	// SettingsDefaultsInsecure allow insecure SSL connections
 	SettingsDefaultsInsecure = "settings.defaults.insecure"
 
@@ -403,9 +406,10 @@ func (c *Config) bindSettings() {
 
 		WithBindEnv(SettingsLoggerHideSensitive, false),
 
-		WithBindEnv(SettingsCacheMethods, "GET"),
+		WithBindEnv(SettingsCacheMethods, "GET POST"),
 		WithBindEnv(SettingsCacheKeyHost, true),
 		WithBindEnv(SettingsCacheKeyAuth, true),
+		WithBindEnv(SettingsCacheKeyBody, ""),
 		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
 
@@ -1303,6 +1307,10 @@ func (c *Config) CacheKeyIncludeHost() bool {
 // CacheKeyIncludeAuth include authorization cache key generation
 func (c *Config) CacheKeyIncludeAuth() bool {
 	return c.viper.GetBool(SettingsCacheKeyAuth)
+}
+
+func (c *Config) CacheBodyKeys() []string {
+	return c.viper.GetStringSlice(SettingsCacheKeyBody)
 }
 
 // SkipSSLVerify skip SSL verify

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -279,8 +279,8 @@ const (
 	// SettingsCacheKeyAuth include authorization header in cache key generation
 	SettingsCacheKeyAuth = "settings.cache.keyauth"
 
-	// SettingsCacheKeyBody include only specific json body keys in cache key generation
-	SettingsCacheKeyBody = "settings.cache.keybody"
+	// SettingsCacheBodyPaths include only specific json body paths in cache hashing calculation
+	SettingsCacheBodyPaths = "settings.defaults.cacheBodyPaths"
 
 	// SettingsDefaultsInsecure allow insecure SSL connections
 	SettingsDefaultsInsecure = "settings.defaults.insecure"
@@ -409,7 +409,7 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsCacheMethods, "GET POST"),
 		WithBindEnv(SettingsCacheKeyHost, true),
 		WithBindEnv(SettingsCacheKeyAuth, true),
-		WithBindEnv(SettingsCacheKeyBody, ""),
+		WithBindEnv(SettingsCacheBodyPaths, ""),
 		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
 
@@ -1310,7 +1310,7 @@ func (c *Config) CacheKeyIncludeAuth() bool {
 }
 
 func (c *Config) CacheBodyKeys() []string {
-	return c.viper.GetStringSlice(SettingsCacheKeyBody)
+	return c.viper.GetStringSlice(SettingsCacheBodyPaths)
 }
 
 // SkipSSLVerify skip SSL verify

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -406,7 +406,7 @@ func (c *Config) bindSettings() {
 
 		WithBindEnv(SettingsLoggerHideSensitive, false),
 
-		WithBindEnv(SettingsCacheMethods, "GET POST"),
+		WithBindEnv(SettingsCacheMethods, "GET PUT POST"),
 		WithBindEnv(SettingsCacheKeyHost, true),
 		WithBindEnv(SettingsCacheKeyAuth, true),
 		WithBindEnv(SettingsCacheBodyPaths, ""),

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -75,6 +75,6 @@ func UTF16Bom(b []byte) int8 {
 	return 0
 }
 
-func IsUTF16(s string) bool {
+func IsUTF16(s []byte) bool {
 	return len(s) >= 2 && ((s[0] == 0xFE && s[1] == 0xFF) || (s[0] == 0xFF && s[1] == 0xFE)) && len(s)%2 == 0
 }

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -107,7 +107,7 @@ func (r *RequestHandler) ProcessRequestAndResponse(requests []c8y.RequestOptions
 		r.Logger.Infof("Response time: %dms", durationMS)
 
 		if r.ActivityLogger != nil && resp != nil {
-			r.ActivityLogger.LogRequest(resp.Response, resp.JSON, durationMS)
+			r.ActivityLogger.LogRequest(resp.Response, resp.JSON(), durationMS)
 		}
 	}
 
@@ -361,7 +361,7 @@ func (r *RequestHandler) GetCurlCommands(req *http.Request) (shell string, pwsh 
 }
 
 func (r *RequestHandler) fetchAllResults(req c8y.RequestOptions, resp *c8y.Response, commonOptions config.CommonCommandOptions) error {
-	if req.DryRun || (resp != nil && resp.StatusCode == 0) {
+	if req.DryRun || (resp != nil && resp.StatusCode() == 0) {
 		return nil
 	}
 
@@ -411,7 +411,7 @@ func (r *RequestHandler) fetchAllResults(req c8y.RequestOptions, resp *c8y.Respo
 		if resp == nil || totalItems == 0 {
 			break
 		}
-		if v := resp.JSON.Get("next"); v.Exists() && v.String() != "" {
+		if v := resp.JSON("next"); v.Exists() && v.String() != "" {
 			nextURI = v.String()
 		} else {
 			break
@@ -441,7 +441,7 @@ func (r *RequestHandler) fetchAllResults(req c8y.RequestOptions, resp *c8y.Respo
 		if resp != nil {
 			durationMS := int64(time.Since(start) / time.Millisecond)
 			r.Logger.Infof("Response time: %dms", durationMS)
-			r.ActivityLogger.LogRequest(resp.Response, resp.JSON, durationMS)
+			r.ActivityLogger.LogRequest(resp.Response, resp.JSON(), durationMS)
 			totalItems, processErr = r.ProcessResponse(resp, err, commonOptions)
 
 			if processErr != nil {
@@ -472,7 +472,7 @@ func (r *RequestHandler) fetchAllResults(req c8y.RequestOptions, resp *c8y.Respo
 }
 
 func (r *RequestHandler) fetchAllInventoryQueryResults(req c8y.RequestOptions, resp *c8y.Response, commonOptions config.CommonCommandOptions) error {
-	if req.DryRun || (resp != nil && resp.StatusCode == 0) {
+	if req.DryRun || (resp != nil && resp.StatusCode() == 0) {
 		return nil
 	}
 
@@ -507,7 +507,7 @@ func (r *RequestHandler) fetchAllInventoryQueryResults(req c8y.RequestOptions, r
 	originalURI := ""
 	lastID := "0"
 
-	if v := resp.JSON.Get("self"); v.Exists() && v.String() != "" {
+	if v := resp.JSON("self"); v.Exists() && v.String() != "" {
 		originalURI = v.String()
 	}
 
@@ -528,7 +528,7 @@ func (r *RequestHandler) fetchAllInventoryQueryResults(req c8y.RequestOptions, r
 		}
 
 		// get last id of the result set
-		if v := resp.JSON.Get(dataProperty); v.Exists() && v.IsArray() {
+		if v := resp.JSON(dataProperty); v.Exists() && v.IsArray() {
 			items := v.Array()
 			if len(items) > 0 {
 				lastID = items[len(items)-1].Get("id").String()
@@ -562,7 +562,7 @@ func (r *RequestHandler) fetchAllInventoryQueryResults(req c8y.RequestOptions, r
 		if resp != nil {
 			durationMS := int64(time.Since(start) / time.Millisecond)
 			r.Logger.Infof("Response time: %dms", durationMS)
-			r.ActivityLogger.LogRequest(resp.Response, resp.JSON, durationMS)
+			r.ActivityLogger.LogRequest(resp.Response, resp.JSON(), durationMS)
 
 			totalItems, processErr = r.ProcessResponse(resp, err, commonOptions)
 
@@ -637,19 +637,19 @@ func optimizeManagedObjectsURL(u *url.URL, lastID string) *url.URL {
 }
 
 func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, commonOptions config.CommonCommandOptions) (int, error) {
-	if resp != nil && resp.StatusCode != 0 {
-		r.Logger.Infof("Response Content-Type: %s", resp.Header.Get("Content-Type"))
+	if resp != nil && resp.StatusCode() != 0 {
+		r.Logger.Infof("Response Content-Type: %s", resp.Response.Header.Get("Content-Type"))
 		r.Logger.Debugf("Response Headers: %v", resp.Header)
 	}
 
 	// Display log output in special scenarios (i.e. Delete and no Accept header), so the user gets some feedback that it did something
-	if resp != nil && (resp.Request.Method == http.MethodDelete && resp.StatusCode == 204 || resp.Request.Header.Get("Accept") == "" && resp.Request.Method != http.MethodDelete && (resp.StatusCode == 201 || resp.StatusCode == 200)) {
+	if resp != nil && (resp.Response.Request.Method == http.MethodDelete && resp.StatusCode() == 204 || resp.Response.Request.Header.Get("Accept") == "" && resp.Response.Request.Method != http.MethodDelete && (resp.StatusCode() == 201 || resp.StatusCode() == 200)) {
 		if r.IsTerminal && !r.Config.ShowProgress() {
 			cs := r.IO.ColorScheme()
 
 			actionText := ""
 			actionColor := cs.Green
-			switch resp.Request.Method {
+			switch resp.Response.Request.Method {
 			case http.MethodDelete:
 				actionText = "Deleted"
 				actionColor = cs.Red
@@ -662,17 +662,17 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 			case http.MethodPatch:
 				actionText = "Patched"
 			default:
-				actionText = resp.Request.Method
+				actionText = resp.Response.Request.Method
 			}
-			fmt.Fprintf(r.IO.ErrOut, "%s %s %s => %s\n", cs.SuccessIconWithColor(actionColor), actionText, resp.Request.URL.Path, resp.Status)
+			fmt.Fprintf(r.IO.ErrOut, "%s %s %s => %s\n", cs.SuccessIconWithColor(actionColor), actionText, resp.Response.Request.URL.Path, resp.Status())
 		}
 	}
 
 	// write response to file instead of to stdout
 	if resp != nil && respError == nil && commonOptions.OutputFileRaw != "" {
-		if resp.StatusCode != 0 {
+		if resp.StatusCode() != 0 {
 			// check if it is a dummy response (i.e. no status code)
-			newline := strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "json")
+			newline := strings.Contains(strings.ToLower(resp.Response.Header.Get("Content-Type")), "json")
 			fullFilePath, err := r.saveResponseToFile(resp, commonOptions.OutputFileRaw, false, newline)
 
 			if err != nil {
@@ -683,23 +683,23 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 		}
 	}
 
-	if resp != nil && respError == nil && (r.Config.IsResponseOutput() || resp.Header.Get("Content-Type") == "application/octet-stream") && resp.JSONData != nil {
+	if resp != nil && respError == nil && (r.Config.IsResponseOutput() || resp.Response.Header.Get("Content-Type") == "application/octet-stream") && len(resp.Body()) > 0 {
 		// estimate size based on utf8 encoding. 1 char is 1 byte
 		r.Logger.Debugf("Writing https response output")
-		r.Logger.Infof("Response Length: %0.1fKB", float64(len(*resp.JSONData)*1)/1024)
+		r.Logger.Infof("Response Length: %0.1fKB", float64(len(resp.String())/1024))
 		outputEOL := ""
 		if r.IsTerminal {
 			outputEOL = "\n"
 		}
 		out := r.IO.Out
-		if encoding.IsUTF16(*resp.JSONData) {
-			if utf8, err := encoding.DecodeUTF16([]byte(*resp.JSONData)); err == nil {
+		if encoding.IsUTF16(resp.String()) {
+			if utf8, err := encoding.DecodeUTF16([]byte(resp.String())); err == nil {
 				fmt.Fprintf(out, "%s", utf8)
 			} else {
-				fmt.Fprintf(out, "%s", *resp.JSONData)
+				fmt.Fprintf(out, "%s", resp.String())
 			}
 		} else {
-			fmt.Fprintf(out, "%s", *resp.JSONData)
+			fmt.Fprintf(out, "%s", resp.String())
 		}
 		if outputEOL != "" {
 			fmt.Fprint(out, outputEOL)
@@ -713,12 +713,12 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 
 	unfilteredSize := 0
 
-	if resp != nil && resp.JSONData != nil {
+	if resp != nil && len(resp.Body()) > 0 {
 		// estimate size based on utf8 encoding. 1 char is 1 byte
-		r.Logger.Printf("Response Length: %0.1fKB", float64(len(*resp.JSONData)*1)/1024)
+		r.Logger.Printf("Response Length: %0.1fKB", float64(len(resp.Body()))/1024)
 
 		var responseText []byte
-		isJSONResponse := jsonUtilities.IsValidJSON([]byte(*resp.JSONData))
+		isJSONResponse := jsonUtilities.IsValidJSON(resp.Body())
 
 		dataProperty := ""
 		showRaw := r.Config.RawOutput() || r.Config.WithTotalPages()
@@ -730,7 +730,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 			dataProperty = ""
 		}
 
-		if v := resp.JSON.Get(dataProperty); v.Exists() && v.IsArray() {
+		if v := resp.JSON(dataProperty); v.Exists() && v.IsArray() {
 			unfilteredSize = len(v.Array())
 			r.Logger.Infof("Unfiltered array size. len=%d", unfilteredSize)
 		}
@@ -748,11 +748,11 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 
 			// Detect view (if no filters are given)
 			if len(commonOptions.Filters.Pluck) == 0 {
-				if resp.JSON != nil && r.DataView != nil {
-					inputData := resp.JSON
+				if len(resp.Body()) > 0 && r.DataView != nil {
+					inputData := resp.JSON()
 					if dataProperty != "" {
-						subpro := resp.JSON.Get(dataProperty)
-						inputData = &subpro
+						subpro := resp.JSON(dataProperty)
+						inputData = subpro
 					}
 
 					switch strings.ToLower(view) {
@@ -762,7 +762,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 							commonOptions.Filters.Pluck = []string{"**"}
 						}
 					case config.ViewsAuto:
-						props, err := r.DataView.GetView(inputData, resp.Header.Get("Content-Type"))
+						props, err := r.DataView.GetView(&inputData, resp.Response.Header.Get("Content-Type"))
 
 						if err != nil || len(props) == 0 {
 							if err != nil {
@@ -794,7 +794,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 				r.Logger.Debugf("using existing pluck values. %v", commonOptions.Filters.Pluck)
 			}
 
-			if filterOutput, filterErr := commonOptions.Filters.Apply(*resp.JSONData, dataProperty, false, r.Console.SetHeaderFromInput); filterErr != nil {
+			if filterOutput, filterErr := commonOptions.Filters.Apply(resp.String(), dataProperty, false, r.Console.SetHeaderFromInput); filterErr != nil {
 				r.Logger.Warnf("filter error. %s", filterErr)
 				responseText = filterOutput
 			} else {
@@ -808,7 +808,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 				responseText = []byte{}
 			}
 		} else {
-			responseText = []byte(*resp.JSONData)
+			responseText = resp.Body()
 		}
 
 		// replace special escaped unicode sequences
@@ -846,9 +846,9 @@ func (r *RequestHandler) guessDataProperty(resp *c8y.Response) string {
 	arrayPropertes := []string{}
 	totalKeys := 0
 
-	if v := resp.JSON.Get("id"); !v.Exists() {
+	if v := resp.JSON("id"); !v.Exists() {
 		// Find the property which is an array
-		resp.JSON.ForEach(func(key, value gjson.Result) bool {
+		resp.JSON().ForEach(func(key, value gjson.Result) bool {
 			totalKeys++
 			if value.IsArray() {
 				arrayPropertes = append(arrayPropertes, key.String())
@@ -890,7 +890,7 @@ func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string,
 	// Support simple variable substitution to be able to set the output file name dynamically to download a collection of files
 	if strings.Contains(filename, "{") && strings.Contains(filename, "}") {
 		if strings.Contains(filename, "{filename}") {
-			if _, params, err := mime.ParseMediaType(resp.Header.Get("Content-Disposition")); err == nil {
+			if _, params, err := mime.ParseMediaType(resp.Response.Header.Get("Content-Disposition")); err == nil {
 				if name, ok := params["filename"]; ok {
 					filename = strings.ReplaceAll(filename, "{filename}", name)
 				}
@@ -898,16 +898,16 @@ func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string,
 		}
 
 		if strings.Contains(filename, "{basename}") {
-			if resp.Request != nil {
-				filename = strings.ReplaceAll(filename, "{basename}", path.Base(resp.Request.URL.Path))
+			if resp.Response.Request != nil {
+				filename = strings.ReplaceAll(filename, "{basename}", path.Base(resp.Response.Request.URL.Path))
 			}
 		}
 
 		if strings.Contains(filename, "{id}") {
-			if resp.Request != nil {
-				r.Logger.Infof("Request: %s", resp.Request.URL.Path)
+			if resp.Response.Request != nil {
+				r.Logger.Infof("Request: %s", resp.Response.Request.URL.Path)
 
-				urlParts := strings.Split(resp.Request.URL.Path, "/")
+				urlParts := strings.Split(resp.Response.Request.URL.Path, "/")
 				for _, part := range urlParts {
 					if part != "" && c8y.IsID(part) {
 						r.Logger.Debugf("Found id like value. Substituting {id} for %s", part)
@@ -949,7 +949,7 @@ func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string,
 
 	// Writer the body to file
 	r.Logger.Printf("header: %v", resp.Header)
-	_, err = io.Copy(out, resp.Body)
+	_, err = io.Copy(out, resp.RawBody())
 
 	if err != nil {
 		return "", fmt.Errorf("failed to copy file contents to file. %s", err)

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -97,6 +97,7 @@ func (r *RequestHandler) ProcessRequestAndResponse(requests []c8y.RequestOptions
 	defer cancel()
 	start := time.Now()
 
+	// TODO: Check if this is required
 	outData := make(map[string]interface{})
 	req.ResponseData = &outData
 	resp, err := r.Client.SendRequest(

--- a/tests/manual/cache/cacheBodyPaths.sh
+++ b/tests/manual/cache/cacheBodyPaths.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+echo "path: $(which c8y)"
+
+ID1=$( c8y inventory create --name cached_device01 --cacheBodyPaths name,id,type --cache --cacheTTL 10min --template "{now: _.Now()}" --select id --output csv -f )
+ID2=$( c8y inventory create --name cached_device01 --cacheBodyPaths name,id,type --cache --cacheTTL 10min --template "{now: _.Now()}" --select id --output csv -f )
+
+cleanup () {
+    echo "$ID1" | c8y inventory delete --silentStatusCodes 404 -f || true
+    echo "$ID2" | c8y inventory delete --silentStatusCodes 404 -f || true
+}
+trap cleanup EXIT
+
+[[ "$ID1" == "$ID2" ]] || exit 10

--- a/tests/manual/cache/cache_bodyPaths.yaml
+++ b/tests/manual/cache/cache_bodyPaths.yaml
@@ -1,0 +1,4 @@
+tests:
+  It limits body caching to specific paths:
+    command: ./manual/cache/cacheBodyPaths.sh
+    exit-code: 0

--- a/tests/manual/cache/cached_commands.yaml
+++ b/tests/manual/cache/cached_commands.yaml
@@ -86,11 +86,12 @@ tests:
         - "Last-Modified:"
         - "Etag:"
 
-  It does not cache PUT or POST requests by default:
+  It can limit caching of specific methods:
     config:
       env:
         C8Y_SETTINGS_DEFAULTS_CACHE: true
         C8Y_SETTINGS_DEFAULTS_DEBUG: true
+        C8Y_SETTINGS_CACHE_METHODS: "GET"
         C8Y_SETTINGS_CACHE_PATH: /tmp/go-c8y-cli-cache-test-06
     command: |
       c8y cache delete


### PR DESCRIPTION
### Support optional selective caching by limiting hash calculation to specific json body paths

* Limit cache calculation of specified body paths when dealing with json bodies via new global flag: `--cacheBodyPaths [paths]`
* GET, PUT and POST methods are cached by default

**Example:  Create inventory managed object with dynamic body but only use name for uniqueness to prevent duplication**

Create an inventory managed object and only use the `name` body path when caching the command. If the same command is run again with the same `name` field value, then the cached response will be used instead.

```sh
# First time creates a new managed object
c8y inventory create \
    --name cached_device01 \
    --cacheBodyPaths name,id,type \
    --cache \
    --cacheTTL 10min \
    --template "{now: _.Now()}"

| id          | name                 |
|-------------|----------------------|
| 330315      | cached_device01      |

# Creating another object with the same name (but different body) just returns the cached response
c8y inventory create \
    --name cached_device01 \
    --cacheBodyPaths name,id,type \
    --cache \
    --cacheTTL 10min \
    --template "{now: _.Now()}"

| id          | name                 |
|-------------|----------------------|
| 330315      | cached_device01      |

```