### PR TITLE
fix building on amd64 architectures

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,7 +8,7 @@ vars:
     sh: git describe | sed "s/^v\?\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*/\1/"
   VERSION: "{{base .TAG}}"
   OS_NAME: '{{ if eq OS "darwin" }}macOS{{ else }}{{OS}}{{ end }}'
-  ARCH_NAME: '{{ARCH}}'
+  ARCH_NAME: '{{ if eq ARCH "amd64" }}amd64_v1{{ else }}{{ARCH}}{{ end }}'
 
 env:
   C8Y_SETTINGS_CI: true
@@ -189,6 +189,7 @@ tasks:
     cmds:
       - goreleaser build --rm-dist --snapshot --single-target --id {{.OS_NAME}} {{.CLI_ARGS}}
       - rm -f .bin/c8y
+      - mkdir -p .bin
       - cp dist/{{.OS_NAME}}_{{OS}}_{{.ARCH_NAME}}/bin/c8y .bin/c8y
 
   generate:


### PR DESCRIPTION
* Fix expected folder name when running `task build-snapshot-single` on linux amd64