### PR TITLE
Feat/support global with total elements

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -182,6 +182,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	cmd.PersistentFlags().Int64("totalPages", 0, "Total number of pages to get")
 	cmd.PersistentFlags().Bool("includeAll", false, "Include all results by iterating through each page")
 	cmd.PersistentFlags().BoolP(flags.FlagWithTotalPages, "t", false, "Request Cumulocity to include the total pages in the response statistics under .statistics.totalPages")
+	cmd.PersistentFlags().Bool(flags.FlagWithTotalElements, false, "Request Cumulocity to include the total elements in the response statistics under .statistics.totalElements (introduced in 10.13)")
 	cmd.PersistentFlags().BoolP("compact", "c", !isTerm, "Compact instead of pretty-printed output when using json output. Pretty print is the default if output is the terminal")
 	cmd.PersistentFlags().Bool("noAccept", false, "Ignore Accept header will remove the Accept header from requests, however PUT and POST requests will only see the effect")
 	cmd.PersistentFlags().Bool("dry", false, "Dry run. Don't send any data to the server")

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -193,7 +193,7 @@ func (f *Factory) GetViewProperties(cfg *config.Config, cmd *cobra.Command, outp
 	}
 
 	view := cfg.ViewOption()
-	showRaw := cfg.RawOutput() || cfg.WithTotalPages()
+	showRaw := cfg.RawOutput() || cfg.WithTotalPages() || cfg.WithTotalElements()
 
 	if showRaw {
 		return []string{"**"}, nil

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -87,6 +87,9 @@ const (
 	// SettingsWithTotalPages include the total pages statistics under statistics.totalPages
 	SettingsWithTotalPages = "settings.defaults.withTotalPages"
 
+	// SettingsWithTotalElements include the total pages statistics under statistics.totalPages
+	SettingsWithTotalElements = "settings.defaults.withTotalElements"
+
 	// SettingsRawOutput include the raw (original) output instead of only returning the nested array property
 	SettingsRawOutput = "settings.defaults.raw"
 
@@ -950,6 +953,11 @@ func (c *Config) WithTotalPages() bool {
 	return c.viper.GetBool(SettingsWithTotalPages)
 }
 
+// WithTotalElements return total of all elements
+func (c *Config) WithTotalElements() bool {
+	return c.viper.GetBool(SettingsWithTotalElements)
+}
+
 // RawOutput return raw (original) response
 func (c *Config) RawOutput() bool {
 	return c.viper.GetBool(SettingsRawOutput)
@@ -1388,6 +1396,7 @@ func (c *Config) GetOutputCommonOptions(cmd *cobra.Command) (CommonCommandOption
 	}
 
 	options.WithTotalPages = c.WithTotalPages()
+	options.WithTotalElements = c.WithTotalElements()
 
 	options.IncludeAll = c.IncludeAll()
 

--- a/pkg/config/commonoptions.go
+++ b/pkg/config/commonoptions.go
@@ -8,16 +8,17 @@ import (
 // CommonCommandOptions control the handling of the response which are available for all commands
 // which interact with the server
 type CommonCommandOptions struct {
-	ConfirmText    string
-	OutputFile     string
-	OutputFileRaw  string
-	Filters        *jsonfilter.JSONFilters
-	ResultProperty string
-	IncludeAll     bool
-	WithTotalPages bool
-	PageSize       int
-	CurrentPage    int64
-	TotalPages     int64
+	ConfirmText       string
+	OutputFile        string
+	OutputFileRaw     string
+	Filters           *jsonfilter.JSONFilters
+	ResultProperty    string
+	IncludeAll        bool
+	WithTotalPages    bool
+	WithTotalElements bool
+	PageSize          int
+	CurrentPage       int64
+	TotalPages        int64
 }
 
 // AddQueryParameters adds the common query parameters to the given query values
@@ -36,5 +37,9 @@ func (options CommonCommandOptions) AddQueryParameters(query *flags.QueryTemplat
 
 	if options.WithTotalPages {
 		query.SetVariable(flags.FlagWithTotalPages, "true")
+	}
+
+	if options.WithTotalElements {
+		query.SetVariable(flags.FlagWithTotalElements, "true")
 	}
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -14,6 +14,7 @@ const (
 	FlagDataTemplateVariablesName = "templateVars"
 	FlagProcessingModeName        = "processingMode"
 	FlagWithTotalPages            = "withTotalPages"
+	FlagWithTotalElements         = "withTotalElements"
 	FlagPageSize                  = "pageSize"
 	FlagCurrentPage               = "currentPage"
 	FlagNullInput                 = "nullInput"

--- a/pkg/flags/queryOptions.go
+++ b/pkg/flags/queryOptions.go
@@ -17,3 +17,7 @@ func WithPageSize() GetOption {
 func WithTotalPages() GetOption {
 	return WithStringValue(FlagWithTotalPages, FlagWithTotalPages)
 }
+
+func WithTotalElements() GetOption {
+	return WithStringValue(FlagWithTotalElements, FlagWithTotalElements)
+}

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -746,7 +746,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 		isJSONResponse := jsonUtilities.IsValidJSON(resp.Body())
 
 		dataProperty := ""
-		showRaw := r.Config.RawOutput() || r.Config.WithTotalPages()
+		showRaw := r.Config.RawOutput() || r.Config.WithTotalPages() || r.Config.WithTotalElements()
 
 		dataProperty = commonOptions.ResultProperty
 		if dataProperty == "" {

--- a/tests/manual/common/flags/withTotalElements/flag_withTotalPages.yaml
+++ b/tests/manual/common/flags/withTotalElements/flag_withTotalPages.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_LOGGER_HIDESENSITIVE: true
+tests:
+  It should support total element statistics:
+    command: |
+      c8y devices list --withTotalElements --dry --dryFormat json
+    exit-code: 0
+    stdout:
+      contains:
+        - withTotalElements=true

--- a/tools/PSc8y/Private/New-ClientArgument.ps1
+++ b/tools/PSc8y/Private/New-ClientArgument.ps1
@@ -118,7 +118,7 @@ Function New-ClientArgument {
             $null = $c8yargs.Add("--verbose")
         }
 
-        if ($Parameters["WithTotalPages"]) {
+        if ($Parameters["WithTotalPages"] -or $Parameters["WithTotalElements"]) {
             $null = $c8yargs.Add("--raw")
         }
 

--- a/tools/PSc8y/Public-manual/ConvertFrom-ClientOutput.ps1
+++ b/tools/PSc8y/Public-manual/ConvertFrom-ClientOutput.ps1
@@ -27,6 +27,7 @@ Function ConvertFrom-ClientOutput {
         $Depth = if ($BoundParameters.ContainsKey("Depth")) { $BoundParameters["Depth"] } else { 100 }
         $AsHashTable = if ($BoundParameters.ContainsKey("AsHashTable")) { $BoundParameters["AsHashTable"] } else { $false }
         $Raw = $BoundParameters["WithTotalPages"] `
+            -or $BoundParameters["WithTotalElements"] `
             -or $BoundParameters["Raw"]
         
         $UseNativeOutput = $BoundParameters["AsJSON"] `

--- a/tools/PSc8y/Public-manual/Get-ClientCommonParameters.ps1
+++ b/tools/PSc8y/Public-manual/Get-ClientCommonParameters.ps1
@@ -45,6 +45,7 @@ Inherit common parameters to a custom function. This will add parameters such as
                 "Collection" {
                     New-DynamicParam -Name "PageSize" -Type "int" -DPDictionary $Dictionary -HelpMessage "Maximum results per page"
                     New-DynamicParam -Name "WithTotalPages" -Type "switch" -DPDictionary $Dictionary -HelpMessage "Request Cumulocity to include the total pages in the response statistics under .statistics.totalPages"
+                    New-DynamicParam -Name "WithTotalElements" -Type "switch" -DPDictionary $Dictionary -HelpMessage "Request Cumulocity to include the total elements in the response statistics under .statistics.totalElements (introduced in 10.13)"
                     New-DynamicParam -Name "CurrentPage" -Type "int" -DPDictionary $Dictionary -HelpMessage "Current page which should be returned"
                     New-DynamicParam -Name "TotalPages" -Type "int" -DPDictionary $Dictionary -HelpMessage "Total number of pages to get"
                     New-DynamicParam -Name "IncludeAll" -Type "switch" -DPDictionary $Dictionary -HelpMessage "Include all results by iterating through each page"

--- a/tools/PSc8y/Tests/Paging.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/Paging.manual.Tests.ps1
@@ -64,6 +64,7 @@ Describe -Name "Get-Pagination" {
             $icmdlet | Should -HaveParameter "IncludeAll"
             $icmdlet | Should -HaveParameter "PageSize"
             $icmdlet | Should -HaveParameter "WithTotalPages"
+            $icmdlet | Should -HaveParameter "WithTotalElements"
             $icmdlet | Should -HaveParameter "Raw"
         }
     }

--- a/tools/PSc8y/format-data/agents.ps1xml
+++ b/tools/PSc8y/format-data/agents.ps1xml
@@ -121,6 +121,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -136,6 +140,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>managedObjects</PropertyName>

--- a/tools/PSc8y/format-data/alarms.ps1xml
+++ b/tools/PSc8y/format-data/alarms.ps1xml
@@ -117,6 +117,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -132,6 +136,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>alarms</PropertyName>

--- a/tools/PSc8y/format-data/applicationReferences.ps1xml
+++ b/tools/PSc8y/format-data/applicationReferences.ps1xml
@@ -95,6 +95,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -110,6 +114,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>references</PropertyName>

--- a/tools/PSc8y/format-data/applications.ps1xml
+++ b/tools/PSc8y/format-data/applications.ps1xml
@@ -113,6 +113,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -128,6 +132,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>applications</PropertyName>

--- a/tools/PSc8y/format-data/auditRecords.ps1xml
+++ b/tools/PSc8y/format-data/auditRecords.ps1xml
@@ -117,6 +117,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -132,6 +136,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>auditRecords</PropertyName>

--- a/tools/PSc8y/format-data/bulkOperations.ps1xml
+++ b/tools/PSc8y/format-data/bulkOperations.ps1xml
@@ -117,6 +117,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -132,6 +136,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>bulkOperations</PropertyName>

--- a/tools/PSc8y/format-data/deviceCredentials.ps1xml
+++ b/tools/PSc8y/format-data/deviceCredentials.ps1xml
@@ -99,6 +99,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -114,6 +118,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>users</PropertyName>

--- a/tools/PSc8y/format-data/deviceGroups.ps1xml
+++ b/tools/PSc8y/format-data/deviceGroups.ps1xml
@@ -99,6 +99,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -114,6 +118,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>managedObjects</PropertyName>

--- a/tools/PSc8y/format-data/devices.ps1xml
+++ b/tools/PSc8y/format-data/devices.ps1xml
@@ -121,6 +121,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -136,6 +140,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>managedObjects</PropertyName>

--- a/tools/PSc8y/format-data/events.ps1xml
+++ b/tools/PSc8y/format-data/events.ps1xml
@@ -112,6 +112,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -127,6 +131,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>events</PropertyName>

--- a/tools/PSc8y/format-data/inventoryRoles.ps1xml
+++ b/tools/PSc8y/format-data/inventoryRoles.ps1xml
@@ -92,6 +92,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -107,6 +111,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>roles</PropertyName>

--- a/tools/PSc8y/format-data/managedObjectReferences.ps1xml
+++ b/tools/PSc8y/format-data/managedObjectReferences.ps1xml
@@ -81,6 +81,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -96,6 +100,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>references</PropertyName>

--- a/tools/PSc8y/format-data/managedObjects.ps1xml
+++ b/tools/PSc8y/format-data/managedObjects.ps1xml
@@ -111,6 +111,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -126,6 +130,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>managedObjects</PropertyName>

--- a/tools/PSc8y/format-data/measurements.ps1xml
+++ b/tools/PSc8y/format-data/measurements.ps1xml
@@ -94,6 +94,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -109,6 +113,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>measurements</PropertyName>

--- a/tools/PSc8y/format-data/microservices.ps1xml
+++ b/tools/PSc8y/format-data/microservices.ps1xml
@@ -87,6 +87,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -102,6 +106,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>applications</PropertyName>

--- a/tools/PSc8y/format-data/operations.ps1xml
+++ b/tools/PSc8y/format-data/operations.ps1xml
@@ -112,6 +112,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -127,6 +131,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>operations</PropertyName>

--- a/tools/PSc8y/format-data/retentionRules.ps1xml
+++ b/tools/PSc8y/format-data/retentionRules.ps1xml
@@ -117,6 +117,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -132,6 +136,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>retentionRules</PropertyName>

--- a/tools/PSc8y/format-data/roleReferences.ps1xml
+++ b/tools/PSc8y/format-data/roleReferences.ps1xml
@@ -95,6 +95,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -110,6 +114,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>references</PropertyName>

--- a/tools/PSc8y/format-data/roles.ps1xml
+++ b/tools/PSc8y/format-data/roles.ps1xml
@@ -86,6 +86,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -101,6 +105,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>roles</PropertyName>

--- a/tools/PSc8y/format-data/tenantStatistics.ps1xml
+++ b/tools/PSc8y/format-data/tenantStatistics.ps1xml
@@ -99,6 +99,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -114,6 +118,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>usageStatistics</PropertyName>

--- a/tools/PSc8y/format-data/tenants.ps1xml
+++ b/tools/PSc8y/format-data/tenants.ps1xml
@@ -117,6 +117,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -132,6 +136,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>tenants</PropertyName>

--- a/tools/PSc8y/format-data/userGroupMembership.ps1xml
+++ b/tools/PSc8y/format-data/userGroupMembership.ps1xml
@@ -111,6 +111,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -126,6 +130,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>groups</PropertyName>

--- a/tools/PSc8y/format-data/userGroups.ps1xml
+++ b/tools/PSc8y/format-data/userGroups.ps1xml
@@ -111,6 +111,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -126,6 +130,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>groups</PropertyName>

--- a/tools/PSc8y/format-data/userReferences.ps1xml
+++ b/tools/PSc8y/format-data/userReferences.ps1xml
@@ -52,6 +52,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -67,6 +71,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>references</PropertyName>

--- a/tools/PSc8y/format-data/users.ps1xml
+++ b/tools/PSc8y/format-data/users.ps1xml
@@ -111,6 +111,10 @@
                         <Width>15</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
+                        <label>totalElements</label>
+                        <Width>15</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
                         <Width>150</Width>
                     </TableColumnHeader>
                 </TableHeaders>
@@ -126,6 +130,9 @@
                             </TableColumnItem>
                             <TableColumnItem>
                                 <scriptblock>$_.statistics.totalPages</scriptblock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <scriptblock>$_.statistics.totalElements</scriptblock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>users</PropertyName>


### PR DESCRIPTION
### New global flag: `withTotalElements`

Show total number of elements in the `.statistics` fragment. This is only supported in Cumulocity versions starting from 10.13.

**Example**

```sh
c8y devices list --withTotalElements 
```
**Output**
```sh
| totalElements | statistics.totalpages | pageSize   | currentPage |
|---------------|-----------------------|------------|-------------|
| 1772          |                       | 5          | 1           |
```