### PR TITLE
upgrade gh actions to use node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,22 +19,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go 1.18
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
-    - name: Use Node.js 14
-      uses: actions/setup-node@v1
+    - name: Use Node.js
+      uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
 
     - name: install tooling
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Install GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v3
       with:
         version: latest
         install-only: true
@@ -46,25 +46,25 @@ jobs:
       run: task build-powershell build-snapshot
       shell: bash
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: c8y.windows.amd64
         path: dist/windows_windows_amd64_v1/bin/c8y*
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: c8y.linux.amd64
         path: dist/linux_linux_amd64_v1/bin/c8y*
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: c8y.macos.amd64
         path: dist/macOS_darwin_amd64_v1/bin/c8y*
         if-no-files-found: error
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: PSc8y Module
         path: output_pwsh/PSc8y/
@@ -90,10 +90,10 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go 1.18
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
 
@@ -137,10 +137,10 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go 1.18
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
     
@@ -157,7 +157,7 @@ jobs:
       shell: bash
       timeout-minutes: 30
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: test-results-${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Install Task
       uses: arduino/setup-task@v1
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       id: download
       with:
         name: c8y.linux.amd64
@@ -174,7 +174,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Get test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: test-results-${{ matrix.os }}
           path: test-results-${{ matrix.os }}

--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -31,10 +31,10 @@ jobs:
     env:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go 1.18
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18
 
@@ -42,7 +42,7 @@ jobs:
       run: go install golang.org/x/tools/cmd/goimports@latest
 
     - name: Install GoReleaser
-      uses: goreleaser/goreleaser-action@v2
+      uses: goreleaser/goreleaser-action@v3
       with:
         version: latest
         install-only: true
@@ -53,7 +53,7 @@ jobs:
     - name: Build Powershell Module
       run: task generate build
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ReleaseArtifacts
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
 
@@ -30,7 +30,7 @@ jobs:
         run: go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           install-only: true


### PR DESCRIPTION
Upgrade all actions to remove gha warnings due to migration from node 12 to node 16

There are still some github actions which are using the soon to be disabled `set-output` commands. However there are already issues on the used gha. After the issues are fixed, then the warnings should disappear from the builds (not further action is required)

* [actions/upload-artifact](https://github.com/actions/upload-artifact/issues/351)