### PR TITLE
include windows arm64 binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,7 @@ builds:
   - <<: *build_defaults
     id: windows
     goos: [windows]
-    goarch: ["386", amd64]
+    goarch: ["386", amd64, arm64]
 
 archives:
   - id: nix

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Unofficial Cumulocity IoT Command Line Tool
 Supported on
 
 * Linux (amd64, x86, armv5->7)
-* MacOS (amd64)
-* Windows (amd64, x86)
+* MacOS (amd64, arm64)
+* Windows (amd64, x86, arm64 (binary only))
 
 ## Installation
 


### PR DESCRIPTION
Adding pre-build binary for Windows arm64. The binary is untested due to lack of testing environment, so please create an issue if something does not work!