### PR TITLE
Support multiple templatevars flag usage in same command line

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/templates.md
+++ b/docs/go-c8y-cli/docs/concepts/templates.md
@@ -159,6 +159,21 @@ c8y inventory create \
 }
 ```
 
+When using `c8y` directly, `--templateVars` can be used multiple times in the same command. This provides a better tab completion experience for the template variable names.
+
+<CodeExample>
+
+```bash
+c8y inventory create \
+    --template "./examples/templates/device.jsonnet" \
+    --templateVars "type=macOS" \
+    --templateVars "fragment=customer_Agent" \
+    --dry
+```
+
+</CodeExample>
+
+
 ## Template Functions (added by go-c8y-cli)
 
 Below lists the additional functions which are available in jsonnet template files. These functions are added to your template automatically by the c8y cli tool itself, and are not part of the standard jsonnet library. The built-in [jsonnet standard library](https://jsonnet.org/ref/stdlib.html) provides additional functions that can be used in combination with those injected by go-c8y-cli.

--- a/pkg/cmdutil/templateflags.go
+++ b/pkg/cmdutil/templateflags.go
@@ -68,7 +68,7 @@ func (f *Factory) WithTemplateFlag(cmd *cobra.Command) flags.Option {
 			return nil
 		}
 		cmd.Flags().String(flags.FlagDataTemplateName, "", "Body template")
-		cmd.Flags().String(flags.FlagDataTemplateVariablesName, "", "Body template variables")
+		cmd.Flags().StringArray(flags.FlagDataTemplateVariablesName, []string{}, "Body template variables")
 
 		_ = cmd.RegisterFlagCompletionFunc(flags.FlagDataTemplateName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			templatePath := cfg.GetTemplatePaths()

--- a/pkg/cmdutil/templateflags_test.go
+++ b/pkg/cmdutil/templateflags_test.go
@@ -25,7 +25,7 @@ func Test_WithTemplateValue(t *testing.T) {
 	flags.WithOptions(
 		cmd,
 		flags.WithData(),
-		flags.WithTemplate(),
+		flags.WithTemplateNoCompletion(),
 	)
 	inputIterator, _ := NewRequestInputIterators(cmd, nil)
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -101,11 +101,11 @@ func WithCommonCumulocityQueryOptions() Option {
 	}
 }
 
-// WithTemplate adds support for templates
-func WithTemplate() Option {
+// WithTemplateNoCompletion adds support for templates
+func WithTemplateNoCompletion() Option {
 	return func(cmd *cobra.Command) *cobra.Command {
 		cmd.Flags().String(FlagDataTemplateName, "", "Body template")
-		cmd.Flags().String(FlagDataTemplateVariablesName, "", "Body template variables")
+		cmd.Flags().StringArray(FlagDataTemplateVariablesName, []string{}, "Body template variables")
 		return cmd
 	}
 }

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -267,3 +267,11 @@ tests:
     stderr:
       contains:
         - 'commandError: Missing required parameter. template'
+
+  It accepts multiple template vars:
+    command: |
+      c8y template execute --template vars --templateVars prop1.value=1 --templateVars prop2=two
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"prop1":{"value":1},"prop2":"two"}


### PR DESCRIPTION
Support multiple usage of the global(ish) `--templateVars` flag to provide an improved tab completion experience. Multiple was values were always supported, 

#### Example

Execute a template which expects two variables: `subtype` and `interval`.

```sh
c8y template execute  --template "
{

  subtype: var('subtype'),
  c8y_RequiredAvailability: {
    responseInterval: var('interval')
  }
}
" --templateVars subtype=linux --templateVars interval=15 --raw
```

**Output**

```sh
{
  "c8y_RequiredAvailability": {
    "responseInterval": 15
  },
  "subtype": "linux"
}
```

**Note**

You can still combine the template variables into one flag (using comma delimited values) if that is what you prefer.

```sh
c8y template execute  --template "
{

  subtype: var('subtype'),
  c8y_RequiredAvailability: {
    responseInterval: var('interval')
  }
}
" --templateVars subtype=linux,interval=15 --raw
```