### PR TITLE
Add child/parent flags to all inventory get commands

### DIFF
--- a/api/spec/json/agents.json
+++ b/api/spec/json/agents.json
@@ -162,6 +162,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
@@ -216,6 +236,33 @@
           "pipeline": true,
           "required": true,
           "description": "Agent ID"
+        }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/configuration.json
+++ b/api/spec/json/configuration.json
@@ -97,6 +97,31 @@
               "format": "(description eq '%s')"
             }
           ]
+        },
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/configuration.json
+++ b/api/spec/json/configuration.json
@@ -272,6 +272,33 @@
           "required": true,
           "description": "Configuration package (managedObject) id"
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {

--- a/api/spec/json/deviceGroups.json
+++ b/api/spec/json/deviceGroups.json
@@ -112,15 +112,30 @@
           ]
         },
         {
-          "name": "withParents",
+          "name": "skipChildrenNames",
           "type": "boolean",
-          "description": "Include a flat list of all parents and grandparents of the given object"
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
         },
         {
           "name": "withChildren",
           "type": "booleanDefault",
           "default": "false",
           "description": "Include names of child assets (only use where necessary as it is slow for large groups)"
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/deviceGroups.json
+++ b/api/spec/json/deviceGroups.json
@@ -188,6 +188,33 @@
           "required": true,
           "description": "Device group ID"
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {
@@ -722,6 +749,18 @@
           "pipeline": true,
           "required": true,
           "description": "Device Group."
+        }
+      ],
+      "queryParameters": [
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         }
       ]
     }

--- a/api/spec/json/deviceGroupsChildren.json
+++ b/api/spec/json/deviceGroupsChildren.json
@@ -98,6 +98,11 @@
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         }
       ]
     },

--- a/api/spec/json/deviceProfile.json
+++ b/api/spec/json/deviceProfile.json
@@ -222,6 +222,33 @@
           "required": true,
           "description": "DeviceProfile (managedObject) id"
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {

--- a/api/spec/json/deviceProfile.json
+++ b/api/spec/json/deviceProfile.json
@@ -80,6 +80,31 @@
               ]
             }
           ]
+        },
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/devices.json
+++ b/api/spec/json/devices.json
@@ -180,6 +180,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
@@ -234,6 +254,33 @@
           "pipeline": true,
           "required": true,
           "description": "Device ID"
+        }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/devicesChildren.json
+++ b/api/spec/json/devicesChildren.json
@@ -98,6 +98,11 @@
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         }
       ]
     },

--- a/api/spec/json/devicesServices.json
+++ b/api/spec/json/devicesServices.json
@@ -390,6 +390,33 @@
           ],
           "position": 0
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {

--- a/api/spec/json/devicesServices.json
+++ b/api/spec/json/devicesServices.json
@@ -102,6 +102,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"

--- a/api/spec/json/firmware.json
+++ b/api/spec/json/firmware.json
@@ -91,6 +91,31 @@
               "format": "(description eq '%s')"
             }
           ]
+        },
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/firmware.json
+++ b/api/spec/json/firmware.json
@@ -276,6 +276,33 @@
             "id"
           ]
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {

--- a/api/spec/json/firmwarePatches.json
+++ b/api/spec/json/firmwarePatches.json
@@ -212,9 +212,29 @@
       ],
       "queryParameters": [
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "booleanDefault",
-          "description": "Include parent references",
+          "description": "Include a flat list of all parents and grandparents of the given object",
           "default": "true"
         }
       ]

--- a/api/spec/json/firmwarePatches.json
+++ b/api/spec/json/firmwarePatches.json
@@ -123,6 +123,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "booleanDefault",
           "description": "Include parent references",

--- a/api/spec/json/firmwareVersions.json
+++ b/api/spec/json/firmwareVersions.json
@@ -116,6 +116,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "booleanDefault",
           "description": "Include parent references",

--- a/api/spec/json/firmwareVersions.json
+++ b/api/spec/json/firmwareVersions.json
@@ -207,9 +207,29 @@
       ],
       "queryParameters": [
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
-          "description": "Include parent references"
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/inventory.json
+++ b/api/spec/json/inventory.json
@@ -117,12 +117,17 @@
         {
           "name": "withParents",
           "type": "boolean",
-          "description": "include a flat list of all parents and grandparents of the given object"
+          "description": "Include a flat list of all parents and grandparents of the given object"
         },
         {
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         },
         {
           "name": "withGroups",
@@ -291,14 +296,29 @@
           "description": "ManagedObject fragment type."
         },
         {
-          "name": "withParents",
-          "type": "boolean",
-          "description": "include a flat list of all parents and grandparents of the given object"
-        },
-        {
           "name": "skipChildrenNames",
           "type": "boolean",
           "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },
@@ -455,9 +475,29 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
-          "description": "include a flat list of all parents and grandparents of the given object"
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },
@@ -592,14 +632,24 @@
           "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
         },
         {
-          "name": "withParents",
-          "type": "boolean",
-          "description": "include a flat list of all parents and grandparents of the given object"
-        },
-        {
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/inventoryAdditions.json
+++ b/api/spec/json/inventoryAdditions.json
@@ -105,6 +105,11 @@
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         }
       ]
     },

--- a/api/spec/json/inventoryAssets.json
+++ b/api/spec/json/inventoryAssets.json
@@ -98,6 +98,11 @@
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         }
       ]
     },

--- a/api/spec/json/inventoryChildren.json
+++ b/api/spec/json/inventoryChildren.json
@@ -98,6 +98,11 @@
           "name": "withChildren",
           "type": "boolean",
           "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
         }
       ]
     },

--- a/api/spec/json/smartgroups.json
+++ b/api/spec/json/smartgroups.json
@@ -64,6 +64,33 @@
           "required": true,
           "description": "Smart group ID"
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {

--- a/api/spec/json/smartgroups.json
+++ b/api/spec/json/smartgroups.json
@@ -420,6 +420,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"

--- a/api/spec/json/software.json
+++ b/api/spec/json/software.json
@@ -277,6 +277,33 @@
           "required": true,
           "description": "Software package (managedObject) id"
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
+        }
       ]
     },
     {

--- a/api/spec/json/software.json
+++ b/api/spec/json/software.json
@@ -92,6 +92,31 @@
               "format": "(description eq '%s')"
             }
           ]
+        },
+        {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withParents",
+          "type": "boolean",
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -109,6 +109,26 @@
           ]
         },
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "booleanDefault",
           "description": "Include parent references",

--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -205,9 +205,29 @@
       ],
       "queryParameters": [
         {
+          "name": "skipChildrenNames",
+          "type": "boolean",
+          "description": "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved"
+        },
+        {
+          "name": "withChildren",
+          "type": "boolean",
+          "description": "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance."
+        },
+        {
+          "name": "withChildrenCount",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)"
+        },
+        {
+          "name": "withGroups",
+          "type": "boolean",
+          "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
           "name": "withParents",
           "type": "boolean",
-          "description": "Include parent references"
+          "description": "Include a flat list of all parents and grandparents of the given object"
         }
       ]
     },

--- a/api/spec/yaml/agents.yaml
+++ b/api/spec/yaml/agents.yaml
@@ -130,6 +130,22 @@ endpoints:
             description: Filter by group inclusion
             format: bygroupid(%s)
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
@@ -169,6 +185,27 @@ endpoints:
         pipeline: true
         required: true
         description: Agent ID
+    
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: updateAgent
     description: 'Update agent'

--- a/api/spec/yaml/configuration.yaml
+++ b/api/spec/yaml/configuration.yaml
@@ -213,6 +213,27 @@ endpoints:
         required: true
         description: Configuration package (managedObject) id
 
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: updateConfiguration
     method: PUT
     path: inventory/managedObjects/{id}

--- a/api/spec/yaml/configuration.yaml
+++ b/api/spec/yaml/configuration.yaml
@@ -78,6 +78,26 @@ endpoints:
             description: Filter by description
             format: (description eq '%s')
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: newConfiguration
     skip: false
     method: POST

--- a/api/spec/yaml/deviceGroups.yaml
+++ b/api/spec/yaml/deviceGroups.yaml
@@ -89,15 +89,26 @@ endpoints:
             description: Filter by group inclusion
             format: bygroupid(%s)
 
-      - name: withParents
+      - name: skipChildrenNames
         type: boolean
-        description: Include a flat list of all parents and grandparents of the given object
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
 
       - name: withChildren
         type: booleanDefault
         default: "false"
         description: Include names of child assets (only use where necessary as it is slow for large groups)
 
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: getDeviceGroup
     description: Get device group

--- a/api/spec/yaml/deviceGroups.yaml
+++ b/api/spec/yaml/deviceGroups.yaml
@@ -147,6 +147,27 @@ endpoints:
         required: true
         description: Device group ID
 
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: updateDeviceGroup
     description: Update device group
     descriptionLong: |
@@ -542,3 +563,12 @@ endpoints:
         pipeline: true
         required: true
         description: Device Group.
+
+    queryParameters:
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)

--- a/api/spec/yaml/deviceGroupsChildren.yaml
+++ b/api/spec/yaml/deviceGroupsChildren.yaml
@@ -78,6 +78,10 @@ endpoints:
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
 
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+
   - name: assignChild
     method: POST
     path: inventory/managedObjects/{id}/{childType}

--- a/api/spec/yaml/deviceProfile.yaml
+++ b/api/spec/yaml/deviceProfile.yaml
@@ -168,6 +168,27 @@ endpoints:
         required: true
         description: DeviceProfile (managedObject) id
 
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: updateDeviceProfile
     method: PUT
     path: inventory/managedObjects/{id}

--- a/api/spec/yaml/deviceProfile.yaml
+++ b/api/spec/yaml/deviceProfile.yaml
@@ -64,6 +64,26 @@ endpoints:
               - "c8y_Software.name"
               - "name"
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: newDeviceProfile
     method: POST
     path: inventory/managedObjects

--- a/api/spec/yaml/devices.yaml
+++ b/api/spec/yaml/devices.yaml
@@ -140,6 +140,22 @@ endpoints:
             description: Filter by group inclusion
             format: bygroupid(%s)
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
@@ -179,6 +195,27 @@ endpoints:
         pipeline: true
         required: true
         description: Device ID
+    
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: updateDevice
     description: Update device

--- a/api/spec/yaml/devicesChildren.yaml
+++ b/api/spec/yaml/devicesChildren.yaml
@@ -78,6 +78,10 @@ endpoints:
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
 
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+
   - name: assignChild
     method: POST
     path: inventory/managedObjects/{id}/{childType}

--- a/api/spec/yaml/devicesServices.yaml
+++ b/api/spec/yaml/devicesServices.yaml
@@ -78,6 +78,23 @@ endpoints:
           - name: orderBy
             type: string
             description: Order by. e.g. _id asc or name asc or creationTime.date desc
+
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object

--- a/api/spec/yaml/devicesServices.yaml
+++ b/api/spec/yaml/devicesServices.yaml
@@ -301,6 +301,27 @@ endpoints:
           - device
         position: 0
 
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: update
     method: PUT
     path: inventory/managedObjects/{id}

--- a/api/spec/yaml/firmware.yaml
+++ b/api/spec/yaml/firmware.yaml
@@ -73,6 +73,26 @@ endpoints:
             description: Filter by description
             format: (description eq '%s')
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: newFirmware
     method: POST
     path: inventory/managedObjects

--- a/api/spec/yaml/firmware.yaml
+++ b/api/spec/yaml/firmware.yaml
@@ -212,6 +212,27 @@ endpoints:
           - additionParents.references.0.managedObject.id
           - id
 
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: updateFirmware
     method: PUT
     path: inventory/managedObjects/{id}

--- a/api/spec/yaml/firmwarePatches.yaml
+++ b/api/spec/yaml/firmwarePatches.yaml
@@ -161,11 +161,27 @@ endpoints:
         type: '[]firmware'
         required: false
         description: Firmware package id or name (used to help completion be more accurate)
-
+    
     queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: booleanDefault
-        description: Include parent references
+        description: Include a flat list of all parents and grandparents of the given object
         default: 'true'
 
   - name: deletePatch

--- a/api/spec/yaml/firmwarePatches.yaml
+++ b/api/spec/yaml/firmwarePatches.yaml
@@ -96,6 +96,22 @@ endpoints:
             description: Filter by url
             format: (c8y_Firmware.url eq '%s')
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: booleanDefault
         description: Include parent references

--- a/api/spec/yaml/firmwareVersions.yaml
+++ b/api/spec/yaml/firmwareVersions.yaml
@@ -160,9 +160,25 @@ endpoints:
         description: Firmware package id or name (used to help completion be more accurate)
 
     queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
-        description: Include parent references
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: deleteFirmwareVersion
     description: Delete firmware package version

--- a/api/spec/yaml/firmwareVersions.yaml
+++ b/api/spec/yaml/firmwareVersions.yaml
@@ -91,6 +91,22 @@ endpoints:
             description: Filter by url
             format: (c8y_Firmware.url eq '%s')
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: booleanDefault
         description: Include parent references

--- a/api/spec/yaml/inventory.yaml
+++ b/api/spec/yaml/inventory.yaml
@@ -93,11 +93,15 @@ endpoints:
       
       - name: withParents
         type: boolean
-        description: include a flat list of all parents and grandparents of the given object
+        description: Include a flat list of all parents and grandparents of the given object
       
       - name: withChildren
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
       
       - name: withGroups
         type: boolean
@@ -224,13 +228,25 @@ endpoints:
         type: string
         description: ManagedObject fragment type.
 
-      - name: withParents
-        type: boolean
-        description: include a flat list of all parents and grandparents of the given object
-
       - name: skipChildrenNames
         type: boolean
         description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
 
 
   - name: findManagedObjectCollection
@@ -354,9 +370,25 @@ endpoints:
             description: Only include devices (deprecated)
             value: 'has(c8y_IsDevice)'
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
-        description: include a flat list of all parents and grandparents of the given object
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: newManagedObject
     method: POST
@@ -451,14 +483,22 @@ endpoints:
       - name: skipChildrenNames
         type: boolean
         description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
-      
-      - name: withParents
-        type: boolean
-        description: include a flat list of all parents and grandparents of the given object
-      
+
       - name: withChildren
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: updateManagedObject
     method: PUT

--- a/api/spec/yaml/inventoryAdditions.yaml
+++ b/api/spec/yaml/inventoryAdditions.yaml
@@ -83,6 +83,10 @@ endpoints:
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
 
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+
   - name: assignChildAddition
     method: POST
     path: inventory/managedObjects/{id}/childAdditions

--- a/api/spec/yaml/inventoryAssets.yaml
+++ b/api/spec/yaml/inventoryAssets.yaml
@@ -79,6 +79,10 @@ endpoints:
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
 
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+
   - name: assignAsset
     description: Assign child asset
     descriptionLong: Assigns a group or device to an existing group and marks them as assets

--- a/api/spec/yaml/inventoryChildren.yaml
+++ b/api/spec/yaml/inventoryChildren.yaml
@@ -78,6 +78,10 @@ endpoints:
         type: boolean
         description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
 
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+
   - name: assignChild
     method: POST
     path: inventory/managedObjects/{id}/{childType}

--- a/api/spec/yaml/smartgroups.yaml
+++ b/api/spec/yaml/smartgroups.yaml
@@ -319,7 +319,23 @@ endpoints:
             type: booleanDefault
             description: Only include visible smart groups
             value: not(has(c8y_IsDynamicGroup.invisible))
+
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
       
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object

--- a/api/spec/yaml/smartgroups.yaml
+++ b/api/spec/yaml/smartgroups.yaml
@@ -42,13 +42,33 @@ endpoints:
             json:
                 path: r//inventory/managedObjects/\d+$
 
-
     pathParameters:
       - name: id
         type: '[]smartgroup'
         pipeline: true
         required: true
         description: Smart group ID
+
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
 
   - name: updateSmartGroup
     description: Update smart group

--- a/api/spec/yaml/software.yaml
+++ b/api/spec/yaml/software.yaml
@@ -213,6 +213,27 @@ endpoints:
         required: true
         description: Software package (managedObject) id
 
+    queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: updateSoftware
     method: PUT
     path: inventory/managedObjects/{id}

--- a/api/spec/yaml/software.yaml
+++ b/api/spec/yaml/software.yaml
@@ -75,6 +75,26 @@ endpoints:
             description: Filter by description
             format: (description eq '%s')
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
+      - name: withParents
+        type: boolean
+        description: Include a flat list of all parents and grandparents of the given object
+
   - name: newSoftware
     method: POST
     path: inventory/managedObjects

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -85,6 +85,22 @@ endpoints:
             description: Filter by url
             format: (c8y_Software.url eq '%s')
 
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: booleanDefault
         description: Include parent references

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -157,9 +157,25 @@ endpoints:
         description: Software package id (used to help completion be more accurate)
 
     queryParameters:
+      - name: skipChildrenNames
+        type: boolean
+        description: Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+
+      - name: withChildren
+        type: boolean
+        description: Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+
+      - name: withChildrenCount
+        type: boolean
+        description: When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+      
+      - name: withGroups
+        type: boolean
+        description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+
       - name: withParents
         type: boolean
-        description: Include parent references
+        description: Include a flat list of all parents and grandparents of the given object
 
 
   - name: deleteSoftwareVersion

--- a/pkg/cmd/agents/get/get.auto.go
+++ b/pkg/cmd/agents/get/get.auto.go
@@ -47,6 +47,11 @@ Get agent by id
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Agent ID (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -94,6 +99,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/agents/list/list.auto.go
+++ b/pkg/cmd/agents/list/list.auto.go
@@ -71,6 +71,10 @@ Find an agent by name, then find other agents which the same type
 	cmd.Flags().String("creationTimeDateTo", "", "Filter creationTime.date to a specific date")
 	cmd.Flags().String("creationTimeDateFrom", "", "Filter creationTime.date from a specific date")
 	cmd.Flags().StringSlice("group", []string{""}, "Filter by group inclusion")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
@@ -126,6 +130,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/configuration/get/get.auto.go
+++ b/pkg/cmd/configuration/get/get.auto.go
@@ -47,6 +47,11 @@ Get a configuration package
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Configuration package (managedObject) id (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -93,6 +98,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/configuration/list/list.auto.go
+++ b/pkg/cmd/configuration/list/list.auto.go
@@ -52,6 +52,11 @@ Get a list of configuration files
 	cmd.Flags().String("name", "", "Filter by name")
 	cmd.Flags().String("deviceType", "", "Filter by deviceType")
 	cmd.Flags().String("description", "", "Filter by description")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -99,6 +104,11 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/devicegroups/children/list/list.auto.go
+++ b/pkg/cmd/devicegroups/children/list/list.auto.go
@@ -55,6 +55,7 @@ Get a list of the child devices of an existing managed object
 	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
 	cmd.Flags().String("orderBy", "", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 
 	completion.WithOptions(
 		cmd,
@@ -107,6 +108,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/devicegroups/get/get.auto.go
+++ b/pkg/cmd/devicegroups/get/get.auto.go
@@ -48,6 +48,11 @@ Get device group by id
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device group ID (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -95,6 +100,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/devicegroups/list/list.auto.go
+++ b/pkg/cmd/devicegroups/list/list.auto.go
@@ -55,8 +55,11 @@ Get a collection of device groups with names that start with 'parent'
 	cmd.Flags().String("owner", "", "Filter by owner")
 	cmd.Flags().Bool("excludeRootGroup", false, "Filter by group inclusion")
 	cmd.Flags().StringSlice("group", []string{""}, "Filter by group inclusion")
-	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
 	cmd.Flags().Bool("withChildren", false, "Include names of child assets (only use where necessary as it is slow for large groups)")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -106,8 +109,11 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
-		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
 		flags.WithDefaultBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/devicegroups/listassets/listAssets.auto.go
+++ b/pkg/cmd/devicegroups/listassets/listAssets.auto.go
@@ -49,6 +49,8 @@ Get a list of the child devices of an existing device
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device Group. (required) (accepts pipeline)")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 
 	completion.WithOptions(
 		cmd,
@@ -99,6 +101,8 @@ func (n *ListAssetsCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/deviceprofiles/get/get.auto.go
+++ b/pkg/cmd/deviceprofiles/get/get.auto.go
@@ -47,6 +47,11 @@ Get a device profile
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "DeviceProfile (managedObject) id (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -93,6 +98,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/deviceprofiles/list/list.auto.go
+++ b/pkg/cmd/deviceprofiles/list/list.auto.go
@@ -49,6 +49,11 @@ Get a list of device profiles
 	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
 	cmd.Flags().String("orderBy", "creationTime.date desc,creationTime desc", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().String("name", "", "Filter by name (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -96,6 +101,11 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/devices/children/list/list.auto.go
+++ b/pkg/cmd/devices/children/list/list.auto.go
@@ -55,6 +55,7 @@ Get a list of the child devices of an existing managed object
 	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
 	cmd.Flags().String("orderBy", "", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 
 	completion.WithOptions(
 		cmd,
@@ -107,6 +108,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/devices/get/get.auto.go
+++ b/pkg/cmd/devices/get/get.auto.go
@@ -47,6 +47,11 @@ Get device by id
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device ID (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -94,6 +99,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/devices/list/list.auto.go
+++ b/pkg/cmd/devices/list/list.auto.go
@@ -72,6 +72,10 @@ Get devices with type 'c8y_MacOS' then devices with type 'c8y_Linux' (using pipe
 	cmd.Flags().String("creationTimeDateTo", "", "Filter creationTime.date to a specific date")
 	cmd.Flags().String("creationTimeDateFrom", "", "Filter creationTime.date from a specific date")
 	cmd.Flags().StringSlice("group", []string{""}, "Filter by group inclusion")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
@@ -127,6 +131,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/devices/services/find/find.auto.go
+++ b/pkg/cmd/devices/services/find/find.auto.go
@@ -56,6 +56,10 @@ Find any ntp services which are currently down
 	cmd.Flags().String("name", "", "Filter by name")
 	cmd.Flags().String("status", "", "Filter by service status (custom values allowed)")
 	cmd.Flags().String("orderBy", "", "Order by. e.g. _id asc or name asc or creationTime.date desc")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
@@ -105,6 +109,10 @@ func (n *FindCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/devices/services/get/get.auto.go
+++ b/pkg/cmd/devices/services/get/get.auto.go
@@ -54,6 +54,11 @@ Get service status (using pipeline)
 
 	cmd.Flags().StringSlice("device", []string{""}, "Device id (required for name lookup)")
 	cmd.Flags().StringSlice("id", []string{""}, "Service id or name (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -102,6 +107,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/firmware/get/get.auto.go
+++ b/pkg/cmd/firmware/get/get.auto.go
@@ -50,6 +50,11 @@ Get a firmware package (using pipeline)
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Firmware package (managedObject) id (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -96,6 +101,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/firmware/list/list.auto.go
+++ b/pkg/cmd/firmware/list/list.auto.go
@@ -51,6 +51,11 @@ Get a list of firmware packages
 	cmd.Flags().String("name", "", "Filter by name")
 	cmd.Flags().String("deviceType", "", "Filter by deviceType")
 	cmd.Flags().String("description", "", "Filter by description")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -98,6 +103,11 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/firmware/patches/get/get.auto.go
+++ b/pkg/cmd/firmware/patches/get/get.auto.go
@@ -48,7 +48,11 @@ Get a firmware patch
 
 	cmd.Flags().StringSlice("id", []string{""}, "Firmware patch id or name (required) (accepts pipeline)")
 	cmd.Flags().StringSlice("firmware", []string{""}, "Firmware package id or name (used to help completion be more accurate)")
-	cmd.Flags().Bool("withParents", true, "Include parent references")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", true, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -96,6 +100,10 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithDefaultBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {

--- a/pkg/cmd/firmware/patches/list/list.auto.go
+++ b/pkg/cmd/firmware/patches/list/list.auto.go
@@ -56,6 +56,10 @@ Get a list of firmware patches where the dependency version starts with '1.'
 	cmd.Flags().String("dependency", "", "Patch dependency version")
 	cmd.Flags().String("version", "", "Patch version")
 	cmd.Flags().String("url", "", "Filter by url")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", true, "Include parent references")
 
 	completion.WithOptions(
@@ -105,6 +109,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithDefaultBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/firmware/versions/get/get.auto.go
+++ b/pkg/cmd/firmware/versions/get/get.auto.go
@@ -51,7 +51,11 @@ Get a firmware package version using pipeline
 
 	cmd.Flags().StringSlice("id", []string{""}, "Firmware Package version id or name (required) (accepts pipeline)")
 	cmd.Flags().StringSlice("firmware", []string{""}, "Firmware package id or name (used to help completion be more accurate)")
-	cmd.Flags().Bool("withParents", false, "Include parent references")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -99,6 +103,10 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {

--- a/pkg/cmd/firmware/versions/list/list.auto.go
+++ b/pkg/cmd/firmware/versions/list/list.auto.go
@@ -58,6 +58,10 @@ Get all versions of a firmware using an existing version object
 	cmd.Flags().StringSlice("firmware", []string{""}, "Firmware package id or name (required) (accepts pipeline)")
 	cmd.Flags().String("version", "", "Filter by version")
 	cmd.Flags().String("url", "", "Filter by url")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", true, "Include parent references")
 
 	completion.WithOptions(
@@ -107,6 +111,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithDefaultBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/inventory/additions/list/list.auto.go
+++ b/pkg/cmd/inventory/additions/list/list.auto.go
@@ -51,6 +51,7 @@ Get a list of the child additions of an existing managed object
 	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
 	cmd.Flags().String("orderBy", "", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 
 	completion.WithOptions(
 		cmd,
@@ -99,6 +100,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/inventory/assets/list/list.auto.go
+++ b/pkg/cmd/inventory/assets/list/list.auto.go
@@ -54,6 +54,7 @@ Get a list of the child devices using pipeline
 	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
 	cmd.Flags().String("orderBy", "", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 
 	completion.WithOptions(
 		cmd,
@@ -102,6 +103,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/inventory/children/list/list.auto.go
+++ b/pkg/cmd/inventory/children/list/list.auto.go
@@ -55,6 +55,7 @@ Get a list of the child devices of an existing managed object
 	cmd.Flags().String("queryTemplate", "", "String template to be used when applying the given query. Use %s to reference the query/pipeline input")
 	cmd.Flags().String("orderBy", "", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 
 	completion.WithOptions(
 		cmd,
@@ -105,6 +106,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/inventory/find/find.auto.go
+++ b/pkg/cmd/inventory/find/find.auto.go
@@ -67,7 +67,11 @@ Invert a given query received via piped input (stdin) by using a template
 	cmd.Flags().String("creationTimeDateFrom", "", "Filter creationTime.date from a specific date")
 	cmd.Flags().StringSlice("group", []string{""}, "Filter by group inclusion")
 	cmd.Flags().Bool("onlyDevices", false, "Only include devices (deprecated)")
-	cmd.Flags().Bool("withParents", false, "include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -124,6 +128,10 @@ func (n *FindCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/inventory/findbytext/findByText.auto.go
+++ b/pkg/cmd/inventory/findbytext/findByText.auto.go
@@ -54,8 +54,11 @@ Find managed objects which contain the text 'myText' and is a device (using pipe
 	cmd.Flags().String("text", "", "managed objects containing a text value starting with the given text (placeholder {text}). Text value is any alphanumeric string starting with a latin letter (A-Z or a-z). (required) (accepts pipeline)")
 	cmd.Flags().String("type", "", "ManagedObject type.")
 	cmd.Flags().String("fragmentType", "", "ManagedObject fragment type.")
-	cmd.Flags().Bool("withParents", false, "include a flat list of all parents and grandparents of the given object")
 	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -106,8 +109,11 @@ func (n *FindByTextCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("text", "text"),
 		flags.WithStringValue("type", "type"),
 		flags.WithStringValue("fragmentType", "fragmentType"),
-		flags.WithBoolValue("withParents", "withParents", ""),
 		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/inventory/get/get.auto.go
+++ b/pkg/cmd/inventory/get/get.auto.go
@@ -51,8 +51,10 @@ Get a managed object with parent references
 
 	cmd.Flags().StringSlice("id", []string{""}, "ManagedObject id (required) (accepts pipeline)")
 	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
-	cmd.Flags().Bool("withParents", false, "include a flat list of all parents and grandparents of the given object")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -99,8 +101,10 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
-		flags.WithBoolValue("withParents", "withParents", ""),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/inventory/list/list.auto.go
+++ b/pkg/cmd/inventory/list/list.auto.go
@@ -65,8 +65,9 @@ Get managed objects which have the same type as the managed object id=1234. pipe
 	cmd.Flags().String("childAssetId", "", "Search for a specific child asset and list all the groups to which it belongs.")
 	cmd.Flags().StringSlice("childDeviceId", []string{""}, "Search for a specific child device and list all the groups to which it belongs.")
 	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
-	cmd.Flags().Bool("withParents", false, "include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 
 	completion.WithOptions(
@@ -129,6 +130,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 	)
 	if err != nil {

--- a/pkg/cmd/smartgroups/get/get.auto.go
+++ b/pkg/cmd/smartgroups/get/get.auto.go
@@ -50,6 +50,11 @@ Get smart group by name
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Smart group ID (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -97,6 +102,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/smartgroups/list/list.auto.go
+++ b/pkg/cmd/smartgroups/list/list.auto.go
@@ -60,6 +60,10 @@ Get a list of smart groups with their names starting with 'myText', then get the
 	cmd.Flags().String("owner", "", "Filter by owner")
 	cmd.Flags().Bool("onlyInvisible", false, "Only include invisible smart groups")
 	cmd.Flags().Bool("onlyVisible", false, "Only include visible smart groups")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
@@ -108,6 +112,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/pkg/cmd/software/get/get.auto.go
+++ b/pkg/cmd/software/get/get.auto.go
@@ -47,6 +47,11 @@ Get a software package
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Software package (managedObject) id (required) (accepts pipeline)")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -93,6 +98,11 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/software/list/list.auto.go
+++ b/pkg/cmd/software/list/list.auto.go
@@ -54,6 +54,11 @@ Get a list of software packages starting with "python3"
 	cmd.Flags().String("name", "", "Filter by name")
 	cmd.Flags().String("deviceType", "", "Filter by deviceType")
 	cmd.Flags().String("description", "", "Filter by description")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -101,6 +106,11 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/software/versions/get/get.auto.go
+++ b/pkg/cmd/software/versions/get/get.auto.go
@@ -48,7 +48,11 @@ Get a software package version using name
 
 	cmd.Flags().StringSlice("id", []string{""}, "Software Package version id or name (required) (accepts pipeline)")
 	cmd.Flags().StringSlice("software", []string{""}, "Software package id (used to help completion be more accurate)")
-	cmd.Flags().Bool("withParents", false, "Include parent references")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
 
 	completion.WithOptions(
 		cmd,
@@ -96,6 +100,10 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
 	)
 	if err != nil {

--- a/pkg/cmd/software/versions/list/list.auto.go
+++ b/pkg/cmd/software/versions/list/list.auto.go
@@ -55,6 +55,10 @@ Get a list of software package versions from multiple software packages
 	cmd.Flags().StringSlice("software", []string{""}, "Software package id or name (accepts pipeline)")
 	cmd.Flags().String("version", "", "Filter by version")
 	cmd.Flags().String("url", "", "Filter by url")
+	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
+	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
+	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
+	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", true, "Include parent references")
 
 	completion.WithOptions(
@@ -104,6 +108,10 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("skipChildrenNames", "skipChildrenNames", ""),
+		flags.WithBoolValue("withChildren", "withChildren", ""),
+		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
+		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithDefaultBoolValue("withParents", "withParents", ""),
 
 		flags.WithCumulocityQuery(

--- a/tools/PSc8y/Public/Find-ByTextManagedObjectCollection.ps1
+++ b/tools/PSc8y/Public/Find-ByTextManagedObjectCollection.ps1
@@ -44,15 +44,30 @@ Find managed objects which contain the text 'myText' (using pipeline)
         [string]
         $FragmentType,
 
-        # include a flat list of all parents and grandparents of the given object
-        [Parameter()]
-        [switch]
-        $WithParents,
-
         # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
         [Parameter()]
         [switch]
-        $SkipChildrenNames
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Find-DeviceServiceCollection.ps1
+++ b/tools/PSc8y/Public/Find-DeviceServiceCollection.ps1
@@ -48,6 +48,26 @@ Find all services (from any device)
         [string]
         $OrderBy,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]

--- a/tools/PSc8y/Public/Find-ManagedObjectCollection.ps1
+++ b/tools/PSc8y/Public/Find-ManagedObjectCollection.ps1
@@ -99,7 +99,27 @@ Find all managed objects with their names starting with 'roomUpperFloor_'
         [switch]
         $OnlyDevices,
 
-        # include a flat list of all parents and grandparents of the given object
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
         $WithParents

--- a/tools/PSc8y/Public/Get-Agent.ps1
+++ b/tools/PSc8y/Public/Get-Agent.ps1
@@ -32,7 +32,32 @@ Get agent by name
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-AgentCollection.ps1
+++ b/tools/PSc8y/Public/Get-AgentCollection.ps1
@@ -89,6 +89,26 @@ Get a collection of agents with type "myType", and their names start with "senso
         [object[]]
         $Group,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]

--- a/tools/PSc8y/Public/Get-Configuration.ps1
+++ b/tools/PSc8y/Public/Get-Configuration.ps1
@@ -32,7 +32,32 @@ Get a configuration package (using pipeline)
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-ConfigurationCollection.ps1
+++ b/tools/PSc8y/Public/Get-ConfigurationCollection.ps1
@@ -56,7 +56,32 @@ Get a list of configuration files
         # Filter by description
         [Parameter()]
         [string]
-        $Description
+        $Description,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-Device.ps1
+++ b/tools/PSc8y/Public/Get-Device.ps1
@@ -32,7 +32,32 @@ Get device by name
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-DeviceChildCollection.ps1
+++ b/tools/PSc8y/Public/Get-DeviceChildCollection.ps1
@@ -58,7 +58,12 @@ Get a list of the child additions of an existing managed object (using pipeline)
         # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
         [Parameter()]
         [switch]
-        $WithChildren
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-DeviceCollection.ps1
+++ b/tools/PSc8y/Public/Get-DeviceCollection.ps1
@@ -94,6 +94,26 @@ c8y devices list --name "sensor*" --type myType
         [object[]]
         $Group,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]

--- a/tools/PSc8y/Public/Get-DeviceGroup.ps1
+++ b/tools/PSc8y/Public/Get-DeviceGroup.ps1
@@ -33,7 +33,32 @@ Get device group by name
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-DeviceGroupChildCollection.ps1
+++ b/tools/PSc8y/Public/Get-DeviceGroupChildCollection.ps1
@@ -58,7 +58,12 @@ Get a list of the child additions of an existing managed object (using pipeline)
         # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
         [Parameter()]
         [switch]
-        $WithChildren
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-DeviceGroupCollection.ps1
+++ b/tools/PSc8y/Public/Get-DeviceGroupCollection.ps1
@@ -68,15 +68,30 @@ Get a collection of device groups with names that start with 'parent'
         [object[]]
         $Group,
 
-        # Include a flat list of all parents and grandparents of the given object
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
         [Parameter()]
         [switch]
-        $WithParents,
+        $SkipChildrenNames,
 
         # Include names of child assets (only use where necessary as it is slow for large groups)
         [Parameter()]
         [switch]
-        $WithChildren
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-DeviceProfile.ps1
+++ b/tools/PSc8y/Public/Get-DeviceProfile.ps1
@@ -32,7 +32,32 @@ Get a device profile (using pipeline)
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-DeviceProfileCollection.ps1
+++ b/tools/PSc8y/Public/Get-DeviceProfileCollection.ps1
@@ -41,7 +41,32 @@ Get a list of device profiles
         [Parameter(ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Name
+        $Name,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-DeviceService.ps1
+++ b/tools/PSc8y/Public/Get-DeviceService.ps1
@@ -32,7 +32,32 @@ Get service status
         # Device id (required for name lookup)
         [Parameter()]
         [object[]]
-        $Device
+        $Device,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-Firmware.ps1
+++ b/tools/PSc8y/Public/Get-Firmware.ps1
@@ -32,7 +32,32 @@ Get a firmware package (using pipeline)
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-FirmwareCollection.ps1
+++ b/tools/PSc8y/Public/Get-FirmwareCollection.ps1
@@ -51,7 +51,32 @@ Get a list of firmware packages
         # Filter by description
         [Parameter()]
         [string]
-        $Description
+        $Description,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-FirmwarePatch.ps1
+++ b/tools/PSc8y/Public/Get-FirmwarePatch.ps1
@@ -39,7 +39,27 @@ Get a firmware package (using pipeline)
         [object[]]
         $Firmware,
 
-        # Include parent references
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
         $WithParents

--- a/tools/PSc8y/Public/Get-FirmwarePatchCollection.ps1
+++ b/tools/PSc8y/Public/Get-FirmwarePatchCollection.ps1
@@ -64,6 +64,26 @@ Get a list of firmware patches where the dependency version starts with '1.'
         [string]
         $Url,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include parent references
         [Parameter()]
         [switch]

--- a/tools/PSc8y/Public/Get-FirmwareVersion.ps1
+++ b/tools/PSc8y/Public/Get-FirmwareVersion.ps1
@@ -39,7 +39,27 @@ Get a firmware package (using pipeline)
         [object[]]
         $Firmware,
 
-        # Include parent references
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
         $WithParents

--- a/tools/PSc8y/Public/Get-FirmwareVersionCollection.ps1
+++ b/tools/PSc8y/Public/Get-FirmwareVersionCollection.ps1
@@ -54,6 +54,26 @@ Get a list of firmware package versions
         [string]
         $Url,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include parent references
         [Parameter()]
         [switch]

--- a/tools/PSc8y/Public/Get-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Get-ManagedObject.ps1
@@ -44,15 +44,25 @@ Get a managed object with parent references
         [switch]
         $SkipChildrenNames,
 
-        # include a flat list of all parents and grandparents of the given object
-        [Parameter()]
-        [switch]
-        $WithParents,
-
         # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
         [Parameter()]
         [switch]
-        $WithChildren
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-ManagedObjectChildCollection.ps1
+++ b/tools/PSc8y/Public/Get-ManagedObjectChildCollection.ps1
@@ -58,7 +58,12 @@ Get a list of the child additions of an existing managed object (using pipeline)
         # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
         [Parameter()]
         [switch]
-        $WithChildren
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-ManagedObjectCollection.ps1
+++ b/tools/PSc8y/Public/Get-ManagedObjectCollection.ps1
@@ -78,7 +78,7 @@ Get a list of managed objects by id
         [switch]
         $SkipChildrenNames,
 
-        # include a flat list of all parents and grandparents of the given object
+        # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
         $WithParents,
@@ -87,6 +87,11 @@ Get a list of managed objects by id
         [Parameter()]
         [switch]
         $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
 
         # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
         [Parameter()]

--- a/tools/PSc8y/Public/Get-SmartGroup.ps1
+++ b/tools/PSc8y/Public/Get-SmartGroup.ps1
@@ -32,7 +32,32 @@ Get smart group by name
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-SmartGroupCollection.ps1
+++ b/tools/PSc8y/Public/Get-SmartGroupCollection.ps1
@@ -73,6 +73,26 @@ Get a list of smart groups with the names starting with 'myText'
         [switch]
         $OnlyVisible,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]

--- a/tools/PSc8y/Public/Get-Software.ps1
+++ b/tools/PSc8y/Public/Get-Software.ps1
@@ -32,7 +32,32 @@ Get a software package (using pipeline)
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-SoftwareCollection.ps1
+++ b/tools/PSc8y/Public/Get-SoftwareCollection.ps1
@@ -51,7 +51,32 @@ Get a list of software packages
         # Filter by description
         [Parameter()]
         [string]
-        $Description
+        $Description,
+
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
+        [Parameter()]
+        [switch]
+        $WithParents
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-SoftwareVersion.ps1
+++ b/tools/PSc8y/Public/Get-SoftwareVersion.ps1
@@ -39,7 +39,27 @@ Get a software package version (using pipeline)
         [object[]]
         $Software,
 
-        # Include parent references
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
+        # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
         $WithParents

--- a/tools/PSc8y/Public/Get-SoftwareVersionCollection.ps1
+++ b/tools/PSc8y/Public/Get-SoftwareVersionCollection.ps1
@@ -53,6 +53,26 @@ Get a list of software package versions
         [string]
         $Url,
 
+        # Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved
+        [Parameter()]
+        [switch]
+        $SkipChildrenNames,
+
+        # Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.
+        [Parameter()]
+        [switch]
+        $WithChildren,
+
+        # When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)
+        [Parameter()]
+        [switch]
+        $WithChildrenCount,
+
+        # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
+        [Parameter()]
+        [switch]
+        $WithGroups,
+
         # Include parent references
         [Parameter()]
         [switch]


### PR DESCRIPTION
Add child/parent related flags to command which send `GET` to the `/inventory/managedObjects` endpoint.

|flag|description|
|----|-----------|
|skipChildrenNames|Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved|
|withChildren|Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance|
|withChildrenCount|When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices|
|withGroups|When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups|
|withParents|Include a flat list of all parents and grandparents of the given object|

**Note**

Some of these options are only supported in new versions of Cumulocity. e.g. `withChildrenCount` is only available from v10.13 onwards.

**Examples**

```sh
c8y devices get --id 12345 --withParents

c8y inventory children list --id 12345 --childType device --withChildrenCount
```

**List of commands**

The following commands were changed.

* `c8y agents list`
* `c8y agents get`
* `c8y configuration get`
* `c8y configuration list`
* `c8y devicegroups get`
* `c8y devicegroups list`
* `c8y devicegroups children list` (only withChildren, withChildrenCount)
* `c8y deviceprofiles get`
* `c8y deviceprofiles list`
* `c8y devices find`
* `c8y devices services find`
* `c8y devices services get`
* `c8y devices get`
* `c8y devices list`
* `c8y devices children list` (only withChildren, withChildrenCount)
* `c8y firmware get`
* `c8y firmware list`
* `c8y firmware patches get`
* `c8y firmware patches list`
* `c8y firmware versions get`
* `c8y firmware versions list`
* `c8y inventory children list` (only withChildren, withChildrenCount)
* `c8y inventory find`
* `c8y inventory findByText`
* `c8y inventory findByText`
* `c8y inventory get`
* `c8y inventory list`
* `c8y smartgroups get`
* `c8y smartgroups list`
* `c8y software get`
* `c8y software list`
* `c8y software versions get`
* `c8y software versions list`
