### PR TITLE
Feat/support null values in data flag

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,11 +13,13 @@ vars:
 env:
   C8Y_SETTINGS_CI: true
   GITHUB_TOKEN: ""
+  LOCAL_PATH:
+    sh: |
+      echo "$(pwd)/.bin:$PATH"
 
 dotenv: ['.env', '{{.ENV}}/.env.', '{{.HOME}}/.env']
 
 tasks:
-
   # ---------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------
@@ -283,7 +285,7 @@ tasks:
     vars:
       FILTER: "*"
     cmds:
-      - ./tests/run-manual.sh {{.CLI_ARGS}}
+      - env PATH="$LOCAL_PATH" ./tests/run-manual.sh {{.CLI_ARGS}}
   
   test-cli-auto:
     desc: Run auto generated cli tests
@@ -292,8 +294,8 @@ tasks:
       task test-cli-auto -- software 
     deps: [install-test-dependencies]
     cmds:
-      - ./tests/scripts/setup.sh
-      - ./tests/run-auto.sh {{.CLI_ARGS}}
+      - env PATH="$LOCAL_PATH" ./tests/scripts/setup.sh
+      - env PATH="$LOCAL_PATH" ./tests/run-auto.sh {{.CLI_ARGS}}
 
   test-installation:
     desc: Test installation of linux packages

--- a/api/spec/json/devices.json
+++ b/api/spec/json/devices.json
@@ -331,7 +331,22 @@
         "go": [
           {
             "description": "Update device by id",
-            "command": "c8y devices update --id 12345"
+            "command": "c8y devices update --id 12345 --newName \"MyDevice\""
+          },
+          {
+            "description": "Update device using a template",
+            "command": "c8y devices update --id 12345 --template \"{c8y_SupportedOperations:['c8y_Restart', 'c8y_Command']}\"",
+            "skipTest": true
+          },
+          {
+            "description": "Update device using a data (with different formats)",
+            "command": "c8y devices update --id 12345 --data \"my.nested.number=1.234,my.nested.bool=true,my.nested.string=my name,my.nested.num_as_str='1.234'\"",
+            "skipTest": true
+          },
+          {
+            "description": "Remove a property from a device by setting it to null",
+            "command": "c8y devices update --id 12345 --data \"myFragment=null\"",
+            "skipTest": true
           }
         ]
       },

--- a/api/spec/json/inventory.json
+++ b/api/spec/json/inventory.json
@@ -691,6 +691,11 @@
           {
             "description": "Update a managed object",
             "command": "c8y inventory update --id 12345 --newName \"my_custom_name\" --data \"{\\\"com_my_props\\\":{},\\\"value\\\":1}\""
+          },
+          {
+            "description": "Remove a property (by setting it to null)",
+            "command": "c8y inventory update --id 12345 --data \"my_Fragment=null\"",
+            "skipTest": true
           }
         ]
       },

--- a/api/spec/yaml/devices.yaml
+++ b/api/spec/yaml/devices.yaml
@@ -251,7 +251,19 @@ endpoints:
 
       go:
         - description: Update device by id
-          command: c8y devices update --id 12345
+          command: c8y devices update --id 12345 --newName "MyDevice"
+        
+        - description: Update device using a template
+          command: c8y devices update --id 12345 --template "{c8y_SupportedOperations:['c8y_Restart', 'c8y_Command']}"
+          skipTest: true
+
+        - description: Update device using a data (with different formats)
+          command: c8y devices update --id 12345 --data "my.nested.number=1.234,my.nested.bool=true,my.nested.string=my name,my.nested.num_as_str='1.234'"
+          skipTest: true
+
+        - description: Remove a property from a device by setting it to null
+          command: c8y devices update --id 12345 --data "myFragment=null"
+          skipTest: true
 
     pathParameters:
       - name: id

--- a/api/spec/yaml/inventory.yaml
+++ b/api/spec/yaml/inventory.yaml
@@ -528,6 +528,10 @@ endpoints:
       go:
         - description: Update a managed object
           command: 'c8y inventory update --id 12345 --newName "my_custom_name" --data "{\"com_my_props\":{},\"value\":1}"'
+        
+        - description: Remove a property (by setting it to null)
+          command: c8y inventory update --id 12345 --data "my_Fragment=null"
+          skipTest: true
     body:
       - name: newName
         property: name

--- a/pkg/cmd/devices/update/update.auto.go
+++ b/pkg/cmd/devices/update/update.auto.go
@@ -34,8 +34,17 @@ func NewUpdateCmd(f *cmdutil.Factory) *UpdateCmd {
 		Short: "Update device",
 		Long:  `Update properties of an existing device`,
 		Example: heredoc.Doc(`
-$ c8y devices update --id 12345
+$ c8y devices update --id 12345 --newName "MyDevice"
 Update device by id
+
+$ c8y devices update --id 12345 --template "{c8y_SupportedOperations:['c8y_Restart', 'c8y_Command']}"
+Update device using a template
+
+$ c8y devices update --id 12345 --data "my.nested.number=1.234,my.nested.bool=true,my.nested.string=my name,my.nested.num_as_str='1.234'"
+Update device using a data (with different formats)
+
+$ c8y devices update --id 12345 --data "myFragment=null"
+Remove a property from a device by setting it to null
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.UpdateModeEnabled()

--- a/pkg/cmd/inventory/update/update.auto.go
+++ b/pkg/cmd/inventory/update/update.auto.go
@@ -36,6 +36,9 @@ func NewUpdateCmd(f *cmdutil.Factory) *UpdateCmd {
 		Example: heredoc.Doc(`
 $ c8y inventory update --id 12345 --newName "my_custom_name" --data "{\"com_my_props\":{},\"value\":1}"
 Update a managed object
+
+$ c8y inventory update --id 12345 --data "my_Fragment=null"
+Remove a property (by setting it to null)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.UpdateModeEnabled()

--- a/pkg/jsonUtilities/shorthand.go
+++ b/pkg/jsonUtilities/shorthand.go
@@ -94,10 +94,10 @@ func parseJSONStructure(value string, data map[string]interface{}) error {
 	return nil
 }
 
-//
 // Examples:
 // "text=one,severity=MAJOR,type=test_Type,time=2019-01-01,source={'id': '12345'}"
 // "text=one,severity=MAJOR,type=test_Type,time=2019-01-01,source={id: '12345'}"
+//
 //	->	{"severity":"MAJOR","source":{"id":"12345"},"text":"one","time":"2019-01-01","type":"test_Type"}
 func parseValue(value string) interface{} {
 	propValue := strings.TrimSpace(value)
@@ -133,6 +133,8 @@ func parseValue(value string) interface{} {
 		return true
 	} else if propValue == "false" {
 		return false
+	} else if propValue == "null" {
+		return nil
 	} else {
 		if hasQuotes(propValue) {
 			// remove quotes

--- a/tests/auto/devices/tests/devices_update.yaml
+++ b/tests/auto/devices/tests/devices_update.yaml
@@ -1,7 +1,37 @@
 tests:
-    devices_update_Update device by id:
-        command: c8y devices update --id 12345
+    devices_update_Remove a property from a device by setting it to null:
+        command: c8y devices update --id 12345 --data "myFragment=null"
         exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.myFragment: <nil>
+                method: PUT
+                path: /inventory/managedObjects/12345
+    devices_update_Update device by id:
+        command: c8y devices update --id 12345 --newName "MyDevice"
+        exit-code: 0
+        stdout:
+            json:
+                body.name: MyDevice
+                method: PUT
+                path: /inventory/managedObjects/12345
+    devices_update_Update device using a data (with different formats):
+        command: c8y devices update --id 12345 --data "my.nested.number=1.234,my.nested.bool=true,my.nested.string=my name,my.nested.num_as_str='1.234'"
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                ..#(body.data="my.nested.bool=true").body.data: my.nested.bool=true
+                ..#(body.data="my.nested.num_as_str='1.234'").body.data: my.nested.num_as_str='1.234'
+                ..#(body.data="my.nested.number=1.234").body.data: my.nested.number=1.234
+                ..#(body.data="my.nested.string=my name").body.data: my.nested.string=my name
+                method: PUT
+                path: /inventory/managedObjects/12345
+    devices_update_Update device using a template:
+        command: c8y devices update --id 12345 --template "{c8y_SupportedOperations:['c8y_Restart', 'c8y_Command']}"
+        exit-code: 0
+        skip: true
         stdout:
             json:
                 method: PUT

--- a/tests/auto/inventory/tests/inventory_update.yaml
+++ b/tests/auto/inventory/tests/inventory_update.yaml
@@ -1,4 +1,13 @@
 tests:
+    inventory_update_Remove a property (by setting it to null):
+        command: c8y inventory update --id 12345 --data "my_Fragment=null"
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.my_Fragment: <nil>
+                method: PUT
+                path: /inventory/managedObjects/12345
     inventory_update_Update a managed object:
         command: c8y inventory update --id 12345 --newName "my_custom_name" --data "{\"com_my_props\":{},\"value\":1}"
         exit-code: 0

--- a/tests/manual/common/flag_data.yaml
+++ b/tests/manual/common/flag_data.yaml
@@ -13,4 +13,35 @@ tests:
         body.name: test
         body.c8y_IsDevice: '{}'
         body.my.nested.value: '1'
+
+  It supports deleting properties using null value:
+    command: |
+      c8y devices update --id 12345 --data "my.nested.value=null" --dry --dryFormat json |
+        c8y util show --select "body" --output json -c
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"body":{"my":{"nested":{"value":null}}}}
   
+  It supports values of different types:
+    command: |
+      c8y devices update --id 12345 --data "my.nested.float=1.234,my.nested.int=2,my.nested.neg_int=-2,my.nested.bool_true=true,my.nested.bool_false=false,my.nested.string=my name,my.nested.num_as_str='1.234'" --dry --dryFormat json |
+        c8y util show --select "body" --output json -c=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "my": {
+              "nested": {
+                "bool_false": false,
+                "bool_true": true,
+                "float": 1.234,
+                "int": 2,
+                "neg_int": -2,
+                "num_as_str": "1.234",
+                "string": "my name"
+              }
+            }
+          }
+        }


### PR DESCRIPTION
Add support  for `null` values in the `data` flag.

`null` values are commonly used when updating managed objects to delete fragments. Previously the `data` flag was interpreting `null` as a string.

### Example

#### Remove property from a managed object

Cumulocity support deletion of root fragment by sending an update to the managed object with the root fragment set to null.

```sh
c8y devices update --id 12345 --data "myFragment=null" --dry
```

**Body**

```json
{
    "myFragment": null
}
```

If you want to remove the fragment from all managed objects containing this fragment then you can use it in a pipeline

```sh
c8y inventory find --query "has(myFragment)" --includeAll | c8y devices update --data "myFragment=null"
```