### PR TITLE
support multiple data flag usage

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -85,7 +85,7 @@ func WithProcessingModeValue() GetOption {
 // WithData adds support for data input
 func WithData() Option {
 	return func(cmd *cobra.Command) *cobra.Command {
-		cmd.Flags().StringP(FlagDataName, "d", "", "static data to be applied to body. accepts json or shorthand json, i.e. --data 'value1=1,my.nested.value=100'")
+		cmd.Flags().StringArrayP(FlagDataName, "d", []string{}, "static data to be applied to body. accepts json or shorthand json, i.e. --data 'value1=1,my.nested.value=100'")
 		return cmd
 	}
 }

--- a/tests/manual/common/flag_data.yaml
+++ b/tests/manual/common/flag_data.yaml
@@ -48,7 +48,7 @@ tests:
 
   It support multiple data flags:
     command: |
-      c8y devices create --data name=MyDevice --data "my.value=1" --data "prop2=false" --dry --dryFormat json |
+      c8y devices create --data name=MyDevice --data "subtypes=[linuxA,linuxB]" --data "my.value=1" --data "prop2=false" --dry --dryFormat json |
       c8y util show --select body --output json -c=false
     exit-code: 0
     stdout:
@@ -60,6 +60,7 @@ tests:
               "value": 1
             },
             "name": "MyDevice",
-            "prop2": false
+            "prop2": false,
+            "subtypes": ["linuxA", "linuxB"]
           }
         }

--- a/tests/manual/common/flag_data.yaml
+++ b/tests/manual/common/flag_data.yaml
@@ -45,3 +45,21 @@ tests:
             }
           }
         }
+
+  It support multiple data flags:
+    command: |
+      c8y devices create --data name=MyDevice --data "my.value=1" --data "prop2=false" --dry --dryFormat json |
+      c8y util show --select body --output json -c=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_IsDevice": {},
+            "my": {
+              "value": 1
+            },
+            "name": "MyDevice",
+            "prop2": false
+          }
+        }

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -275,3 +275,21 @@ tests:
     stdout:
       exactly: |
         {"prop1":{"value":1},"prop2":"two"}
+
+  It can combine data and template flags:
+    command: |
+      c8y template execute \
+        --template "{name: 'testdevice'}" \
+        --data "my.value=1" \
+        --data "prop2=false" \
+        --output json -c=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "my": {
+            "value": 1
+          },
+          "name": "testdevice",
+          "prop2": false
+        }


### PR DESCRIPTION
Change `data` flag from `string` to `stringArray` which allows the user to use `data` flag multiple times in the same command. This makes the command a bit more readable when setting multiple fields.


### Example

#### Create a new device

Create a new device my combining the `template` and `data` usage. Use multiple `data` flags to make the command a bit more readable as it can be split across multiple lines.

```sh
c8y devices create \
    --name "Test device" \
    --template "{c8y_SupportedOperations:['c8y_Command', 'c8y_Restart']}" \
    --data "subtypes=[linuxA,linuxB]" \
    --data "c8y_Hardware.model=linux" \
    --data "c8y_Hardware.serial=abcdef" \
    --dry
```

**Body**

```json
{
  "c8y_Hardware": {
    "model": "linux",
    "serial": "abcdef"
  },
  "c8y_IsDevice": {},
  "c8y_SupportedOperations": ["c8y_Command", "c8y_Restart"],
  "name": "Test device",
  "subtypes": ["linuxA", "linuxB"]
}
```
