### PR TITLE
Support insecure on session creation

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/sessions.md
+++ b/docs/go-c8y-cli/docs/concepts/sessions.md
@@ -25,6 +25,30 @@ c8y sessions create \
 
 You will be prompted for the username and password.
 
+### Create a session for a host with self-signed certificates
+
+If your Cumulocity host is using a self-signed certificate (which is usually the case if you are using the Cumulocity IoT Edge), then you may want to use the `allowInsecure` flag. This option ignores the SSL verification. It should only be used if you trust the host and you have no option available (e.g. importing the missing CA certificate to the operating system)!
+
+<CodeExample>
+
+```bash
+c8y sessions create \
+    --host "mytenant.eu-latest.cumulocity.com" \
+    --allowInsecure
+```
+
+</CodeExample>
+
+Alternatively you can allow insecure mode (i.e. disable SSL verification) for a single command by using the `--insecure` global flag.
+
+<CodeExample>
+
+```bash
+c8y devices list --insecure
+```
+
+</CodeExample>
+
 ## Activate a session (interactive)
 
 A helper is provided to set the session interactively by providing the user a list of configured sessions. The user will be prompted to select one of the listed sessions.
@@ -46,6 +70,12 @@ set-session
 ```
 
 </CodeExample>
+
+:::tip
+You can also provide additional flags to set session, as these are passed directly to the underlying `c8y sessions set` command.
+
+`set-session --debug`
+:::
 
 ## Activate a session (manual)
 

--- a/docs/go-c8y-cli/docs/configuration/settings.md
+++ b/docs/go-c8y-cli/docs/configuration/settings.md
@@ -63,6 +63,7 @@ c8y settings list --select "**" --output json
     "flatten": false,
     "force": false,
     "includeall": false,
+    "insecure": false,
     "logmessage": "",
     "maxjobs": 0,
     "maxworkers": 50,

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -318,6 +318,11 @@ func GetSettingsName(flagName string) string {
 	return SettingsDefaultsPrefix + "." + flagName
 }
 
+// GetSettingsNameWithoutPrefix converts the setting name without the settings prefix
+func GetSettingsNameWithoutPrefix(name string) string {
+	return strings.TrimPrefix(name, SettingsDefaultsPrefix+".")
+}
+
 // Config cli configuration settings
 type Config struct {
 	viper *viper.Viper

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -2,14 +2,15 @@ package config
 
 // CommandSettings contains the standard commonly used configuration settings
 type CommandSettings struct {
-	ActivityLog *ActivityLogSettings `json:"activityLog,omitempty"`
-	Encryption  *EncryptionSettings  `json:"encryption,omitempty"`
-	IncludeAll  *IncludeAllSettings  `json:"includeAll,omitempty"`
-	Session     *SessionSettings     `json:"session,omitempty"`
-	Mode        *ModeSettings        `json:"mode,omitempty"`
-	Storage     *StorageSettings     `json:"storage,omitempty"`
-	Template    *TemplateSettings    `json:"template,omitempty"`
-	View        *ViewSettings        `json:"views,omitempty"`
+	ActivityLog *ActivityLogSettings   `json:"activityLog,omitempty"`
+	Encryption  *EncryptionSettings    `json:"encryption,omitempty"`
+	IncludeAll  *IncludeAllSettings    `json:"includeAll,omitempty"`
+	Session     *SessionSettings       `json:"session,omitempty"`
+	Mode        *ModeSettings          `json:"mode,omitempty"`
+	Storage     *StorageSettings       `json:"storage,omitempty"`
+	Template    *TemplateSettings      `json:"template,omitempty"`
+	View        *ViewSettings          `json:"views,omitempty"`
+	Defaults    map[string]interface{} `json:"defaults,omitempty"`
 }
 
 // Bool returns a bool pointer set to the given value

--- a/tests/manual/sessions/create/session_create.yaml
+++ b/tests/manual/sessions/create/session_create.yaml
@@ -8,3 +8,25 @@ tests:
     stderr:
       contains:
         - 'commandError: Missing required parameter. host'
+  
+  It support insecure mode when creating a session:
+    command: |
+      export C8Y_SESSION_HOME=/tmp/session_create_test01/
+      rm -Rf /tmp/session_create_test01/
+      c8y sessions create --type dev --host "https://mytenant.iot.cumulocity.com" --username "dummy" --password "test" --allowInsecure
+      cat /tmp/session_create_test01/*.json | jq -c | c8y util show --select username,password,host,settings.defaults -o json -c=false
+      rm -rf /tmp/session_create_test01/
+    exit-code: 0
+    stdout:
+      exactly: |
+        /tmp/session_create_test01/mytenant.iot.cumulocity.com-dummy.json
+        {
+          "host": "https://mytenant.iot.cumulocity.com",
+          "password": "test",
+          "settings": {
+            "defaults": {
+              "insecure": true
+            }
+          },
+          "username": "dummy"
+        }

--- a/tools/PSc8y/Public-manual/New-Session.ps1
+++ b/tools/PSc8y/Public-manual/New-Session.ps1
@@ -55,7 +55,12 @@ None
         # Don't use tenant name as a prefix to the user name when using Basic Authentication
         [Parameter(Mandatory = $false)]
         [switch]
-        $NoTenantPrefix
+        $NoTenantPrefix,
+
+        # Allow insecure connection (e.g. when using self-signed certificates)
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $AllowInsecure
     )
 
     Begin {


### PR DESCRIPTION
Add support for setting the insecure (skip SSL verification) when creating a new session. This is sometimes required if the host is using a self-signed certificate.

Insecure mode already existed and could be set via the `c8y settings update` command. However it makes it more convenient to set it when session is being created.

**Example: Create session with insecure mode activated for a localhost instance**

```sh
c8y sessions create \
    --type dev
    --host "https://127.0.0.1" \
    --allowInsecure
```

If you need to modify an existing session then you can run the following to update the value

```sh
# Switch to existing session
set-session myexistingsession --insecure

# Set insecure and save it in the current session
c8y settings update defaults.insecure true
```

