### PR TITLE
feat: software/firmware allow empty version and url values

### DIFF
--- a/pkg/c8yquery/query.go
+++ b/pkg/c8yquery/query.go
@@ -64,6 +64,8 @@ func (i *CumulocityQueryIterator) GetNext() (line []byte, input interface{}, err
 			if len(line) > 0 {
 				queryParts = append(queryParts, UnescapeValue(format, string(line)))
 			}
+		default:
+			queryParts = append(queryParts, UnescapeValue(format, fmt.Sprintf("%v", value)))
 		}
 	}
 

--- a/pkg/cmd/firmware/patches/create/create.manual.go
+++ b/pkg/cmd/firmware/patches/create/create.manual.go
@@ -42,6 +42,9 @@ func NewCreatePatchCmd(f *cmdutil.Factory) *CreateCmd {
 
 			$ c8y firmware patches create --firmware custom\ firmware\ 1 --dependencyVersion 2.2.0 --version 2.2.1 --file ./install.ps1
 			Create a new patch (storing the file in Cumulocity) to an existing firmware version
+
+			$ c8y firmware patches create --firmware 12345 --dependencyVersion 2.2.0
+			Create a new patch with an empty version number and url
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()

--- a/pkg/cmd/firmware/patches/create/create.manual.go
+++ b/pkg/cmd/firmware/patches/create/create.manual.go
@@ -140,6 +140,8 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		cmd,
 		body,
 		inputIterators,
+		flags.WithStaticStringValue("c8y_Firmware.version", ""),
+		flags.WithStaticStringValue("c8y_Firmware.url", ""),
 		flags.WithDataFlagValue(),
 		flags.WithVersion("file", "version", "c8y_Firmware.version"),
 		flags.WithStringValue("url", "c8y_Firmware.url"),

--- a/pkg/cmd/firmware/versions/create/create.manual.go
+++ b/pkg/cmd/firmware/versions/create/create.manual.go
@@ -42,6 +42,9 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 
 			$ c8y firmware versions create --firmware "linux-os1" --version "1.0.0" --url "https://blob.azure.com/device-firmare/1.0.0/image.mender"
 			Create a new version with an external URL and link it to the existing "linux-os1" firmware
+
+			$ c8y firmware versions create --firmware 12345
+			Create a new version with an empty version number and url
 			`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()

--- a/pkg/cmd/firmware/versions/create/create.manual.go
+++ b/pkg/cmd/firmware/versions/create/create.manual.go
@@ -134,6 +134,8 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		cmd,
 		body,
 		inputIterators,
+		flags.WithStaticStringValue("c8y_Firmware.version", ""),
+		flags.WithStaticStringValue("c8y_Firmware.url", ""),
 		flags.WithDataFlagValue(),
 		flags.WithVersion("file", "version", "c8y_Firmware.version"),
 		flags.WithStringValue("url", "c8y_Firmware.url"),

--- a/pkg/cmd/software/versions/create/create.manual.go
+++ b/pkg/cmd/software/versions/create/create.manual.go
@@ -42,6 +42,9 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 
 			$ c8y software versions create --software "my-app" --version "1.0.0" --url "https://"
 			Create a new version with an external URL
+
+			$ c8y software versions create --software 12345
+			Create a new version with an empty version number and url
 			`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()

--- a/pkg/cmd/software/versions/create/create.manual.go
+++ b/pkg/cmd/software/versions/create/create.manual.go
@@ -134,6 +134,8 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		cmd,
 		body,
 		inputIterators,
+		flags.WithStaticStringValue("c8y_Software.version", ""),
+		flags.WithStaticStringValue("c8y_Software.url", ""),
 		flags.WithDataFlagValue(),
 		flags.WithVersion("file", "version", "c8y_Software.version"),
 		flags.WithStringValue("url", "c8y_Software.url"),

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -55,6 +55,8 @@ func WithQueryParameters(cmd *cobra.Command, query *QueryTemplate, inputIterator
 					query.SetVariable(key, url.EscapeQueryString(val))
 				}
 			}
+		case AnyString:
+			query.SetVariable(name, string(v))
 		default:
 			strValue := fmt.Sprintf("%v", v)
 			if strValue != "" {
@@ -164,6 +166,10 @@ func WithBody(cmd *cobra.Command, body *mapbuilder.MapBuilder, inputIterators *R
 			if v != "" {
 				err = body.Set(name, v)
 			}
+
+		case AnyString:
+			// Allow any string even empty values
+			err = body.Set(name, v)
 
 		case Template:
 			body.AppendTemplate(string(v))
@@ -353,7 +359,16 @@ func WithStaticStringValue(opts ...string) GetOption {
 		if len(opts) < 2 {
 			return "", nil, nil
 		}
-		return opts[0], opts[1], nil
+		return opts[0], AnyString(opts[1]), nil
+	}
+}
+
+func WithStaticStringValue2(opts ...string) GetOption {
+	return func(cmd *cobra.Command, inputIterators *RequestInputIterators) (string, interface{}, error) {
+		if len(opts) < 2 {
+			return "", nil, nil
+		}
+		return opts[0], AnyString(opts[1]), nil
 	}
 }
 
@@ -843,6 +858,9 @@ func WithFilePath(opts ...string) GetOption {
 
 // RawString raw string type
 type RawString string
+
+// AnyString string type which allows also empty values
+type AnyString string
 
 // WithDataValueAdvanced adds json or shorthand json parsing with additional option to strip the Cumulocity properties from the input
 func WithDataValueAdvanced(stripCumulocityKeys bool, raw bool, opts ...string) GetOption {

--- a/tests/manual/firmware/patches/firmware_patches.yaml
+++ b/tests/manual/firmware/patches/firmware_patches.yaml
@@ -2,3 +2,12 @@ tests:
     It can create/update/delete a firmware patch:
         command: ./manual/firmware/patches/crud.sh
         exit-code: 0
+
+    It creates firmware patch with a blank version:
+        command: |
+            c8y firmware patches create --firmware 1234 --dependencyVersion "1.2.3" --dry |
+                c8y util show --select method,body -o json -c
+        exit-code: 0
+        stdout:
+            exactly: |
+                {"body":{"c8y_Firmware":{"url":"","version":""},"c8y_Global":{},"c8y_Patch":{"dependency":"1.2.3"},"type":"c8y_FirmwareBinary"},"method":"POST"}

--- a/tests/manual/firmware/versions/firmware_patches_create.yaml
+++ b/tests/manual/firmware/versions/firmware_patches_create.yaml
@@ -1,4 +1,0 @@
-tests:
-    It can create/update/delete a firmware version:
-        command: ./manual/firmware/versions/crud.sh
-        exit-code: 0

--- a/tests/manual/firmware/versions/firmware_versions_create.yaml
+++ b/tests/manual/firmware/versions/firmware_versions_create.yaml
@@ -1,0 +1,13 @@
+tests:
+    It can create/update/delete a firmware version:
+        command: ./manual/firmware/versions/crud.sh
+        exit-code: 0
+
+    It creates firmware version with a blank version:
+        command: |
+            c8y firmware versions create --firmware 1234 --dry |
+                c8y util show --select method,body -o json -c
+        exit-code: 0
+        stdout:
+            exactly: |
+                {"body":{"c8y_Firmware":{"url":"","version":""},"c8y_Global":{},"type":"c8y_FirmwareBinary"},"method":"POST"}

--- a/tests/manual/software/software.yaml
+++ b/tests/manual/software/software.yaml
@@ -35,3 +35,12 @@ tests:
       json:
         method: GET
         query: r/.*name eq '\*python\*'.*
+
+  It creates software version with a blank version:
+    command: |
+      c8y software versions create --software 1234 --dry |
+        c8y util show --select method,body -o json -c
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"body":{"c8y_Global":{},"c8y_Software":{"url":"","version":""},"type":"c8y_SoftwareBinary"},"method":"POST"}


### PR DESCRIPTION
Support creating empty software/firmware/firmware patch versions. This is sometimes common when an empty value is used to represent the `latest` value.

```sh
# Create a new version with an empty version number and url
c8y software versions create --software 12345

# Create a new version with an empty version number and url
c8y firmware versions create --firmware 12345

# Create a new patch with an empty version number and url
c8y firmware patches create --firmware 12345 --dependencyVersion 2.2.0
```