### PR TITLE
c8y tenantstatistics listSummaryAllTenants: fix command error due to incorrect response unmarshalling

### DIFF
--- a/api/spec/json/tenantStatistics.json
+++ b/api/spec/json/tenantStatistics.json
@@ -70,6 +70,8 @@
       "method": "GET",
       "path": "/tenant/statistics/allTenantsSummary",
       "accept": "application/json",
+      "collectionProperty": "-",
+      "responseType": "array",
       "permissions": [
         "managementTenant"
       ],

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -346,6 +346,14 @@
             "type": "string",
             "description": "Type of each item in the array related to the collectionType. Use '-' disable any automatic guessing"
           },
+          "responseType": {
+            "type": "string",
+            "description": "Expected response type returned by the server. If not provided a JSON object is assumed",
+            "enum": [
+              "object",
+              "array"
+            ]
+          },
           "skip": {
             "type": "boolean",
             "title": "Skip parameter",

--- a/api/spec/yaml/tenantStatistics.yaml
+++ b/api/spec/yaml/tenantStatistics.yaml
@@ -55,6 +55,8 @@ endpoints:
     method: GET
     path: /tenant/statistics/allTenantsSummary
     accept: application/json
+    collectionProperty: '-'
+    responseType: array
     permissions:
       - managementTenant
     alias:

--- a/pkg/cmd/tenantstatistics/listsummaryalltenants/listSummaryAllTenants.auto.go
+++ b/pkg/cmd/tenantstatistics/listsummaryalltenants/listSummaryAllTenants.auto.go
@@ -64,6 +64,8 @@ Get tenant summary statistics collection for the last 10 days, only return until
 		flags.WithExtendedPipelineSupport("", "", false),
 		flags.WithPipelineAliases("dateFrom", "time", "creationTime", "lastUpdated"),
 		flags.WithPipelineAliases("dateTo", "time", "creationTime", "lastUpdated"),
+
+		flags.WithCollectionProperty("-"),
 	)
 
 	// Required flags
@@ -172,6 +174,8 @@ func (n *ListSummaryAllTenantsCmd) RunE(cmd *cobra.Command, args []string) error
 		Header:       headers,
 		IgnoreAccept: cfg.IgnoreAcceptHeader(),
 		DryRun:       cfg.ShouldUseDryRun(cmd.CommandPath()),
+
+		ResponseData: make([]map[string]interface{}, 0),
 	}
 
 	return n.factory.RunWithWorkers(client, cmd, &req, inputIterators)

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -108,9 +108,10 @@ func (r *RequestHandler) ProcessRequestAndResponse(requests []c8y.RequestOptions
 	defer cancel()
 	start := time.Now()
 
-	// TODO: Check if this is required
-	outData := make(map[string]interface{})
-	req.ResponseData = &outData
+	// Support both JSON objects or arrays, but default to an object
+	if req.ResponseData == nil {
+		req.ResponseData = make(map[string]interface{})
+	}
 	resp, err := r.Client.SendRequest(
 		ctx,
 		req,
@@ -827,10 +828,13 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, co
 
 			emptyArray := []byte("[]\n")
 
-			if len(responseText) == len(emptyArray) && bytes.Equal(responseText, emptyArray) {
-				r.Logger.Info("No matching results found. Empty response will be omitted")
-				responseText = []byte{}
+			if !showRaw {
+				if len(responseText) == len(emptyArray) && bytes.Equal(responseText, emptyArray) {
+					r.Logger.Info("No matching results found. Empty response will be omitted")
+					responseText = []byte{}
+				}
 			}
+
 		} else {
 			responseText = resp.Body()
 		}

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -505,6 +505,14 @@
         default { "nil" }
     }
 
+    # Additional options
+    $RequestOptionsBuilder = New-Object System.Text.StringBuilder
+    if ($Specification.responseType -eq "array") {
+        $null = $RequestOptionsBuilder.AppendLine("ResponseData: make([]map[string]interface{}, 0),")
+    } elseif ($Specification.responseType -eq "object") {
+        # Do nothing, so it already defaults to a map[string]interface{}
+    }
+
     #
     # Template
     #
@@ -726,6 +734,7 @@ func (n *${NameCamel}Cmd) RunE(cmd *cobra.Command, args []string) error {
         IgnoreAccept: cfg.IgnoreAcceptHeader(),
         DryRun:       cfg.ShouldUseDryRun(cmd.CommandPath()),
         $PrepareRequest
+        $RequestOptionsBuilder
     }
     $PostActionOptions
 

--- a/tests/manual/tenantstatistics/tenantstatistics_listSummaryAllTenants.yaml
+++ b/tests/manual/tenantstatistics/tenantstatistics_listSummaryAllTenants.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+tests:
+    It supports getting a summary of all tenants:
+        command: c8y tenantstatistics listSummaryAllTenants
+        exit-code: 0
+    
+    It supports raw values:
+        command: c8y tenantstatistics listSummaryAllTenants --raw
+        exit-code: 0
+        stdout:
+            match-pattern: |
+                \[.*\]


### PR DESCRIPTION
Fix handling of response from the `GET /tenant/statistics/allTenantsSummary` endpoint (due to an unexpected array format instead of the object format on almost all other API responses)

The command now works as expected.

```sh
c8y tenantstatistics listSummaryAllTenants --dateFrom -1d

# Or using global --raw argument to view raw server response
c8y tenantstatistics listSummaryAllTenants --raw
```
