### PR TITLE
support updating proxy setting via cli

### DIFF
--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -336,6 +336,9 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"false",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
+	// proxy
+	"defaults.proxy": {"defaults.proxy", "string", "settings.defaults.proxy", []string{}, nil, cobra.ShellCompDirectiveNoFileComp},
+
 	// Table view settings
 	"views.rowMode": {"views.rowMode", "string", config.SettingsViewRowMode, []string{
 		tableviewer.RowModeTruncate,


### PR DESCRIPTION
Support updating the proxy setting via `c8y settings update`.

```sh
# update session setting (persist to file)
c8y settings update defaults.proxy "10.0.0.1:8080"

# set environment variable
eval $(c8y settings update defaults.proxy "10.0.0.1:8080" --shell auto)
```
