### PR TITLE
fix: `c8y tenants get|delete` Use `--id` flag value over piped value

### DIFF
--- a/tests/manual/tenants/tenants.yaml
+++ b/tests/manual/tenants/tenants.yaml
@@ -9,3 +9,12 @@ tests:
                 path: /tenant/tenants
                 body.domain: "abc.con.iot"
                 body.company: "ABC Con"
+
+    It uses explicit tenant id over piped value:
+        command: >
+          echo t11111 | c8y tenants get --id t22222 --dry
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /tenant/tenants/t22222


### PR DESCRIPTION
Example

The following example will use the tenant id provided by the `--id` flag (`t22222`) instead of the value from the pipeline.

```
echo t11111 | c8y tenants get --id t22222 --dry
```