### PR TITLE
Fix/session `c8y sessions create` name sanitization

### DIFF
--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -316,6 +317,14 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 }
 
 func (n *CmdCreate) formatFilename(name string) string {
+	// Remove any characters which cause parsing problems in the future
+	// https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js
+	reg := regexp.MustCompile(`[|\\{}()[\]^$+*?:/]`)
+	name = reg.ReplaceAllStringFunc(name, func(s string) string {
+		// Replace invalid char with an empty string
+		return ""
+	})
+
 	if !strings.HasSuffix(name, ".json") {
 		name = fmt.Sprintf("%s.json", name)
 	}

--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -297,7 +297,8 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 	// session name (default to host and username)
 	hostname := "c8y"
 	if u, err := url.Parse(session.GetHost()); err == nil {
-		hostname = u.Host
+		// Don't include port number by default as it causes problems with paths across differents OS's
+		hostname = u.Hostname()
 	}
 
 	sessionName := hostname + "-" + session.Username
@@ -317,9 +318,8 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 }
 
 func (n *CmdCreate) formatFilename(name string) string {
-	// Remove any characters which cause parsing problems in the future
-	// https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js
-	reg := regexp.MustCompile(`[|\\{}()[\]^$+*?:/]`)
+	// Remove any characters that don't match the allowed chars
+	reg := regexp.MustCompile(`[^A-Za-z0-9_#(). !,;'@%=&-]`)
 	name = reg.ReplaceAllStringFunc(name, func(s string) string {
 		// Replace invalid char with an empty string
 		return ""

--- a/tests/manual/sessions/create/session_create.yaml
+++ b/tests/manual/sessions/create/session_create.yaml
@@ -30,3 +30,37 @@ tests:
           },
           "username": "dummy"
         }
+
+  It santizes the session name:
+    command: |
+      export C8Y_SESSION_HOME=/tmp/session_create_test02/
+      rm -Rf /tmp/session_create_test02/
+      c8y sessions create --type dev --host "https://mytenant.iot.cumulocity.com:9090" --username "dummy@me.com" --password "test"
+      cat /tmp/session_create_test02/*.json | jq -c | c8y util show --select username,password,host -o json -c=false
+      rm -rf /tmp/session_create_test02/
+    exit-code: 0
+    stdout:
+      exactly: |
+        /tmp/session_create_test02/mytenant.iot.cumulocity.com-dummy@me.com.json
+        {
+          "host": "https://mytenant.iot.cumulocity.com:9090",
+          "password": "test",
+          "username": "dummy@me.com"
+        }
+
+  It santizes the session name when specified by the user:
+    command: |
+      export C8Y_SESSION_HOME=/tmp/session_create_test03/
+      rm -Rf /tmp/session_create_test03/
+      c8y sessions create --type dev --name 'some[]{}+*&?:/\_-(crazy)"!' --host "https://mytenant.iot.cumulocity.com:9090" --username "dummy@me.com" --password "test"
+      cat /tmp/session_create_test03/*.json | jq -c | c8y util show --select username,password,host -o json -c=false
+      rm -rf /tmp/session_create_test03/
+    exit-code: 0
+    stdout:
+      exactly: |
+        /tmp/session_create_test03/some&_-(crazy)!.json
+        {
+          "host": "https://mytenant.iot.cumulocity.com:9090",
+          "password": "test",
+          "username": "dummy@me.com"
+        }


### PR DESCRIPTION
Sanitize the session name before creating the session file to improve the compatibility across operating systems, and to prevent parsing errors when re-reading the session in `set-session`.

The session filename is sanitized when using the default naming or when the user set a specific name using the `--name` flag. The following sanitization is done:

* Default session name uses the host (without port) and the username joined by a hyphen `-`. The user can override this using the `--name` flag.
* Any character that does match the regex `[A-Za-z0-9_#(). !,;'@%=&-]` will be removed

**Examples**

The following shows examples of using the default session name and a manually defined name. The filenames of the output files are shown after the command.

```sh
# Auto session name (from host and username)
c8y sessions create --host "https://mytenant.iot.cumulocity.com:9090" --username "dummy@me.com"
# => mytenant.iot.cumulocity.com-dummy@me.com.json

# Manual session name
c8y sessions create --name 'something[]{}+*&?:/\_-(crazy)"!' --host "https://mytenant.iot.cumulocity.com:9090" --username "dummy@me.com"
# => something&_-(crazy)!.json
```