### PR TITLE
feat(c8y api): support common query parameters for GET requests

### DIFF
--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -238,11 +238,16 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return nil
 	}
-	commonOptions, err := cfg.GetOutputCommonOptions(cmd)
-	if err != nil {
-		return cmderrors.NewUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+
+	// Only add common query parameter (for paging) to GET requests
+	if strings.EqualFold(method, http.MethodGet) {
+		commonOptions, err := cfg.GetOutputCommonOptions(cmd)
+		if err != nil {
+			return cmderrors.NewUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+		}
+		commonOptions.AddQueryParameters(query)
 	}
-	commonOptions.AddQueryParameters(query)
+
 	queryValue, err := query.GetQueryUnescape(true)
 
 	if err != nil {

--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -238,6 +238,11 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return nil
 	}
+	commonOptions, err := cfg.GetOutputCommonOptions(cmd)
+	if err != nil {
+		return cmderrors.NewUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
+	}
+	commonOptions.AddQueryParameters(query)
 	queryValue, err := query.GetQueryUnescape(true)
 
 	if err != nil {

--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -54,8 +54,11 @@ func NewSubCommand(f *cmdutil.Factory) *CmdAPI {
 			$ c8y api GET /alarm/alarms
 			Get a list of alarms
 
-			$ c8y api GET "/alarm/alarms?pageSize=10&status=ACTIVE"
+			$ c8y api GET "/alarm/alarms&status=ACTIVE" --pageSize 10
 			Get a list of alarms with custom query parameters
+
+			$ c8y api GET "/alarm/alarms&status=ACTIVE" --pageSize 1 --withTotalPages
+			Get a total ACTIVE alarms
 
 			$ c8y api POST "alarm/alarms" --data "text=one,severity=MAJOR,type=test_Type,time=2019-01-01,source.id='12345'" --keepProperties
 			Create a new alarm

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -130,6 +130,14 @@ tests:
         path: /alarm/alarms
         query: pageSize=10&status=ACTIVE
 
+  It supports the pageSize flag:
+    command: |
+      c8y api /inventory/managedObjects --pageSize 10 --dry
+    exit-code: 0
+    stdout:
+      json:
+        query: pageSize=10
+
   It accepts positional arguments for path and defaults to GET (not using pipeline):
     command: |
       c8y api "/alarm/alarms"


### PR DESCRIPTION
`c8y api`: Add support for common query parameters to align with other inbuilt commands.

The following flags are respected when the `GET` request method is used:

* `--pageSize <int>`
* `--currentPage <int>`
* `--withTotalPages`
* `--withTotalElements`

**Examples**

```sh
c8y api GET "/alarm/alarms&status=ACTIVE" --pageSize 10
# Get a list of alarms with custom query parameters

c8y api GET "inventory/managedObjects" --pageSize 1 --withTotalPages
# Get a total ACTIVE alarms
```