### PR TITLE
feat(c8y tenantoptions): Template support for create and update

### DIFF
--- a/api/spec/json/tenantOptions.json
+++ b/api/spec/json/tenantOptions.json
@@ -68,22 +68,29 @@
         {
           "name": "category",
           "type": "string",
-          "required": true,
           "description": "Category of option"
         },
         {
           "name": "key",
           "type": "string",
-          "required": true,
           "pipeline": true,
           "description": "Key of option"
         },
         {
           "name": "value",
           "type": "string",
-          "required": true,
           "description": "Value of option"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties"
         }
+      ],
+      "bodyRequiredKeys": [
+        "category",
+        "key",
+        "value"
       ]
     },
     {
@@ -229,9 +236,16 @@
         {
           "name": "value",
           "type": "string",
-          "required": true,
           "description": "New value"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties"
         }
+      ],
+      "bodyRequiredKeys": [
+        "value"
       ]
     },
     {

--- a/api/spec/yaml/tenantOptions.yaml
+++ b/api/spec/yaml/tenantOptions.yaml
@@ -55,20 +55,25 @@ endpoints:
     body:
       - name: category
         type: string
-        required: true
         description: Category of option
 
       - name: key
         type: string
-        required: true
         pipeline: true
         description: Key of option
 
       - name: value
         type: string
-        required: true
         description: Value of option
 
+      - name: data
+        type: json
+        description: Additional properties
+
+    bodyRequiredKeys:
+      - "category"
+      - "key"
+      - "value"
 
   - name: getTenantOption
     description: Get tenant option
@@ -172,8 +177,14 @@ endpoints:
     body:
       - name: value
         type: string
-        required: true
         description: New value
+
+      - name: data
+        type: json
+        description: Additional properties
+
+    bodyRequiredKeys:
+      - value
 
   - name: updateTenantOptionBulk
     description: Update multiple tenant options

--- a/pkg/cmd/tenantoptions/create/create.auto.go
+++ b/pkg/cmd/tenantoptions/create/create.auto.go
@@ -44,9 +44,9 @@ Create a tenant option
 
 	cmd.SilenceUsage = true
 
-	cmd.Flags().String("category", "", "Category of option (required)")
-	cmd.Flags().String("key", "", "Key of option (required) (accepts pipeline)")
-	cmd.Flags().String("value", "", "Value of option (required)")
+	cmd.Flags().String("category", "", "Category of option")
+	cmd.Flags().String("key", "", "Key of option (accepts pipeline)")
+	cmd.Flags().String("value", "", "Value of option")
 
 	completion.WithOptions(
 		cmd,
@@ -57,13 +57,12 @@ Create a tenant option
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
-		flags.WithExtendedPipelineSupport("key", "key", true, "id"),
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
+		flags.WithExtendedPipelineSupport("key", "key", false, "id"),
 	)
 
 	// Required flags
-	_ = cmd.MarkFlagRequired("category")
-	_ = cmd.MarkFlagRequired("value")
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
@@ -145,6 +144,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("value", "value"),
 		cmdutil.WithTemplateValue(cfg),
 		flags.WithTemplateVariablesValue(),
+		flags.WithRequiredProperties("category", "key", "value"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/tenantoptions/update/update.auto.go
+++ b/pkg/cmd/tenantoptions/update/update.auto.go
@@ -46,7 +46,7 @@ Update a tenant option
 
 	cmd.Flags().String("category", "", "Tenant Option category (required)")
 	cmd.Flags().String("key", "", "Tenant Option key (required) (accepts pipeline)")
-	cmd.Flags().String("value", "", "New value (required)")
+	cmd.Flags().String("value", "", "New value")
 
 	completion.WithOptions(
 		cmd,
@@ -57,13 +57,13 @@ Update a tenant option
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("key", "key", true, "id"),
 	)
 
 	// Required flags
 	_ = cmd.MarkFlagRequired("category")
-	_ = cmd.MarkFlagRequired("value")
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
@@ -142,6 +142,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("value", "value"),
 		cmdutil.WithTemplateValue(cfg),
 		flags.WithTemplateVariablesValue(),
+		flags.WithRequiredProperties("value"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tools/PSc8y/Public/New-TenantOption.ps1
+++ b/tools/PSc8y/Public/New-TenantOption.ps1
@@ -22,20 +22,19 @@ Create a tenant option
     [Alias()]
     [OutputType([object])]
     Param(
-        # Category of option (required)
-        [Parameter(Mandatory = $true)]
+        # Category of option
+        [Parameter()]
         [string]
         $Category,
 
-        # Key of option (required)
-        [Parameter(Mandatory = $true,
-                   ValueFromPipeline=$true,
+        # Key of option
+        [Parameter(ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
         $Key,
 
-        # Value of option (required)
-        [Parameter(Mandatory = $true)]
+        # Value of option
+        [Parameter()]
         [string]
         $Value
     )

--- a/tools/PSc8y/Public/Update-TenantOption.ps1
+++ b/tools/PSc8y/Public/Update-TenantOption.ps1
@@ -34,8 +34,8 @@ Update a tenant option
         [object[]]
         $Key,
 
-        # New value (required)
-        [Parameter(Mandatory = $true)]
+        # New value
+        [Parameter()]
         [string]
         $Value
     )


### PR DESCRIPTION
Add support for creating and updating tenant options using templates.


**Example: Create new tenant option using a template and stored encoded json as the value**
```sh
c8y tenantoptions create --category dummy --key one --template "{value: std.manifestJsonMinified({some:{value:'one'}})}" --dry
```

*Output Body*
```json
{
  "category": "dummy",
  "key": "one",
  "value": "{\"some\":{\"value\":\"one\"}}"
}
```

**Example: Update tenant option using a template**

```sh
c8y tenantoptions update --category dummy --key one --template "{value: 'again'}" --dry
```