### PR TITLE
docs: use 'external identity' terminology to align with c8y docs

### DIFF
--- a/api/spec/json/identity.json
+++ b/api/spec/json/identity.json
@@ -1,15 +1,15 @@
 {
   "information": {
     "name": "identity",
-    "description": "Cumulocity identity",
-    "descriptionLong": "REST endpoint to interact with Cumulocity identity objects",
+    "description": "Cumulocity external identity",
+    "descriptionLong": "REST endpoint to interact with Cumulocity external identity objects",
     "link": "https://cumulocity.com/guides/reference/identity/"
   },
   "endpoints": [
     {
       "name": "getExternalIDCollection",
       "method": "GET",
-      "description": "Get external id collection",
+      "description": "Get external identity collection",
       "descriptionLong": "Get a collection of external ids related to an existing managed object",
       "path": "identity/globalIds/{device}/externalIds",
       "accept": "application/vnd.com.nsn.cumulocity.externalIdCollection+json",
@@ -67,7 +67,7 @@
     },
     {
       "name": "getExternalID",
-      "description": "Get external id",
+      "description": "Get external identity",
       "descriptionLong": "Get an external identity object. An external identify will include the reference to a single device managed object\n",
       "method": "GET",
       "path": "/identity/externalIds/{type}/{name}",
@@ -121,7 +121,7 @@
     },
     {
       "name": "deleteExternalID",
-      "description": "Delete external id",
+      "description": "Delete external identity",
       "descriptionLong": "Delete an existing external id. This does not delete the device managed object",
       "method": "DELETE",
       "path": "/identity/externalIds/{type}/{name}",
@@ -188,7 +188,7 @@
       "method": "POST",
       "path": "identity/globalIds/{device}/externalIds",
       "accept": "application/vnd.com.nsn.cumulocity.externalId+json",
-      "description": "Create external id",
+      "description": "Create external identity",
       "descriptionLong": "Create a new external id for an existing managed object",
       "alias": {
         "go": "create",

--- a/api/spec/yaml/identity.yaml
+++ b/api/spec/yaml/identity.yaml
@@ -2,14 +2,14 @@
 ---
 information:
   name: identity
-  description: Cumulocity identity
-  descriptionLong: 'REST endpoint to interact with Cumulocity identity objects'
+  description: Cumulocity external identity
+  descriptionLong: 'REST endpoint to interact with Cumulocity external identity objects'
   link: https://cumulocity.com/guides/reference/identity/
 
 endpoints:
   - name: getExternalIDCollection
     method: GET
-    description: Get external id collection
+    description: Get external identity collection
     descriptionLong: Get a collection of external ids related to an existing managed object
     path: identity/globalIds/{device}/externalIds
     accept: application/vnd.com.nsn.cumulocity.externalIdCollection+json
@@ -53,7 +53,7 @@ endpoints:
 
 
   - name: getExternalID
-    description: Get external id
+    description: Get external identity
     descriptionLong: |
       Get an external identity object. An external identify will include the reference to a single device managed object
     method: GET
@@ -93,7 +93,7 @@ endpoints:
           - id
 
   - name: deleteExternalID
-    description: Delete external id
+    description: Delete external identity
     descriptionLong: Delete an existing external id. This does not delete the device managed object
     method: DELETE
     path: /identity/externalIds/{type}/{name}
@@ -144,7 +144,7 @@ endpoints:
     method: POST
     path: identity/globalIds/{device}/externalIds
     accept: application/vnd.com.nsn.cumulocity.externalId+json
-    description: Create external id
+    description: Create external identity
     descriptionLong: Create a new external id for an existing managed object
     alias:
         go: create

--- a/pkg/cmd/identity/create/create.auto.go
+++ b/pkg/cmd/identity/create/create.auto.go
@@ -24,14 +24,14 @@ type CreateCmd struct {
 	factory *cmdutil.Factory
 }
 
-// NewCreateCmd creates a command to Create external id
+// NewCreateCmd creates a command to Create external identity
 func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 	ccmd := &CreateCmd{
 		factory: f,
 	}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create external id",
+		Short: "Create external identity",
 		Long:  `Create a new external id for an existing managed object`,
 		Example: heredoc.Doc(`
 $ c8y identity create --device 1234 --type test --name myserialnumber

--- a/pkg/cmd/identity/delete/delete.auto.go
+++ b/pkg/cmd/identity/delete/delete.auto.go
@@ -23,14 +23,14 @@ type DeleteCmd struct {
 	factory *cmdutil.Factory
 }
 
-// NewDeleteCmd creates a command to Delete external id
+// NewDeleteCmd creates a command to Delete external identity
 func NewDeleteCmd(f *cmdutil.Factory) *DeleteCmd {
 	ccmd := &DeleteCmd{
 		factory: f,
 	}
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete external id",
+		Short: "Delete external identity",
 		Long:  `Delete an existing external id. This does not delete the device managed object`,
 		Example: heredoc.Doc(`
 $ c8y identity delete --type test --name myserialnumber

--- a/pkg/cmd/identity/get/get.auto.go
+++ b/pkg/cmd/identity/get/get.auto.go
@@ -24,14 +24,14 @@ type GetCmd struct {
 	factory *cmdutil.Factory
 }
 
-// NewGetCmd creates a command to Get external id
+// NewGetCmd creates a command to Get external identity
 func NewGetCmd(f *cmdutil.Factory) *GetCmd {
 	ccmd := &GetCmd{
 		factory: f,
 	}
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "Get external id",
+		Short: "Get external identity",
 		Long: `Get an external identity object. An external identify will include the reference to a single device managed object
 `,
 		Example: heredoc.Doc(`

--- a/pkg/cmd/identity/identity.auto.go
+++ b/pkg/cmd/identity/identity.auto.go
@@ -19,8 +19,8 @@ func NewSubCommand(f *cmdutil.Factory) *SubCmdIdentity {
 
 	cmd := &cobra.Command{
 		Use:   "identity",
-		Short: "Cumulocity identity",
-		Long:  `REST endpoint to interact with Cumulocity identity objects`,
+		Short: "Cumulocity external identity",
+		Long:  `REST endpoint to interact with Cumulocity external identity objects`,
 	}
 
 	// Subcommands

--- a/pkg/cmd/identity/list/list.auto.go
+++ b/pkg/cmd/identity/list/list.auto.go
@@ -25,14 +25,14 @@ type ListCmd struct {
 	factory *cmdutil.Factory
 }
 
-// NewListCmd creates a command to Get external id collection
+// NewListCmd creates a command to Get external identity collection
 func NewListCmd(f *cmdutil.Factory) *ListCmd {
 	ccmd := &ListCmd{
 		factory: f,
 	}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "Get external id collection",
+		Short: "Get external identity collection",
 		Long:  `Get a collection of external ids related to an existing managed object`,
 		Example: heredoc.Doc(`
 $ c8y identity list --device 12345

--- a/tools/PSc8y/Public/Get-ExternalId.ps1
+++ b/tools/PSc8y/Public/Get-ExternalId.ps1
@@ -2,7 +2,7 @@
 Function Get-ExternalId {
 <#
 .SYNOPSIS
-Get external id
+Get external identity
 
 .DESCRIPTION
 Get an external identity object. An external identify will include the reference to a single device managed object

--- a/tools/PSc8y/Public/Get-ExternalIdCollection.ps1
+++ b/tools/PSc8y/Public/Get-ExternalIdCollection.ps1
@@ -2,7 +2,7 @@
 Function Get-ExternalIdCollection {
 <#
 .SYNOPSIS
-Get external id collection
+Get external identity collection
 
 .DESCRIPTION
 Get a collection of external ids related to an existing managed object

--- a/tools/PSc8y/Public/New-ExternalId.ps1
+++ b/tools/PSc8y/Public/New-ExternalId.ps1
@@ -2,7 +2,7 @@
 Function New-ExternalId {
 <#
 .SYNOPSIS
-Create external id
+Create external identity
 
 .DESCRIPTION
 Create a new external id for an existing managed object

--- a/tools/PSc8y/Public/Remove-ExternalId.ps1
+++ b/tools/PSc8y/Public/Remove-ExternalId.ps1
@@ -2,7 +2,7 @@
 Function Remove-ExternalId {
 <#
 .SYNOPSIS
-Delete external id
+Delete external identity
 
 .DESCRIPTION
 Delete an existing external id. This does not delete the device managed object


### PR DESCRIPTION
Use 'external identity' instead of 'external id' to align with Cumulocity IoT docs.