### PR TITLE
Fix `create external id`: Use externalid accept header value instead of application/json

### DIFF
--- a/api/spec/json/identity.json
+++ b/api/spec/json/identity.json
@@ -13,7 +13,7 @@
       "descriptionLong": "Get a collection of external ids related to an existing managed object",
       "path": "identity/globalIds/{device}/externalIds",
       "accept": "application/vnd.com.nsn.cumulocity.externalIdCollection+json",
-      "collectionType": "application/vnd.com.nsn.cumulocity.externalId+json",
+      "collectionType": "application/vnd.com.nsn.cumulocity.externalid+json",
       "collectionProperty": "externalIds",
       "alias": {
         "go": "list",
@@ -71,7 +71,7 @@
       "descriptionLong": "Get an external identity object. An external identify will include the reference to a single device managed object\n",
       "method": "GET",
       "path": "/identity/externalIds/{type}/{name}",
-      "accept": "application/vnd.com.nsn.cumulocity.externalId+json",
+      "accept": "application/vnd.com.nsn.cumulocity.externalid+json",
       "alias": {
         "go": "get",
         "powershell": "Get-ExternalId"
@@ -187,7 +187,8 @@
       "name": "newExternalID",
       "method": "POST",
       "path": "identity/globalIds/{device}/externalIds",
-      "accept": "application/vnd.com.nsn.cumulocity.externalId+json",
+      "addAccept": true,
+      "accept": "application/vnd.com.nsn.cumulocity.externalid+json",
       "description": "Create external identity",
       "descriptionLong": "Create a new external id for an existing managed object",
       "alias": {

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -334,6 +334,10 @@
             "type": "string",
             "title": "Partial url i.e. /alarm/alarms"
           },
+          "addAccept": {
+            "type": "boolean",
+            "description": "Add an explicit Accept header value if set"
+          },
           "accept": {
             "type": "string",
             "description": "Accept header value. Data to be returned from the platform. The accept header will also control how the data will be displayed within the PowerShell module"

--- a/api/spec/yaml/identity.yaml
+++ b/api/spec/yaml/identity.yaml
@@ -13,7 +13,7 @@ endpoints:
     descriptionLong: Get a collection of external ids related to an existing managed object
     path: identity/globalIds/{device}/externalIds
     accept: application/vnd.com.nsn.cumulocity.externalIdCollection+json
-    collectionType: application/vnd.com.nsn.cumulocity.externalId+json
+    collectionType: application/vnd.com.nsn.cumulocity.externalid+json
     collectionProperty: externalIds
     alias:
         go: list
@@ -58,7 +58,7 @@ endpoints:
       Get an external identity object. An external identify will include the reference to a single device managed object
     method: GET
     path: /identity/externalIds/{type}/{name}
-    accept: application/vnd.com.nsn.cumulocity.externalId+json
+    accept: application/vnd.com.nsn.cumulocity.externalid+json
     alias:
         go: get
         powershell: Get-ExternalId
@@ -143,7 +143,8 @@ endpoints:
   - name: newExternalID
     method: POST
     path: identity/globalIds/{device}/externalIds
-    accept: application/vnd.com.nsn.cumulocity.externalId+json
+    addAccept: true
+    accept: application/vnd.com.nsn.cumulocity.externalid+json
     description: Create external identity
     descriptionLong: Create a new external id for an existing managed object
     alias:

--- a/pkg/cmd/identity/create/create.auto.go
+++ b/pkg/cmd/identity/create/create.auto.go
@@ -118,6 +118,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		headers,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetHeader(), nil }, "header"),
+		flags.WithStaticStringValue("Accept", "application/vnd.com.nsn.cumulocity.externalid+json"),
 		flags.WithProcessingModeValue(),
 	)
 	if err != nil {

--- a/tools/PSc8y/Public/Get-ExternalId.ps1
+++ b/tools/PSc8y/Public/Get-ExternalId.ps1
@@ -49,7 +49,7 @@ Get external identity
         $c8yargs = New-ClientArgument -Parameters $PSBoundParameters -Command "identity get"
         $ClientOptions = Get-ClientOutputOption $PSBoundParameters
         $TypeOptions = @{
-            Type = "application/vnd.com.nsn.cumulocity.externalId+json"
+            Type = "application/vnd.com.nsn.cumulocity.externalid+json"
             ItemType = ""
             BoundParameters = $PSBoundParameters
         }

--- a/tools/PSc8y/Public/Get-ExternalIdCollection.ps1
+++ b/tools/PSc8y/Public/Get-ExternalIdCollection.ps1
@@ -44,7 +44,7 @@ Get a list of external ids
         $ClientOptions = Get-ClientOutputOption $PSBoundParameters
         $TypeOptions = @{
             Type = "application/vnd.com.nsn.cumulocity.externalIdCollection+json"
-            ItemType = "application/vnd.com.nsn.cumulocity.externalId+json"
+            ItemType = "application/vnd.com.nsn.cumulocity.externalid+json"
             BoundParameters = $PSBoundParameters
         }
     }

--- a/tools/PSc8y/Public/New-ExternalId.ps1
+++ b/tools/PSc8y/Public/New-ExternalId.ps1
@@ -58,7 +58,7 @@ Create external identity (using pipeline)
         $c8yargs = New-ClientArgument -Parameters $PSBoundParameters -Command "identity create"
         $ClientOptions = Get-ClientOutputOption $PSBoundParameters
         $TypeOptions = @{
-            Type = "application/vnd.com.nsn.cumulocity.externalId+json"
+            Type = "application/vnd.com.nsn.cumulocity.externalid+json"
             ItemType = ""
             BoundParameters = $PSBoundParameters
         }


### PR DESCRIPTION
`c8y identity create`: Set "Accept" header to `application/vnd.com.nsn.cumulocity.externalid+json` to avoid HTTP 406 errors