### PR TITLE
feat(build): strip path information from build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
   - <<: &build_defaults
       binary: 'bin/{{ if index .Env "BINARY_INCLUDE_VERSION" }}{{ .ProjectName }}_{{ .RawVersion }}_{{ if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_{{ .Arch }}{{ else }}{{ .ProjectName }}{{ end }}'
       main: ./cmd/c8y/main.go
+      flags:
+        - -trimpath
       ldflags:
         - -s -w -X github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd.buildVersion={{.Version}} -X github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd.buildBranch={{.Branch}}
       hooks:


### PR DESCRIPTION
Strip the build path information from the binary via use of the `--trimpath` golang build option. This means there will no longer be the path of the build machine included in the binary.