### PR TITLE
fix: ignore .git directories when looking for session files

### DIFF
--- a/pkg/cmd/sessions/selectsession/selectsession.go
+++ b/pkg/cmd/sessions/selectsession/selectsession.go
@@ -74,7 +74,10 @@ func SelectSession(io *iostreams.IOStreams, cfg *config.Config, log *logger.Logg
 			log.Printf("Ignoring dir: %+v", info.Name())
 			return filepath.SkipDir
 		}
-
+		if info.IsDir() && info.Name() == ".git" {
+			log.Printf("Ignoring dir: %+v", info.Name())
+			return filepath.SkipDir
+		}
 		if info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
Do not traverse `.git` folders when looking for session files.