### PR TITLE
disable datahub prompt when querying high performance api

### DIFF
--- a/api/spec/json/datahub.json
+++ b/api/spec/json/datahub.json
@@ -9,10 +9,8 @@
     {
       "name": "query",
       "method": "POST",
+      "semanticMethod": "GET",
       "path": "service/datahub/sql",
-      "confirmation": {
-        "disable": true
-      },
       "accept": "application/json",
       "description": "Execute a SQL query and retrieve the results",
       "descriptionLong": "Execute a SQL query and retrieve the results",

--- a/api/spec/json/datahub.json
+++ b/api/spec/json/datahub.json
@@ -10,6 +10,9 @@
       "name": "query",
       "method": "POST",
       "path": "service/datahub/sql",
+      "confirmation": {
+        "disable": true
+      },
       "accept": "application/json",
       "description": "Execute a SQL query and retrieve the results",
       "descriptionLong": "Execute a SQL query and retrieve the results",

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -327,15 +327,16 @@
               "DELETE"
             ]
           },
-          "confirmation": {
-            "type": "object",
-            "title": "Custom control over the confirmation",
-            "properties": {
-              "disable": {
-                "type": "boolean",
-                "title": "Disable the confirmation for the command"
-              }
-            }
+          "semanticMethod": {
+            "type": "string",
+            "title": "Semantic REST method",
+            "description": "How the call should be handled internally. This will override how the request is processed in respect to confirmation, create/update/delete modes etc.",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE"
+            ]
           },
           "description": {
             "type": "string",

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -327,6 +327,16 @@
               "DELETE"
             ]
           },
+          "confirmation": {
+            "type": "object",
+            "title": "Custom control over the confirmation",
+            "properties": {
+              "disable": {
+                "type": "boolean",
+                "title": "Disable the confirmation for the command"
+              }
+            }
+          },
           "description": {
             "type": "string",
             "title": "Description of the endpoint"

--- a/api/spec/yaml/datahub.yaml
+++ b/api/spec/yaml/datahub.yaml
@@ -22,6 +22,8 @@ endpoints:
   - name: query
     method: POST
     path: service/datahub/sql
+    confirmation:
+      disable: true
     accept: application/json
     description: Execute a SQL query and retrieve the results
     descriptionLong: Execute a SQL query and retrieve the results

--- a/api/spec/yaml/datahub.yaml
+++ b/api/spec/yaml/datahub.yaml
@@ -21,9 +21,8 @@ information:
 endpoints:
   - name: query
     method: POST
+    semanticMethod: GET
     path: service/datahub/sql
-    confirmation:
-      disable: true
     accept: application/json
     description: Execute a SQL query and retrieve the results
     descriptionLong: Execute a SQL query and retrieve the results

--- a/pkg/cmd/datahub/query/query.auto.go
+++ b/pkg/cmd/datahub/query/query.auto.go
@@ -43,7 +43,7 @@ $ c8y datahub query --sql "SELECT * FROM myTenantIdDataLake.Dremio.myTenantId.al
 Get a list of alarms from datahub using the PANDAS format (note the raw format is necessary here)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return nil
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/datahub/query/query.auto.go
+++ b/pkg/cmd/datahub/query/query.auto.go
@@ -68,6 +68,7 @@ Get a list of alarms from datahub using the PANDAS format (note the raw format i
 		flags.WithExtendedPipelineSupport("sql", "sql", false, "id"),
 
 		flags.WithCollectionProperty("rows"),
+		flags.WithSemanticMethod("GET"),
 	)
 
 	// Required flags

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -29,6 +29,7 @@ const (
 	AnnotationValueFromPipelineData   = "valueFromPipeline.data"
 	AnnotationValueCollectionProperty = "collectionProperty"
 	AnnotationValueDeprecated         = "deprecatedNotice"
+	AnnotationValueSemanticMethod     = "semanticMethod"
 )
 
 // Option adds flags to a given command
@@ -263,6 +264,34 @@ func GetDeprecationNoticeFromAnnotation(cmd *cobra.Command) (value string) {
 		return
 	}
 	if v, ok := cmd.Annotations[AnnotationValueDeprecated]; ok {
+		value = v
+	}
+	return
+}
+
+// WithSemanticMethod sets a semantic REST method which may be different to the actual REST method used
+// useful to be more descriptive about how the action should behave (e.g. prompting).
+func WithSemanticMethod(v string) Option {
+	return func(cmd *cobra.Command) *cobra.Command {
+		if v != "" {
+			if cmd.Annotations == nil {
+				cmd.Annotations = map[string]string{}
+			}
+			cmd.Annotations[AnnotationValueSemanticMethod] = v
+		}
+		return cmd
+	}
+}
+
+// GetSemanticMethodFromAnnotation returns semantic REST method related to the action from the annotations
+func GetSemanticMethodFromAnnotation(cmd *cobra.Command) (value string) {
+	if cmd == nil {
+		return
+	}
+	if cmd.Annotations == nil {
+		return
+	}
+	if v, ok := cmd.Annotations[AnnotationValueSemanticMethod]; ok {
 		value = v
 	}
 	return

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -507,15 +507,17 @@
     #
     # Pre run validation (disable some commands without switch flags)
     #
-    if ($Specification.confirmation.disable -eq $true) {
-        $PreRunFunction = "nil"
+     $FunctionalMethod = if ($Specification.semanticMethod) {
+        $Specification.semanticMethod
     } else {
-        $PreRunFunction = switch ($Specification.method) {
-            "POST" { "f.CreateModeEnabled()" }
-            "PUT" { "f.UpdateModeEnabled()" }
-            "DELETE" { "f.DeleteModeEnabled()" }
-            default { "nil" }
-        }
+        $Specification.method
+    }
+
+    $PreRunFunction = switch ($FunctionalMethod) {
+        "POST" { "f.CreateModeEnabled()" }
+        "PUT" { "f.UpdateModeEnabled()" }
+        "DELETE" { "f.DeleteModeEnabled()" }
+        default { "nil" }
     }
 
     # Additional options
@@ -628,12 +630,13 @@ $($Examples -join "`n`n")
         )
         $(
             if ($collectionProperty) {
-                "flags.WithCollectionProperty(`"$collectionProperty`"),"
+                "flags.WithCollectionProperty(`"$collectionProperty`"),`n"
             }
-        )
-        $(
             if ($DeprecationNotice) {
-                "flags.WithDeprecationNotice(`"$DeprecationNotice`"),"
+                "flags.WithDeprecationNotice(`"$DeprecationNotice`"),`n"
+            }
+            if ($Specification.semanticMethod) {
+                "flags.WithSemanticMethod(`"$($Specification.semanticMethod)`"),`n"
             }
         )
 	)

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -507,11 +507,15 @@
     #
     # Pre run validation (disable some commands without switch flags)
     #
-    $PreRunFunction = switch ($Specification.method) {
-        "POST" { "f.CreateModeEnabled()" }
-        "PUT" { "f.UpdateModeEnabled()" }
-        "DELETE" { "f.DeleteModeEnabled()" }
-        default { "nil" }
+    if ($Specification.confirmation.disable -eq $true) {
+        $PreRunFunction = "nil"
+    } else {
+        $PreRunFunction = switch ($Specification.method) {
+            "POST" { "f.CreateModeEnabled()" }
+            "PUT" { "f.UpdateModeEnabled()" }
+            "DELETE" { "f.DeleteModeEnabled()" }
+            default { "nil" }
+        }
     }
 
     # Additional options


### PR DESCRIPTION
Remove the confirmation prompt for `c8y datahub query` commands. This was initially activated because the underlying REST API is a `POST`, however the function of the API is more like a `GET` for the user.

The following will no longer prompt for confirmation before sending the request.

```sh
c8y datahub query --sql "SELECT * FROM myTenantIdDataLake.Dremio.myTenantId.alarms"
```
