### PR TITLE
fix: `c8y api` url parsing bug which resulted in a panic

### DIFF
--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -224,12 +224,12 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	baseURL, _ := url.Parse(uri)
-
 	// query parameters
 	query := flags.NewQueryTemplate()
-	for key, values := range baseURL.Query() {
-		query.SetVariable(key, values)
+	if baseURL, err := url.Parse(uri); err == nil {
+		for key, values := range baseURL.Query() {
+			query.SetVariable(key, values)
+		}
 	}
 
 	err = flags.WithQueryParameters(
@@ -262,10 +262,16 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 		host = n.flagHost
 	}
 
+	// Get base path without query parameter (for when an iterator is not used)
+	urlPath := path.GetTemplate()
+	if i := strings.Index(path.GetTemplate(), "?"); i != -1 {
+		urlPath = path.GetTemplate()[0:i]
+	}
+
 	req := c8y.RequestOptions{
 		Method:       method,
 		Host:         host,
-		Path:         baseURL.Path,
+		Path:         urlPath,
 		Query:        queryValue,
 		Header:       headers,
 		DryRun:       cfg.ShouldUseDryRun(cmd.CommandPath()),

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -46,6 +46,25 @@ tests:
         body.name: "hello"
         body.url: "12345"
 
+  It can pipe simple text to a url:
+    command: >
+      echo "1" | c8y api --method DELETE "/endpoint/%s" --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: DELETE
+        path: /endpoint/1
+
+  It can pipe simple text to a url query parameters:
+    command: >
+      echo "1" | c8y api DELETE "/endpoint?id=%s" --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: DELETE
+        path: /endpoint
+        query: id=1
+
   It sends a PUT request using piped json and a format style url template:
     command: >
       echo "{\"url\": \"12345\", \"name\":\"hello\"}" | c8y api --method PUT --url "/test/%s/endpoint" --template "input.value" --dry


### PR DESCRIPTION
Fix URL parsing bug when providing the URL via positional arguments instead of the `--url` flag and using the `%s` template variable.

Now the following works as expected.

**Option 1: With url as positional argument**

```sh
echo -e "1\n2" | c8y api DELETE "/endpoint?id=%s" --dry
# => DELETE /endpoint?id=1
# => DELETE /endpoint?id=2
```

**Option 2: With --url flag**
```sh
echo -e "1\n2" | c8y api DELETE --url "/endpoint?id=%s" --dry
# => DELETE /endpoint?id=1
# => DELETE /endpoint?id=2
```