### PR TITLE
fix: don't include piped input in template by default

### DIFF
--- a/pkg/cmd/template/execute/execute.manual.go
+++ b/pkg/cmd/template/execute/execute.manual.go
@@ -60,7 +60,7 @@ Pass external json data into the template, and reference it via the "input.value
 		cmd,
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
-		flags.WithExtendedPipelineSupport("input", "input", false),
+		flags.WithExtendedPipelineSupport("input", "", false),
 	)
 
 	cmdutil.DisableAuthCheck(cmd)

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
 
 tests:
+  It does not include piped input without referencing it:
+    command: |
+      echo "1" | c8y template execute --template "{}"
+    exit-code: 0
+    stdout:
+      exactly: |
+        {}
+
   It preserves double quotes in bash/zsh:
     command: |
       c8y template execute --template "{\"email\": \"he llo@ex ample.com\"}"


### PR DESCRIPTION
Fixed bug where piping text into `c8y template execute` would automatically include the `.input` without the user specifying `input.value`.

The example below shows the before and after behaviour.

```sh
echo "1" | c8y template execute --template "{}" -o json -c
```

**Template output (before fix)**
```json
{"input":"1"}
```

**Template output (after fix)**
```json
{}
```

