### PR TITLE
Add more create measurement examples

### DIFF
--- a/api/spec/json/measurements.json
+++ b/api/spec/json/measurements.json
@@ -340,13 +340,31 @@
         "powershell": [
           {
             "description": "Create measurement",
-            "command": "New-Measurement -Device {{ randomdevice }} -Time \"0s\" -Type \"myType\" -Data @{ c8y_Winding = @{ temperature = @{ value = 1.2345; unit = \"°C\" } } }"
+            "command": "New-Measurement -Device {{ randomdevice }} -Time \"0s\" -Type \"myType\" -Data @{ c8y_Winding = @{ temperature = @{ value = 25.0; unit = \"°C\" } } }"
           }
         ],
         "go": [
           {
-            "description": "Create measurement",
-            "command": "c8y measurements create --device 12345 --time \"0s\" --type \"myType\" --data \"{\\\"c8y_Winding\\\":{ \\\"temperature\\\":{\\\"value\\\": 1.2345,\\\"unit\\\":\\\"°C\\\"}}}\""
+            "description": "Create measurement using shorthand data",
+            "command": "c8y measurements create --device 12345 --type \"myType\" --data \"c8y_Winding.temperature.value=25.0,c8y_Winding.temperature.unit=°C\"\n"
+          },
+          {
+            "description": "Create measurement using a template (more portable across shells)",
+            "command": "c8y measurements create --device 12345 --type \"myType\" --template \"{c8y_Winding:{temperature:{value: 25.0,unit:'°C'}}}\"\n"
+          },
+          {
+            "description": "Create measurement using a template file",
+            "command": "c8y measurements create --device 12345 --type \"myType\" --template ./mymeasurement.jsonnet\n",
+            "skipTest": true
+          },
+          {
+            "description": "Create measurement using json data (sh/bash/zsh/fish only)",
+            "command": "c8y measurements create --device 12345 --type \"myType\" --data \"{\\\"c8y_Winding\\\":{ \\\"temperature\\\":{\\\"value\\\": 25,\\\"unit\\\":\\\"°C\\\"}}}\"\n"
+          },
+          {
+            "description": "Create measurement using json data (powershell only)",
+            "command": "c8y measurements create --device 12345 --type \"myType\" --data '{\\\"c8y_Winding\\\":{\\\"temperature\\\":{\\\"value\\\": 25,\\\"unit\\\":\\\"C\\\"}}}'\n",
+            "skipTest": true
           },
           {
             "description": "Copy measurements from one device to another",

--- a/api/spec/yaml/measurements.yaml
+++ b/api/spec/yaml/measurements.yaml
@@ -253,11 +253,30 @@ endpoints:
     examples:
       powershell:
         - description: Create measurement
-          command: New-Measurement -Device {{ randomdevice }} -Time "0s" -Type "myType" -Data @{ c8y_Winding = @{ temperature = @{ value = 1.2345; unit = "°C" } } }
+          command: New-Measurement -Device {{ randomdevice }} -Time "0s" -Type "myType" -Data @{ c8y_Winding = @{ temperature = @{ value = 25.0; unit = "°C" } } }
 
       go:
-        - description: Create measurement
-          command: 'c8y measurements create --device 12345 --time "0s" --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 1.2345,\"unit\":\"°C\"}}}"'
+        - description: Create measurement using shorthand data
+          command: |
+            c8y measurements create --device 12345 --type "myType" --data "c8y_Winding.temperature.value=25.0,c8y_Winding.temperature.unit=°C"
+
+        - description: Create measurement using a template (more portable across shells)
+          command: |
+            c8y measurements create --device 12345 --type "myType" --template "{c8y_Winding:{temperature:{value: 25.0,unit:'°C'}}}"
+
+        - description: Create measurement using a template file
+          command: |
+            c8y measurements create --device 12345 --type "myType" --template ./mymeasurement.jsonnet
+          skipTest: true
+
+        - description: Create measurement using json data (sh/bash/zsh/fish only)
+          command: |
+            c8y measurements create --device 12345 --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 25,\"unit\":\"°C\"}}}"
+
+        - description: Create measurement using json data (powershell only)
+          command: |
+            c8y measurements create --device 12345 --type "myType" --data '{\"c8y_Winding\":{\"temperature\":{\"value\": 25,\"unit\":\"C\"}}}'
+          skipTest: true
 
         - description: Copy measurements from one device to another
           command: c8y measurements list --device 12345 --select '!id,**' | c8y measurements create --device 22222 --template input.value

--- a/cmd/gen-tests/main.go
+++ b/cmd/gen-tests/main.go
@@ -301,7 +301,8 @@ func formatJsonAssertion(jsonAssertion map[string]string, propType string, prop 
 		if strings.HasSuffix(prop, ".data") || strings.EqualFold(propType, "json_custom") {
 			data := make(map[string]interface{})
 			if err := jsonUtilities.ParseJSON(values[0], data); err != nil {
-				loggerS.Fatalf("Could not parse shorthand json. %s", err)
+				loggerS.Warnf("Could not parse shorthand json. %s", err)
+				return
 			}
 
 			prefix := "body."

--- a/pkg/cmd/binaries/create/create.auto.go
+++ b/pkg/cmd/binaries/create/create.auto.go
@@ -41,7 +41,6 @@ $ c8y binaries create --file "myConfig.json" --type c8y_upload --data "c8y_Globa
 Upload a config file and make it globally accessible for all users
 
 $ c8y binaries create --file "myConfig.json" --file "device01-myConfig.json" --type c8y_upload --template "{collectedAt: _.Now('-5min')}"
-
 Upload a file with a custom name and custom meta information
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/events/createbinary/createBinary.auto.go
+++ b/pkg/cmd/events/createbinary/createBinary.auto.go
@@ -39,7 +39,6 @@ $ c8y events createBinary --id 12345 --file ./myfile.log
 Add a binary to an event
 
 $ c8y events createBinary --id 12345 --file ./myfile.log --name "myfile-2022-03-31.log"
-
 Add a binary to an event using a custom name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/measurements/create/create.auto.go
+++ b/pkg/cmd/measurements/create/create.auto.go
@@ -34,8 +34,20 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 		Short: "Create measurement",
 		Long:  `Create a new measurement`,
 		Example: heredoc.Doc(`
-$ c8y measurements create --device 12345 --time "0s" --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 1.2345,\"unit\":\"°C\"}}}"
-Create measurement
+$ c8y measurements create --device 12345 --type "myType" --data "c8y_Winding.temperature.value=25.0,c8y_Winding.temperature.unit=°C"
+Create measurement using shorthand data
+
+$ c8y measurements create --device 12345 --type "myType" --template "{c8y_Winding:{temperature:{value: 25.0,unit:'°C'}}}"
+Create measurement using a template (more portable across shells)
+
+$ c8y measurements create --device 12345 --type "myType" --template ./mymeasurement.jsonnet
+Create measurement using a template file
+
+$ c8y measurements create --device 12345 --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 25,\"unit\":\"°C\"}}}"
+Create measurement using json data (sh/bash/zsh/fish only)
+
+$ c8y measurements create --device 12345 --type "myType" --data '{\"c8y_Winding\":{\"temperature\":{\"value\": 25,\"unit\":\"C\"}}}'
+Create measurement using json data (powershell only)
 
 $ c8y measurements list --device 12345 --select '!id,**' | c8y measurements create --device 22222 --template input.value
 Copy measurements from one device to another

--- a/pkg/cmd/notification2/subscriptions/create/create.auto.go
+++ b/pkg/cmd/notification2/subscriptions/create/create.auto.go
@@ -38,11 +38,9 @@ $ c8y notification2 subscriptions create --name deviceSub --device 12345 --conte
 Create a new subscription to operations for a specific device
 
 $ echo -e "1111\n2222" | c8y notification2 subscriptions create --name devicegroup --context mo --apiFilter operations
-
 Create a subscription which groups all devices in a single subscription name
 
 $ c8y devices list | c8y notification2 subscriptions create --name devicegroup --context mo --apiFilter operations
-
 Create a subscription which groups all devices in a single subscription name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/usergroups/update/update.auto.go
+++ b/pkg/cmd/usergroups/update/update.auto.go
@@ -38,7 +38,6 @@ $ c8y usergroups update --id 12345 --name "customGroup2"
 Update a user group
 
 $ c8y usergroups update --id 12345 --name "customGroup2" --template "{example: 'value'}"
-
 Update a user group with custom properties
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/users/create/create.auto.go
+++ b/pkg/cmd/users/create/create.auto.go
@@ -37,7 +37,6 @@ $ c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" 
 Create a user
 
 $ c8y users create --template "{email: 'test@me.com', userName: $.email, firstName: 'Peter'}" --sendPasswordResetEmail
-
 Create a user using a template
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/users/update/update.auto.go
+++ b/pkg/cmd/users/update/update.auto.go
@@ -38,7 +38,6 @@ $ c8y users update --id "myuser" --firstName "Simon"
 Update a user
 
 $ c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"
-
 Update the email field in each user to match the id (if the id includes the @ sign)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -29,7 +29,7 @@
     $DescriptionLong = $Specification.descriptionLong
     $Examples = foreach ($iExample in $Specification.examples.go) {
         if ($iExample.command) {
-            $ExampleText = "`$ {0}`n{1}" -f $iExample.command, $iExample.description
+            $ExampleText = "`$ {0}`n{1}" -f $iExample.command.TrimEnd(), $iExample.description
         } else {
             $ExampleText = $iExample
         }

--- a/tests/auto/measurements/tests/measurements_create.yaml
+++ b/tests/auto/measurements/tests/measurements_create.yaml
@@ -8,16 +8,57 @@ tests:
                 body.source.id: "22222"
                 method: POST
                 path: /measurement/measurements
-    measurements_create_Create measurement:
-        command: 'c8y measurements create --device 12345 --time "0s" --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 1.2345,\"unit\":\"°C\"}}}"'
+    measurements_create_Create measurement using a template (more portable across shells):
+        command: |
+            c8y measurements create --device 12345 --type "myType" --template "{c8y_Winding:{temperature:{value: 25.0,unit:'°C'}}}"
         exit-code: 0
         stdout:
             json:
-                body.c8y_Winding.temperature.unit: °C
-                body.c8y_Winding.temperature.value: "1.2345"
                 body.source.id: "12345"
                 body.type: myType
                 method: POST
                 path: /measurement/measurements
-            contains:
-                - '"time":'
+    measurements_create_Create measurement using a template file:
+        command: |
+            c8y measurements create --device 12345 --type "myType" --template ./mymeasurement.jsonnet
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.source.id: "12345"
+                body.type: myType
+                method: POST
+                path: /measurement/measurements
+    measurements_create_Create measurement using json data (powershell only):
+        command: |
+            c8y measurements create --device 12345 --type "myType" --data '{\"c8y_Winding\":{\"temperature\":{\"value\": 25,\"unit\":\"C\"}}}'
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.source.id: "12345"
+                body.type: myType
+                method: POST
+                path: /measurement/measurements
+    measurements_create_Create measurement using json data (sh/bash/zsh/fish only):
+        command: |
+            c8y measurements create --device 12345 --type "myType" --data "{\"c8y_Winding\":{ \"temperature\":{\"value\": 25,\"unit\":\"°C\"}}}"
+        exit-code: 0
+        stdout:
+            json:
+                body.c8y_Winding.temperature.unit: °C
+                body.c8y_Winding.temperature.value: "25"
+                body.source.id: "12345"
+                body.type: myType
+                method: POST
+                path: /measurement/measurements
+    measurements_create_Create measurement using shorthand data:
+        command: |
+            c8y measurements create --device 12345 --type "myType" --data "c8y_Winding.temperature.value=25.0,c8y_Winding.temperature.unit=°C"
+        exit-code: 0
+        stdout:
+            json:
+                body.source.id: "12345"
+                body.type: myType
+                method: POST
+                path: /measurement/measurements

--- a/tools/PSc8y/Public/New-Measurement.ps1
+++ b/tools/PSc8y/Public/New-Measurement.ps1
@@ -11,7 +11,7 @@ Create a new measurement
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/measurements_create
 
 .EXAMPLE
-PS> New-Measurement -Device {{ randomdevice }} -Time "0s" -Type "myType" -Data @{ c8y_Winding = @{ temperature = @{ value = 1.2345; unit = "°C" } } }
+PS> New-Measurement -Device {{ randomdevice }} -Time "0s" -Type "myType" -Data @{ c8y_Winding = @{ temperature = @{ value = 25.0; unit = "°C" } } }
 
 Create measurement
 

--- a/tools/PSc8y/Tests/New-Measurement.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/New-Measurement.auto.Tests.ps1
@@ -7,7 +7,7 @@ Describe -Name "New-Measurement" {
     }
 
     It "Create measurement" {
-        $Response = PSc8y\New-Measurement -Device $TestDevice.id -Time "0s" -Type "myType" -Data @{ c8y_Winding = @{ temperature = @{ value = 1.2345; unit = "°C" } } }
+        $Response = PSc8y\New-Measurement -Device $TestDevice.id -Time "0s" -Type "myType" -Data @{ c8y_Winding = @{ temperature = @{ value = 25.0; unit = "°C" } } }
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
Extend the `c8y measurements create` examples to direct users to use `--template` over `--data` for more portable one-liners across linux/macos/windows