### PR TITLE
fix: reduce ping interval used in notification2 client subscription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.12.0-rc.10
+	github.com/reubenmiller/go-c8y v0.13.0-rc.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/reubenmiller/go-c8y v0.12.0-rc.10 h1:fhqraGWY+hWSPMXx3jW/S+Qjw0ipN8WX2d7wNYmj8+I=
-github.com/reubenmiller/go-c8y v0.12.0-rc.10/go.mod h1:t+biKGzNJKWx0A8inMl6xkmVWKuRyTe36+Mq/kFLBkM=
+github.com/reubenmiller/go-c8y v0.13.0-rc.1 h1:0mNtzUbqd9LBPDAPunc3EegdOd0HrQTA21tEiRaS2NY=
+github.com/reubenmiller/go-c8y v0.13.0-rc.1/go.mod h1:t+biKGzNJKWx0A8inMl6xkmVWKuRyTe36+Mq/kFLBkM=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
+++ b/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
@@ -118,6 +118,12 @@ func (n *SubscribeCmd) RunE(cmd *cobra.Command, args []string) error {
 			Subscription:     n.Subscription,
 			ExpiresInMinutes: n.ExpiresInMinutes,
 		},
+		ConnectionOptions: notification2.ConnectionOptions{
+			PingInterval: 60 * time.Second,
+			PongWait:     180 * time.Second,
+			WriteWait:    60 * time.Second,
+			Insecure:     cfg.SkipSSLVerify(),
+		},
 	})
 
 	if err != nil {


### PR DESCRIPTION
Fix bug with the `c8y notification2 subscriptions subscribe` which resulted in the Websocket timing with the following errors:

```log
WARN	Failed to send ack. write tcp 192.168.178.162:55650->172.12.34.56:443: i/o timeout
```

In addition the following optimizations were also implemented:

* Added more verbose debug messages
* Reduced ping interval to 60 seconds
* Increased websocket write timeout to 60 seconds
* SSL Verification now uses the global setting (same as the REST API calls)