### PR TITLE
fix(extensions): Only read file from fileContentsAsString type if provided by user and not empty

### DIFF
--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -867,9 +867,18 @@ func WithFileContentsAsString(opts ...string) GetOption {
 	return func(cmd *cobra.Command, inputIterators *RequestInputIterators) (string, interface{}, error) {
 		src, dst, _ := UnpackGetterOptions("%s", opts...)
 
+		// Only try reading the file if the argument as been provided
+		if !cmd.Flags().Changed(src) {
+			return "", "", nil
+		}
+
 		value, err := cmd.Flags().GetString(src)
 		if err != nil {
 			return dst, value, err
+		}
+		// Ignore empty values
+		if value == "" {
+			return "", "", nil
 		}
 		file, err := os.Open(value)
 

--- a/tests/manual/extensions/example/body_basic_tests.yaml
+++ b/tests/manual/extensions/example/body_basic_tests.yaml
@@ -235,6 +235,22 @@ tests:
       exactly: |
         {"body":{"file":"one\ntwo\nthree"}}
 
+  fileContentsAsString without flag:
+    command: |
+      c8y kitchensink body fileContentsAsString --dry --dryFormat json |
+        c8y util show --select body
+    stdout:
+      exactly: |
+        {"body":{}}
+
+  fileContentsAsString with empty value:
+    command: |
+      c8y kitchensink body fileContentsAsString --file "" --dry --dryFormat json |
+        c8y util show --select body
+    stdout:
+      exactly: |
+        {"body":{}}
+
   attachment - multipart formdata upload without meta info:
     command: |
       c8y kitchensink body attachment --file manual/extensions/file1.txt --dry --dryFormat dump


### PR DESCRIPTION
Fix the handling of the extension flag type `fileContentsAsString` so that it is optional. This means if the user does not specify the flag, then it will not try and read the non-existent value.

Empty strings are also treated the same as not being provided at all.