### PR TITLE
fix(extensions): update json schema url reference to use the official schema after release

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/extensions/01-overview.md
+++ b/docs/go-c8y-cli/docs/concepts/extensions/01-overview.md
@@ -104,7 +104,7 @@ The API YAML specification uses a similar specification which is used by go-c8y-
 A schema is available to help guide you through the large set of options. Below shows a short example of the API specification.
 
 ```yaml title="file: ./api/devices.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: devices

--- a/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/01-command-groups.md
+++ b/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/01-command-groups.md
@@ -26,7 +26,7 @@ It is advised to keep the name of the specification file the same as the group n
 The example below defines a command group called `unicorns` and it has three commands. For simplicity all three commands just send a GET request to hardcoded endpoints (including both path and query parameters).
 
 ```yaml title="file: api/unicorns.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: unicorns

--- a/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/02-body-buliding.md
+++ b/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/02-body-buliding.md
@@ -122,7 +122,7 @@ It is typically used in Cumulocity IoT to add new inventory binaries or applicat
 The file upload scenario can be utilized by using the special `file` type in the body section. The snippet below adds a `utils` group command with a single command called `upload`.
 
 ```yaml title="file: api/utils.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: utils
@@ -218,7 +218,7 @@ Plain binary data can be sent in a request using the `fileContents` type. Using 
 To demonstrate this, a new command can be added called `replace` which sends a PUT request to the inventory binary API to replace an existing binary with the contents from a new file. The api command definition to achieve this is shown below:
 
 ```yaml title="file: api/utils.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: utils

--- a/docs/go-c8y-cli/docs/tutorials/extensions/creating-an-extension.md
+++ b/docs/go-c8y-cli/docs/tutorials/extensions/creating-an-extension.md
@@ -165,7 +165,7 @@ The YAML files under the `api/` folder are yaml based API specifications which t
 So to create sub commands which are callable using `c8y organizer assets`, create the following file under the `api/` folder:
 
 ```yaml title="file: api/assets.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 group:
   name: assets    # <= sets the name of the command group
   description: Manage assets
@@ -240,7 +240,7 @@ Now let's say that our fictitious API also supports a query parameter to determi
 Below adds the `detailed` parameter which is a boolean. The boolean type is mapped to a flag which does not accept an argument, e.g. `--detailed`. If `--detailed` is not present, then the query parameter is not added to the outgoing request.
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 commands:
   - name: get
     description: Get asset
@@ -514,7 +514,7 @@ The `type-asset` anchor can then be reused through the YAML specification where 
 Below shows the final API specification after all the commands have been added to it and the `id` parameters reference the `type-asset` anchor (using the slightly obscure but useful YAML syntax `<<: *type-asset`):
 
 ```yaml title="file: api/assets.yaml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: assets

--- a/pkg/cmd/extension/ext_tmpls/apiCommandTemplate.yaml
+++ b/pkg/cmd/extension/ext_tmpls/apiCommandTemplate.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: devices

--- a/tests/testdata/extensions/c8y-kitchensink/api/body_basic.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/body_basic.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: body

--- a/tests/testdata/extensions/c8y-kitchensink/api/body_cumulocity.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/body_cumulocity.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: body_complex

--- a/tests/testdata/extensions/c8y-kitchensink/api/features.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/features.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: features

--- a/tests/testdata/extensions/c8y-kitchensink/api/presets.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/presets.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
 ---
 group:
   name: presets


### PR DESCRIPTION
Replacing the feature branch reference to the extension json schema with the official url (after the release of the extensions feature).

If you have existing extensions, then you should replace this:

```
# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/feat/extensions-manager/tools/schema/extensionCommands.json
```

With this:

```
# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
```