### PR TITLE
feat(extensions): support mapping or ignoring pageSize query parameter value

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/01-command-groups.md
+++ b/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/01-command-groups.md
@@ -76,3 +76,73 @@ Available Commands:
 Flags:
   -h, --help   help for example
 ```
+
+### Example: Ignoring or mapping the pageSize query parameter value
+
+The example below shows how the common query parameter `pageSize` can be controlled to either map the value to a different query parameter, or to ignore the value entirely from the outgoing HTTP request.
+
+By default go-c8y-cli will automatically add the `pageSize` query parameter to all GET requests. This is done as all of the core Cumulocity API supports pagination, so it just made sense to support it by default. Having a default value also allows a global pageSize value to be set in the settings which is then added to all requests automatically.
+
+However, if you are interacting with a service which does not support pagination, then the HTTP request might fail if there are unexpected query parameters sent along with the request.
+
+The example below shows simple commands which execute a GET request. The both are configured to handle the `pageSize` flag value slightly different. The first command will ignore the pageSize value completely, and the seconds command will map the pageSize to a different query parameter. The mapping is made possible by using the `flagMapping` object.
+
+```yaml title="file: api/unicorns.yaml"
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
+---
+group:
+  name: unicorns
+  description: Fetch different unicorns
+
+commands:
+  - name: list
+    description: List unicorns
+    method: GET
+    path: service/unicorns/list
+    flagMapping:
+      pageSize:       # <== If the value is empty, then the `pageSize` query parameter will be ignored
+  
+  - name: listpaginated
+    description: List unicorns that supports pagination
+    method: GET
+    path: service/unicorns/paginated
+    flagMapping:
+      pageSize: limit       # <== Map the `pageSize` value to the `limit` query parameter
+```
+
+The first `list` command will exclude the `pageSize` query parameter which is added by default when the `defaults.pageSize` setting is used (or if the user provides `--pageSize <size>`). We can check this behaviour by using dry mode.
+
+<CodeExample>
+
+```sh
+c8y settings update defaults.pageSize 100
+c8y myextension unicorns list --dry
+```
+
+</CodeExample>
+
+As you can see below, the outgoing request does not have the `pageSize` query parameter set.
+
+```bash title="Output"
+What If: Sending [GET] request to [https://{host}service/unicorns/list]
+
+### GET service/unicorns/list
+```
+
+The second command, `listpaginated`, supports pagination however the unicorn service expects the page size information to be provided via the `limit` query parameter instead of the `pageSize`. The user can control where the `--pageSize` (or default page size) value is mapped to. This enables a more consistent user interface where any differences between services can be normalized on the command line.
+
+Executing the second command using an explicit `--pageSize <size>` flag results in the following output (note `limit=11` is being used now):
+
+<CodeExample>
+
+```sh
+c8y myextension unicorns listpaginated --pageSize 11
+```
+
+</CodeExample>
+
+```bash title="Output"
+What If: Sending [GET] request to [https://{host}/service/unicorns/paginated?limit=11]
+
+### GET /service/unicorns/paginated?limit=11
+```

--- a/internal/integration/models/api_spec.go
+++ b/internal/integration/models/api_spec.go
@@ -39,31 +39,32 @@ func (cp *CommandPreset) GetOption(k string, defaultValue ...string) string {
 }
 
 type Command struct {
-	Name               string         `yaml:"name"`
-	Description        string         `yaml:"description"`
-	DescriptionLong    string         `yaml:"descriptionLong"`
-	Preset             CommandPreset  `yaml:"preset"`
-	Deprecated         string         `yaml:"deprecated"`
-	DeprecatedAt       string         `yaml:"deprecatedAt"`
-	Method             string         `yaml:"method"`
-	SemanticMethod     string         `yaml:"semanticMethod"`
-	Accept             string         `yaml:"accept,omitempty"`
-	ContentType        string         `yaml:"contentType,omitempty"`
-	CollectionType     string         `yaml:"collectionType,omitempty"`
-	CollectionProperty string         `yaml:"collectionProperty,omitempty"`
-	Path               string         `yaml:"path"`
-	Examples           Examples       `yaml:"examples"`
-	ExampleList        []Example      `yaml:"exampleList"`
-	Alias              Aliases        `yaml:"alias"`
-	Hidden             *bool          `yaml:"hidden,omitempty"`
-	Skip               *bool          `yaml:"skip,omitempty"`
-	QueryParameters    []Parameter    `yaml:"queryParameters,omitempty"`
-	PathParameters     []Parameter    `yaml:"pathParameters,omitempty"`
-	HeaderParameters   []Parameter    `yaml:"headerParameters,omitempty"`
-	Body               []Parameter    `yaml:"body,omitempty"`
-	BodyContent        *BodyContent   `yaml:"bodyContent,omitempty"`
-	BodyTemplates      []BodyTemplate `yaml:"bodyTemplates,omitempty"`
-	BodyRequiredKeys   []string       `yaml:"bodyRequiredKeys,omitempty"`
+	Name               string            `yaml:"name"`
+	Description        string            `yaml:"description"`
+	DescriptionLong    string            `yaml:"descriptionLong"`
+	Preset             CommandPreset     `yaml:"preset"`
+	Deprecated         string            `yaml:"deprecated"`
+	DeprecatedAt       string            `yaml:"deprecatedAt"`
+	Method             string            `yaml:"method"`
+	SemanticMethod     string            `yaml:"semanticMethod"`
+	Accept             string            `yaml:"accept,omitempty"`
+	ContentType        string            `yaml:"contentType,omitempty"`
+	CollectionType     string            `yaml:"collectionType,omitempty"`
+	CollectionProperty string            `yaml:"collectionProperty,omitempty"`
+	Path               string            `yaml:"path"`
+	Examples           Examples          `yaml:"examples"`
+	ExampleList        []Example         `yaml:"exampleList"`
+	Alias              Aliases           `yaml:"alias"`
+	Hidden             *bool             `yaml:"hidden,omitempty"`
+	Skip               *bool             `yaml:"skip,omitempty"`
+	QueryParameters    []Parameter       `yaml:"queryParameters,omitempty"`
+	PathParameters     []Parameter       `yaml:"pathParameters,omitempty"`
+	HeaderParameters   []Parameter       `yaml:"headerParameters,omitempty"`
+	Body               []Parameter       `yaml:"body,omitempty"`
+	BodyContent        *BodyContent      `yaml:"bodyContent,omitempty"`
+	BodyTemplates      []BodyTemplate    `yaml:"bodyTemplates,omitempty"`
+	BodyRequiredKeys   []string          `yaml:"bodyRequiredKeys,omitempty"`
+	FlagMapping        map[string]string `yaml:"flagMapping"`
 }
 
 func (c *Command) HasPreset() bool {

--- a/pkg/cmdparser/runtime_command.go
+++ b/pkg/cmdparser/runtime_command.go
@@ -243,7 +243,7 @@ func (n *RuntimeCmd) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return cmderrors.NewUserError(fmt.Sprintf("Failed to get common options. err=%s", err))
 	}
-	commonOptions.AddQueryParameters(query)
+	commonOptions.AddQueryParametersWithMapping(query, n.options.Spec.FlagMapping)
 
 	queryValue, err := query.GetQueryUnescape(true)
 

--- a/pkg/config/commonoptions.go
+++ b/pkg/config/commonoptions.go
@@ -44,6 +44,10 @@ func (options CommonCommandOptions) AddQueryParameters(query *flags.QueryTemplat
 	}
 }
 
+func shouldIgnoreValue(v string) bool {
+	return v == "" || v == "-"
+}
+
 func (options CommonCommandOptions) AddQueryParametersWithMapping(query *flags.QueryTemplate, aliases map[string]string) {
 	if query == nil {
 		return
@@ -51,7 +55,9 @@ func (options CommonCommandOptions) AddQueryParametersWithMapping(query *flags.Q
 
 	if options.CurrentPage > 0 {
 		if alias, ok := aliases[flags.FlagCurrentPage]; ok {
-			query.SetVariable(alias, options.CurrentPage)
+			if !shouldIgnoreValue(alias) {
+				query.SetVariable(alias, options.CurrentPage)
+			}
 		} else {
 			query.SetVariable(flags.FlagCurrentPage, options.CurrentPage)
 		}
@@ -59,7 +65,9 @@ func (options CommonCommandOptions) AddQueryParametersWithMapping(query *flags.Q
 
 	if options.PageSize > 0 {
 		if alias, ok := aliases[flags.FlagPageSize]; ok {
-			query.SetVariable(alias, options.PageSize)
+			if !shouldIgnoreValue(alias) {
+				query.SetVariable(alias, options.PageSize)
+			}
 		} else {
 			query.SetVariable(flags.FlagPageSize, options.PageSize)
 		}
@@ -67,7 +75,9 @@ func (options CommonCommandOptions) AddQueryParametersWithMapping(query *flags.Q
 
 	if options.WithTotalPages {
 		if alias, ok := aliases[flags.FlagWithTotalPages]; ok {
-			query.SetVariable(alias, "true")
+			if !shouldIgnoreValue(alias) {
+				query.SetVariable(alias, "true")
+			}
 		} else {
 			query.SetVariable(flags.FlagWithTotalPages, "true")
 		}
@@ -75,7 +85,9 @@ func (options CommonCommandOptions) AddQueryParametersWithMapping(query *flags.Q
 
 	if options.WithTotalElements {
 		if alias, ok := aliases[flags.FlagWithTotalElements]; ok {
-			query.SetVariable(alias, "true")
+			if !shouldIgnoreValue(alias) {
+				query.SetVariable(alias, "true")
+			}
 		} else {
 			query.SetVariable(flags.FlagWithTotalElements, "true")
 		}

--- a/tests/manual/extensions/example/extension_example.yaml
+++ b/tests/manual/extensions/example/extension_example.yaml
@@ -12,3 +12,39 @@ tests:
   It supports subcommands:
     command: c8y kitchensink features
     exit-code: 0
+  
+  Default pagesize can be ignored:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_PAGESIZE: "10"
+    command: |
+      c8y kitchensink features disable_pageSize
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        pathEncoded: /inventory/managedObjects
+
+  Default pagesize can be mapped to another flag value:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_PAGESIZE: "10"
+    command: |
+      c8y kitchensink features map_pageSize_to_limit
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        pathEncoded: /inventory/managedObjects?limit=10
+
+  Manual pagesize is accepted and mapped to a custom query parameter:
+    config:
+      env:
+        C8Y_SETTINGS_DEFAULTS_PAGESIZE: "10"
+    command: |
+      c8y kitchensink features map_pageSize_to_limit --pageSize 11
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        pathEncoded: /inventory/managedObjects?limit=11

--- a/tests/testdata/extensions/c8y-kitchensink/api/features.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/features.yaml
@@ -90,3 +90,17 @@ commands:
       - name: usergroup
         type: usergroup[]
         description: Usergroup
+
+  - name: disable_pageSize
+    description: Common flags such as pageSize can be disabled
+    path: inventory/managedObjects
+    method: GET
+    flagMapping:
+      pageSize:
+
+  - name: map_pageSize_to_limit
+    description: Common flags such as pageSize can be disabled
+    path: inventory/managedObjects
+    method: GET
+    flagMapping:
+      pageSize: limit

--- a/tools/schema/extensionCommands.json
+++ b/tools/schema/extensionCommands.json
@@ -538,21 +538,11 @@
                         }
                     },
                     "flagMapping": {
-                        "type": "array",
-                        "title": "Common/global flag mapping",
-                        "description": "Customize where common flags are mapped to in the request, e.g. pageSize => limit",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "description": "Current property to map"
-                                },
-                                "property": {
-                                    "type": "string",
-                                    "description": "Value where the name should be mapped to"
-                                }
-                            }
+                        "type": "object",
+                        "title": "Custom flag mapping",
+                        "description": "Customize where common flags are mapped to in the request, e.g. pageSize => limit. Currently only used to map default query parameters such as pageSize. Set the value to '-' if you want the value to be ignored",
+                        "default": {
+                            "pageSize": ""
                         }
                     },
                     "headerParameters": {


### PR DESCRIPTION
Support mapping the `pageSize` query parameter to a custom query parameter, or ignore it completely.

Checkout the [documentation](https://goc8ycli.netlify.app/docs/concepts/extensions/api-commands/command-groups/#example-ignoring-or-mapping-the-pagesize-query-parameter-value) for the full example.

**Example: API Spec**

Below shows an example of the usage.

```yaml title="file: api/unicorns.yaml"
# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
---
group:
  name: unicorns
  description: Fetch different unicorns

commands:
  - name: list
    description: List unicorns
    method: GET
    path: service/unicorns/list
    flagMapping:
      pageSize:       # <== If the value is empty, then the `pageSize` query parameter will be ignored
  
  - name: listpaginated
    description: List unicorns that supports pagination
    method: GET
    path: service/unicorns/paginated
    flagMapping:
      pageSize: limit       # <== Map the `pageSize` value to the `limit` query parameter
```
