### PR TITLE
fix(build): align flag mapping used by internal spec to extension spec

### DIFF
--- a/api/spec/json/datahubConfiguration.json
+++ b/api/spec/json/datahubConfiguration.json
@@ -34,12 +34,9 @@
           }
         ]
       },
-      "flagMapping": [
-        {
-          "name": "pageSize",
-          "property": "limit"
-        }
-      ],
+      "flagMapping": {
+        "pageSize": "limit"
+      },
       "queryParameters": [
         {
           "name": "lastMaxReportedUUID",

--- a/api/spec/json/datahubJobs.json
+++ b/api/spec/json/datahubJobs.json
@@ -200,12 +200,9 @@
           ]
         }
       ],
-      "flagMapping": [
-        {
-          "name": "pageSize",
-          "property": "limit"
-        }
-      ],
+      "flagMapping": {
+        "pageSize": "limit"
+      },
       "queryParameters": [
         {
           "name": "offset",

--- a/api/spec/json/datahubScheduler.json
+++ b/api/spec/json/datahubScheduler.json
@@ -34,12 +34,9 @@
           }
         ]
       },
-      "flagMapping": [
-        {
-          "name": "pageSize",
-          "property": "limit"
-        }
-      ],
+      "flagMapping": {
+        "pageSize": "limit"
+      },
       "queryParameters": [
         {
           "name": "jobType",

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -542,20 +542,11 @@
             ]
           },
           "flagMapping": {
-            "type": "array",
-            "description": "Common flag mapping. Customize where common flags are mapped to, e.g. pageSize => limit",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Current property to map"
-                },
-                "property": {
-                  "type": "string",
-                  "description": "Value where the name should be mapped to"
-                }
-              }
+            "type": "object",
+            "title": "Custom flag mapping",
+            "description": "Customize where common flags are mapped to in the request, e.g. pageSize => limit. Currently only used to map default query parameters such as pageSize. Set the value to '-' if you want the value to be ignored",
+            "default": {
+              "pageSize": ""
             }
           },
           "headerParameters": {

--- a/api/spec/yaml/datahubConfiguration.yaml
+++ b/api/spec/yaml/datahubConfiguration.yaml
@@ -29,8 +29,7 @@ commands:
           command: c8y datahub configuration list
     
     flagMapping:
-      - name: pageSize
-        property: limit
+      pageSize: limit
 
     queryParameters:
       - name: lastMaxReportedUUID

--- a/api/spec/yaml/datahubJobs.yaml
+++ b/api/spec/yaml/datahubJobs.yaml
@@ -153,8 +153,7 @@ commands:
           - id
 
     flagMapping:
-      - name: pageSize
-        property: limit
+      pageSize: limit
 
     queryParameters:
       - name: offset

--- a/api/spec/yaml/datahubScheduler.yaml
+++ b/api/spec/yaml/datahubScheduler.yaml
@@ -32,8 +32,7 @@ commands:
           command: c8y datahub scheduler list
 
     flagMapping:
-      - name: pageSize
-        property: limit
+      pageSize: limit
 
     queryParameters:
       - name: jobType

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -445,8 +445,8 @@
         # Support mapping common flags to custom query parameters (e.g. if a service uses limit instead of pageSize)
         # but for consistency the flag --pageSize will still be used and mapped to 'limit'.
         if ($Specification.flagMapping) {
-            $flagAliases = foreach ($item in $Specification.flagMapping) {
-                "`"$($item.name)`":`"$($item.property)`""
+            $flagAliases = foreach ($item in $Specification.flagMapping.PSObject.Properties) {
+                "`"$($item.Name)`":`"$($item.Value)`""
             }
             $null = $RESTQueryBuilderPost.AppendLine("commonOptions.AddQueryParametersWithMapping(query, map[string]string{$($flagAliases -join ',')})")
         } else {


### PR DESCRIPTION
Fix a problem with the internal command specification introduced by https://github.com/reubenmiller/go-c8y-cli/pull/252

The internal command specification has been aligned to use the same data structure as the external api commands.