### PR TITLE
feat(extension): add `datetime_utc` type

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/04-parameter-types.md
+++ b/docs/go-c8y-cli/docs/concepts/extensions/02-api-commands/04-parameter-types.md
@@ -67,6 +67,7 @@ The following basic types are available for use.
 |Type|Description|Example usage|Example output|
 |----|----|----|----|
 |`datetime`|Relative or fixed date/time string| `--dateFrom -10d` |`"2023-04-27T22:52:06.622+02:00"`|
+|`datetime_utc`|Relative or fixed date/time string in UTC| `--dateFrom -10d` |`"2023-04-27T20:52:06.622Z"`|
 |`date`|Relative or fixed time string| `--dateFrom -10d` |`"2023-04-27"`|
 
 ### Numbers (integer/float)

--- a/pkg/c8ydata/c8ydata.go
+++ b/pkg/c8ydata/c8ydata.go
@@ -86,7 +86,7 @@ type TransformRelativeTimestamp struct {
 
 func (t *TransformRelativeTimestamp) Run(v interface{}) (resp interface{}, err error) {
 	if value, ok := v.(string); ok {
-		return timestamp.TryGetTimestamp(value, t.Encode)
+		return timestamp.TryGetTimestamp(value, t.Encode, false)
 	}
 	return
 }

--- a/pkg/c8ywaiter/alarms.go
+++ b/pkg/c8ywaiter/alarms.go
@@ -33,13 +33,13 @@ func (s *AlarmCount) Check(m interface{}) (done bool, err error) {
 	if mo, ok := m.(*c8y.ManagedObject); ok {
 		var dateFrom, dateTo string
 		if s.DateFrom != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false, false); err == nil {
 				dateFrom = v
 			}
 		}
 
 		if s.DateTo != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateTo, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateTo, false, false); err == nil {
 				dateTo = v
 			}
 		}

--- a/pkg/c8ywaiter/events.go
+++ b/pkg/c8ywaiter/events.go
@@ -30,13 +30,13 @@ func (s *EventCount) Check(m interface{}) (done bool, err error) {
 	if mo, ok := m.(*c8y.ManagedObject); ok {
 		var dateFrom, dateTo string
 		if s.DateFrom != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false, false); err == nil {
 				dateFrom = v
 			}
 		}
 
 		if s.DateTo != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateTo, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateTo, false, false); err == nil {
 				dateTo = v
 			}
 		}

--- a/pkg/c8ywaiter/measurements.go
+++ b/pkg/c8ywaiter/measurements.go
@@ -31,13 +31,13 @@ func (s *MeasurementCount) Check(m interface{}) (done bool, err error) {
 	if mo, ok := m.(*c8y.ManagedObject); ok {
 		var dateFrom, dateTo string
 		if s.DateFrom != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false, false); err == nil {
 				dateFrom = v
 			}
 		}
 
 		if s.DateTo != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateTo, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateTo, false, false); err == nil {
 				dateTo = v
 			}
 		}

--- a/pkg/c8ywaiter/operations.go
+++ b/pkg/c8ywaiter/operations.go
@@ -75,13 +75,13 @@ func (s *OperationCount) Check(m interface{}) (done bool, err error) {
 	if mo, ok := m.(*c8y.ManagedObject); ok {
 		var dateFrom, dateTo string
 		if s.DateFrom != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateFrom, false, false); err == nil {
 				dateFrom = v
 			}
 		}
 
 		if s.DateTo != "" {
-			if v, err := timestamp.TryGetTimestamp(s.DateTo, false); err == nil {
+			if v, err := timestamp.TryGetTimestamp(s.DateTo, false, false); err == nil {
 				dateTo = v
 			}
 		}

--- a/pkg/cmd/activitylog/list/list.manual.go
+++ b/pkg/cmd/activitylog/list/list.manual.go
@@ -84,7 +84,7 @@ func (n *CmdList) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if n.dateFrom != "" {
-		dateFrom, err := timestamp.TryGetTimestamp(n.dateFrom, false)
+		dateFrom, err := timestamp.TryGetTimestamp(n.dateFrom, false, false)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func (n *CmdList) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if n.dateTo != "" {
-		dateTo, err := timestamp.TryGetTimestamp(n.dateTo, false)
+		dateTo, err := timestamp.TryGetTimestamp(n.dateTo, false, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmdparser/cmdparser.go
+++ b/pkg/cmdparser/cmdparser.go
@@ -245,7 +245,7 @@ func AddFlag(cmd *CmdOptions, p *models.Parameter, factory *cmdutil.Factory) err
 	case "json":
 		// Ignore, as it is add by default to all PUT and POST requests
 
-	case "datefrom", "dateto", "datetime", "date":
+	case "datefrom", "dateto", "datetime", "date", "datetime_utc":
 		cmd.Command.Flags().StringP(p.Name, p.ShortName, p.Default, p.GetDescription())
 		p.PipelineAliases = append(p.PipelineAliases, "time", "creationTime", "creationTime", "lastUpdated")
 
@@ -372,6 +372,12 @@ func GetOption(cmd *CmdOptions, p *models.Parameter, factory *cmdutil.Factory, a
 			opts = append(opts, flags.WithEncodedRelativeTimestamp(p.Name, targetProp, p.Format))
 		} else {
 			opts = append(opts, flags.WithRelativeTimestamp(p.Name, targetProp, p.Format))
+		}
+	case "datetime_utc":
+		if p.TargetType == models.ParamPath || p.TargetType == models.ParamQueryParameter {
+			opts = append(opts, flags.WithEncodedRelativeTimestampUTC(p.Name, targetProp, p.Format))
+		} else {
+			opts = append(opts, flags.WithRelativeTimestampUTC(p.Name, targetProp, p.Format))
 		}
 	case "date":
 		opts = append(opts, flags.WithRelativeDate(false, p.Name, targetProp, p.Format))

--- a/pkg/iterator/time.go
+++ b/pkg/iterator/time.go
@@ -7,9 +7,9 @@ import (
 )
 
 // NewRelativeTimeIterator returns a relative time iterator which can generate timestamps based on time.Now when the value is retrieved
-func NewRelativeTimeIterator(relative string, encode bool, format ...string) *FuncIterator {
+func NewRelativeTimeIterator(relative string, encode bool, utc bool, format ...string) *FuncIterator {
 	next := func(i int64) (string, error) {
-		value, err := timestamp.TryGetTimestamp(relative, encode)
+		value, err := timestamp.TryGetTimestamp(relative, encode, utc)
 		if len(format) > 0 {
 			if format[0] != "" {
 				value = fmt.Sprintf(format[0], value)

--- a/pkg/iterator/time_test.go
+++ b/pkg/iterator/time_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_RelativeTimeIterator(t *testing.T) {
 
-	iter := NewRelativeTimeIterator("0s", false)
+	iter := NewRelativeTimeIterator("0s", false, false)
 
 	v1, _, err1 := iter.GetNext()
 	assert.OK(t, err1)
@@ -31,7 +31,7 @@ func Test_RelativeTimeIterator(t *testing.T) {
 
 func Test_RelativeTimeIteratorWithFormatter(t *testing.T) {
 
-	iter := NewRelativeTimeIterator("0s", false, "value gt '%s'")
+	iter := NewRelativeTimeIterator("0s", false, false, "value gt '%s'")
 
 	v1, _, err1 := iter.GetNext()
 	assert.OK(t, err1)

--- a/pkg/timestamp/timestamp.go
+++ b/pkg/timestamp/timestamp.go
@@ -57,14 +57,20 @@ func DecodeC8yTimestamp(value string) string {
 	return strings.ReplaceAll(value, "%2B", "+")
 }
 
-func TryGetTimestamp(value string, encode bool) (string, error) {
+func TryGetTimestamp(value string, encode bool, utc bool) (string, error) {
 	// Try parsing relative timestamp
 	if ts, err := ParseDurationRelativeToNow(value); err == nil {
+		if utc {
+			return FormatC8yTimestamp(ts.UTC(), encode), nil
+		}
 		return FormatC8yTimestamp(*ts, encode), nil
 	}
 
 	// Try parsing timestamp (if valid)
 	if timestamp, err := dateparse.ParseAny(value); err == nil {
+		if utc {
+			return FormatC8yTimestamp(timestamp.UTC(), encode), nil
+		}
 		return FormatC8yTimestamp(timestamp, encode), nil
 	}
 

--- a/tests/manual/extensions/example/extension_types.yaml
+++ b/tests/manual/extensions/example/extension_types.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+    C8Y_SETTINGS_DEFAULTS_DRY_FORMAT: json
+
+tests:
+  # datetime_utc
+  datetime_utc returns date in UTC:
+    command: |
+      c8y kitchensink types dates --dateFromUTC '2022-01-01T02:00:00+02' --dry --dryFormat json \
+      | c8y util show --select query,pathEncoded -o json
+    exit-code: 0
+    stdout:
+      json:
+        pathEncoded: /inventory/managedObjects?dateFromUTC=2022-01-01T00%3A00%3A00Z
+        query: dateFromUTC=2022-01-01T00:00:00Z

--- a/tests/testdata/extensions/c8y-kitchensink/api/types.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/types.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
+---
+group:
+  name: types
+  description: Example types
+
+commands:
+  - name: dates
+    path: inventory/managedObjects
+    method: GET
+    description: Get inventory list
+    queryParameters:
+      - name: dateFromUTC
+        type: datetime_utc
+        description: Date from

--- a/tools/schema/extensionCommands.json
+++ b/tools/schema/extensionCommands.json
@@ -250,6 +250,7 @@
                 "configurationDetails",
                 "date",
                 "datetime",
+                "datetime_utc",
                 "device[]",
                 "devicegroup[]",
                 "deviceprofile[]",


### PR DESCRIPTION
Add support for new `datetime_utc` type in API Command extensions. It generates a datetime from a fixed or relative string, and return the RFC3334 formatted time in UTC.