### PR TITLE
fix(extensions): honour query parameters which are marked as required

### DIFF
--- a/pkg/cmd/tenantstatistics/listdevicestatistics/listDeviceStatistics.auto.go
+++ b/pkg/cmd/tenantstatistics/listdevicestatistics/listDeviceStatistics.auto.go
@@ -94,7 +94,7 @@ func (n *ListDeviceStatisticsCmd) RunE(cmd *cobra.Command, args []string) error 
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
-		c8yfetcher.WithDeviceByNameFirstMatch(client, args, "deviceId", "deviceId"),
+		c8yfetcher.WithDeviceByNameFirstMatch(n.factory, args, "deviceId", "deviceId"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmdparser/cmdparser.go
+++ b/pkg/cmdparser/cmdparser.go
@@ -240,7 +240,7 @@ func AddFlag(cmd *CmdOptions, p *models.Parameter, factory *cmdutil.Factory) err
 	}
 	switch p.Type {
 	case "string", "stringStatic", "devicerequest", "json_custom", "directory", "softwareName", "softwareversionName", "softwareDetails", "firmwareName", "firmwareversionName", "firmwarepatchName", "firmwareDetails", "binaryUploadURL", "inventoryChildType", "subscriptionName", "subscriptionId", "file", "attachment", "fileContents", "fileContentsAsString", "certificatefile":
-		cmd.Command.Flags().StringP(p.Name, p.ShortName, p.Default, p.Description)
+		cmd.Command.Flags().StringP(p.Name, p.ShortName, p.Default, p.GetDescription())
 
 	case "json":
 		// Ignore, as it is add by default to all PUT and POST requests

--- a/tests/manual/extensions/example/extension_required.yaml
+++ b/tests/manual/extensions/example/extension_required.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+    C8Y_SETTINGS_DEFAULTS_DRY_FORMAT: json
+
+tests:
+  Should return an error if missing query parameters are not provided:
+    command: |
+      c8y kitchensink required queryparameters_withoutpipe
+    exit-code: 100
+    stderr:
+      contains:
+        - Missing required parameter. required_string
+
+  Should return an error if missing query parameters are not provided and not piped:
+    command: |
+      c8y kitchensink required queryparameters_withpipe
+    exit-code: 101
+    stderr:
+      contains:
+        - Missing required parameter. required_string
+
+  Should support piping to a required parameter:
+    command: |
+      echo testme | c8y kitchensink required queryparameters_withpipe
+    exit-code: 0
+    stdout:
+      json:
+        query: required_string=testme

--- a/tests/testdata/extensions/c8y-kitchensink/api/required.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/required.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/go-c8y-cli/v2/tools/schema/extensionCommands.json
+---
+group:
+  name: required
+  description: Example required
+
+commands:
+  - name: queryparameters_withoutpipe
+    path: inventory/managedObjects
+    method: GET
+    description: Get inventory list
+    queryParameters:
+      - name: required_string
+        type: string
+        pipeline: false
+        required: true
+        description: Date from
+
+      - name: option1
+        type: string
+        description: Option 1
+
+  - name: queryparameters_withpipe
+    path: inventory/managedObjects
+    method: GET
+    description: Get inventory list
+    queryParameters:
+      - name: required_string
+        type: string
+        pipeline: true
+        required: true
+        description: Date from


### PR DESCRIPTION
Fix the handling of query parameters which are marked as honoured. Previously this property was not being enforced for queryParameters and headerParameters (though it worked for both path and body).

Resolves #254