### PR TITLE
docs: fix powershell code block translation errors

### DIFF
--- a/docs/go-c8y-cli/src/components/CodeBlock.jsx
+++ b/docs/go-c8y-cli/src/components/CodeBlock.jsx
@@ -15,6 +15,7 @@ const c8yCommands = {
     'c8y alarms delete': 'Remove-Alarm',
     'c8y alarms subscribe': 'Watch-Alarm',
     'c8y alarms list': 'Get-AlarmCollection',
+    'c8y alarms count': 'Get-AlarmCount',
 
     // events
     'c8y events create': 'New-Event',
@@ -99,7 +100,7 @@ const c8yCommands = {
 };
 
 const powershellCommands = {
-    'rm': 'Remove-Item',
+    'rm ': 'Remove-Item ',
 };
 
 function replaceAll(string, search, replace) {
@@ -122,7 +123,7 @@ function transformToPowerShell(code = '') {
     if (parts.length) {
         for (let i = 0; i < parts.length; i++) {
             if (parts[i].startsWith('--')) {
-                parts[i] = '-' + parts[i].substring(2, 1).toUpperCase() + parts[i].substring(3)
+                parts[i] = '-' + parts[i].substring(2, 3).toUpperCase() + parts[i].substring(3)
             } else if (parts[i].startsWith('-')) {
             }
         }


### PR DESCRIPTION
The error resulted in the powershell code blocks with mangled parameters due to a substring error after refactoring.

The automatic mapping of linux commands to powershell commands would result in a lot of false positives. For example the `rm` command translation to `Remove-Item` was matching inside the `c8y alarms` command.

**Example**

A translation errors would result in the following mangled powershell commands as below:

```powershell
Get-AlaRemove-ItemCollection --ateFrom "-30d"
```

Now, the powershell snippet will be displayed correctly:

```powershell
Get-AlarmCollection -DateFrom "-30d"
```