### PR TITLE
feat(set-session): store and display c8y api version used in session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.14.2
+	github.com/reubenmiller/go-c8y v0.14.4
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reubenmiller/go-c8y v0.14.2 h1:Nm0Iwv9q5z28F2zA7foY+Ic0NdcE3ItVik1uF5dEiO8=
-github.com/reubenmiller/go-c8y v0.14.2/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
+github.com/reubenmiller/go-c8y v0.14.4 h1:9Re48V0sxvWAh0eayHPJDwEEdxnvgRvm5kWFrnSx3Ms=
+github.com/reubenmiller/go-c8y v0.14.4/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -452,6 +452,15 @@ func (lh *LoginHandler) verify() {
 			lh.state <- LoginStateAuth
 			lh.Logger.Infof("Detected tenant: %s", tenant.Name)
 			lh.C8Yclient.TenantName = tenant.Name
+
+			// Get Cumulocity system version
+			if lh.C8Yclient.Version == "" {
+				if version, err := lh.C8Yclient.TenantOptions.GetVersion(context.Background()); err == nil {
+					lh.C8Yclient.Version = version
+				} else {
+					lh.Logger.Warnf("Could not get Cumulocity IoT System version. %s", err)
+				}
+			}
 		}
 		return err
 	})

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -23,6 +23,7 @@ type CumulocitySession struct {
 	// ID          string `json:"id"`
 	Host            string `json:"host"`
 	Tenant          string `json:"tenant"`
+	Version         string `json:"version"`
 	Username        string `json:"username"`
 	Password        string `json:"password"`
 	Token           string `json:"token"`
@@ -98,6 +99,9 @@ func PrintSessionInfo(w io.Writer, client *c8y.Client, cfg *config.Config, sessi
 	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "host")), value(cfg.HideSensitiveInformationIfActive(client, session.Host)))
 	if session.Tenant != "" {
 		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "tenant")), value(cfg.HideSensitiveInformationIfActive(client, session.Tenant)))
+	}
+	if session.Version != "" {
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "version")), value(cfg.HideSensitiveInformationIfActive(client, session.Version)))
 	}
 	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "username")), value(cfg.HideSensitiveInformationIfActive(client, session.Username)))
 	fmt.Fprintf(w, "\n")

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -200,6 +200,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		Path:     cfg.GetSessionFile(),
 		Host:     handler.C8Yclient.BaseURL.Host,
 		Tenant:   cfg.GetTenant(),
+		Version:  cfg.GetCumulocityVersion(),
 		Username: handler.C8Yclient.Username,
 	})
 
@@ -216,6 +217,10 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 
 func hasChanged(client *c8y.Client, cfg *config.Config) bool {
 	if client.TenantName != "" && client.TenantName != cfg.GetTenant() {
+		return true
+	}
+
+	if client.Version != "" && client.Version != cfg.GetCumulocityVersion() {
 		return true
 	}
 

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -681,6 +681,7 @@ func (c Config) GetEnvironmentVariables(client *c8y.Client, setPassword bool) ma
 	host := c.GetHost()
 	domain := c.GetDomain()
 	tenant := c.GetTenant()
+	c8yVersion := c.GetCumulocityVersion()
 	username := c.GetUsername()
 	password := c.MustGetPassword()
 	token := c.MustGetToken()
@@ -724,6 +725,7 @@ func (c Config) GetEnvironmentVariables(client *c8y.Client, setPassword bool) ma
 		"C8Y_HOST":                 host,
 		"C8Y_DOMAIN":               domain,
 		"C8Y_TENANT":               tenant,
+		"C8Y_VERSION":              c8yVersion,
 		"C8Y_USER":                 username,
 		"C8Y_TOKEN":                token,
 		"C8Y_USERNAME":             username,
@@ -883,6 +885,16 @@ func (c *Config) MustGetToken() string {
 		c.Logger.Warningf("Could not decrypt token. %s", err)
 	}
 	return decryptedValue
+}
+
+// SetCumulocityVersion sets the Cumulocity version
+func (c *Config) SetCumulocityVersion(p string) {
+	c.Persistent.Set("version", p)
+}
+
+// GetCumulocityVersion gets Cumulocity version
+func (c *Config) GetCumulocityVersion() string {
+	return c.Persistent.GetString("version")
 }
 
 // SetPassword sets the password
@@ -1561,6 +1573,10 @@ func (c *Config) SaveClientConfig(client *c8y.Client) error {
 			c.SetToken(client.Token)
 		}
 		c.SetTenant(client.TenantName)
+
+		if client.Version != "" {
+			c.SetCumulocityVersion(client.Version)
+		}
 	}
 	return c.WritePersistentConfig()
 }


### PR DESCRIPTION
Display c8y api version when setting a session (`set-session`).

In additional to displaying the c8y api version the following actions are also done:

* Set the `C8Y_VERSION` environment variable when loading a session (for easy of access)
* Store c8y api version in the session file under `.version` (to allow users to check the last known version information)

**Example**

```sh
set-session runner
```

```text
---------------------  Cumulocity Session  ---------------------

    path: /Users/reubenmiller/.cumulocity/mytenant.json


host         : example.c8y.com
tenant       : t12345
version      : 1016.0.214
username     : myuser
```