### PR TITLE
fix(api): extend host parsing to infer scheme and fallback to a sensible default

### DIFF
--- a/pkg/url/format.go
+++ b/pkg/url/format.go
@@ -1,0 +1,34 @@
+package url
+
+import (
+	"net/url"
+	"strings"
+)
+
+func ParseURL(value string) (*url.URL, error) {
+	if !strings.Contains(value, "//") {
+		value = "//" + value
+	}
+
+	u, err := url.Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme == "" {
+		switch u.Port() {
+		case "443":
+			u.Scheme = "https"
+			u.Host = u.Hostname()
+		case "":
+			u.Scheme = "https"
+		case "80":
+			u.Scheme = "http"
+			u.Host = u.Hostname()
+		default:
+			u.Scheme = "http"
+		}
+	}
+
+	return u, nil
+}

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -217,3 +217,43 @@ tests:
       command: |
         c8y api POST /inventory/managedObjects --data name=test --select id,name --dry=false | c8y inventory delete
       exit-code: 0
+
+  It supports a custom host flag without scheme:
+      command: |
+        c8y api --url "/inventory" --host localhost/service --dry
+      exit-code: 0
+      stdout:
+          json:
+              method: GET
+              path: /service/inventory
+              host: https://localhost
+
+  It supports a custom host flag with only port number:
+      command: |
+        c8y api --url "/inventory" --host localhost:80/service --dry
+      exit-code: 0
+      stdout:
+          json:
+              method: GET
+              path: /service/inventory
+              host: http://localhost
+  
+  It supports a custom host flag with 443 port:
+      command: |
+        c8y api --url "/inventory" --host localhost:443/service --dry
+      exit-code: 0
+      stdout:
+          json:
+              method: GET
+              path: /service/inventory
+              host: https://localhost
+
+  It supports a custom host flag with custom url with schema and port:
+      command: |
+        c8y api --url "/inventory" --host https://localhost:8080/service --dry
+      exit-code: 0
+      stdout:
+          json:
+              method: GET
+              path: /service/inventory
+              host: https://localhost:8080


### PR DESCRIPTION
Allow users to leave out the scheme (e.g. `http://` or `https://`) from the `host` flag when using the `c8y api` command.

If the user provides a host with a port but does not provide a scheme, then port `80` will be automatically mapped to `http` and port `443` or an empty port will be mapped to `https`. Remember you can always control the exact scheme by using a prefix in the `host` flag.

**Examples**

Below shows some examples showing how the mapping is done:

```sh
c8y api --url "/inventory" --host localhost:443/service --dry
# => What If: Sending [GET] request to [https://localhost/service/inventory]

c8y api --url "/inventory" --host localhost/service --dry
# => What If: Sending [GET] request to [https://localhost/service/inventory]

c8y api --url "/inventory" --host localhost:80/service --dry
# => What If: Sending [GET] request to [http://localhost/service/inventory]

c8y api --url "/inventory" --host https://localhost:443/service --dry
# => What If: Sending [GET] request to [https://localhost:443/service/inventory]
```