### PR TITLE
fix(session): prevent panics when the session url only contains whitespace

### DIFF
--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -29,7 +29,7 @@ var EnvCumulocityHostNames = []string{
 func GetHostFromEnvironment() string {
 	var value = ""
 	for _, name := range EnvCumulocityHostNames {
-		value = os.Getenv(name)
+		value = strings.TrimSpace(os.Getenv(name))
 		if value != "" {
 			break
 		}
@@ -146,6 +146,14 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 
 		if domain := cfg.GetDomain(); domain != "" {
 			client.SetDomain(domain)
+		}
+
+		if client == nil {
+			return nil, fmt.Errorf("failed to create client")
+		}
+
+		if client.BaseURL == nil {
+			return nil, fmt.Errorf("invalid client url")
 		}
 
 		client.SetRequestOptions(c8y.DefaultRequestOptions{

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -562,7 +562,7 @@ func (c *Config) GetTenant() string {
 
 // GetHost returns the Cumulocity host URL
 func (c *Config) GetHost() string {
-	return c.viper.GetString("host")
+	return strings.TrimSpace(c.viper.GetString("host"))
 }
 
 // GetDomain gets the custom Cumulocity domain for cases where it differs from the Host

--- a/tests/manual/sessions/sessions_set.yaml
+++ b/tests/manual/sessions/sessions_set.yaml
@@ -183,3 +183,25 @@ tests:
     stdout:
       exactly: |
         {"defaults":{"pagesize":110},"includeall":{"pagesize":202}}
+
+  It does not panic when the url is only contains whitespace:
+    config:
+      env:
+        C8Y_HOST: ' '
+        C8Y_URL: ''
+        C8Y_BASEURL: ''
+        C8Y_SESSION: ''
+        C8Y_USER: ''
+        C8Y_USERNAME: ''
+        C8Y_TENANT: ''
+        C8Y_TOKEN: ''
+        C8Y_PASSWORD: ''
+      inherit-env: false
+    command: |
+      c8y devices list
+    exit-code: 102
+    stderr:
+      not-contains:
+        - panic
+      contains:
+        - A c8y session has not been loaded. Please create or activate a session and try again


### PR DESCRIPTION
A url that only contains whitespace is treated the same as an empty url.

The following no longer panics:

```sh
clear-session

# The command below previously would panic
env C8Y_HOST=' ' c8y devices list
```