### PR TITLE
feat: session improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.14.6
+	github.com/reubenmiller/go-c8y v0.14.7
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.14.7
+	github.com/reubenmiller/go-c8y v0.14.9
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reubenmiller/go-c8y v0.14.6 h1:F1X6kFc+n9rnFs0bC446kzWQW4hdKjeFhiASG9m19Hs=
-github.com/reubenmiller/go-c8y v0.14.6/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
+github.com/reubenmiller/go-c8y v0.14.7 h1:Yw0EfXpnrxw2H/VVCxXnt7zgijjxnJFDYEonkknns3Q=
+github.com/reubenmiller/go-c8y v0.14.7/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reubenmiller/go-c8y v0.14.7 h1:Yw0EfXpnrxw2H/VVCxXnt7zgijjxnJFDYEonkknns3Q=
-github.com/reubenmiller/go-c8y v0.14.7/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
+github.com/reubenmiller/go-c8y v0.14.9 h1:rS9uS4jeLf2whaq7vS7+XfdF3tfNuRcNp7P4IEMj68s=
+github.com/reubenmiller/go-c8y v0.14.9/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/c8yfetcher/agentFetcher.manual.go
+++ b/pkg/c8yfetcher/agentFetcher.manual.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ func NewAgentFetcher(factory *cmdutil.Factory) *AgentFetcher {
 
 func (f *AgentFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.Client().Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -42,7 +43,7 @@ func (f *AgentFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *AgentFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	mcol, _, err := f.Client().Inventory.GetManagedObjects(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ManagedObjectOptions{
 			// fmt.Sprintf("$filter=%s+$orderby=name", filter)
 			Query:             fmt.Sprintf("$filter=has(com_cumulocity_model_Agent) and name eq '%s' $orderby=name", name),

--- a/pkg/c8yfetcher/applicationFetcher.go
+++ b/pkg/c8yfetcher/applicationFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ func NewApplicationFetcher(factory *cmdutil.Factory) *ApplicationFetcher {
 
 func (f *ApplicationFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	app, resp, err := f.Client().Application.GetApplication(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -42,7 +43,7 @@ func (f *ApplicationFetcher) getByID(id string) ([]fetcherResultSet, error) {
 // getByName returns applications matching a given using regular expression
 func (f *ApplicationFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	col, _, err := f.Client().Application.GetApplications(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ApplicationOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(2000),
 		},

--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -61,12 +61,6 @@ type idValue struct {
 	raw string
 }
 
-func WithDisabledDryRunContext(c *c8y.Client) context.Context {
-	return c.Context.CommonOptions(c8y.CommonOptions{
-		DryRun: false,
-	})
-}
-
 // NewIDValue returns a new id formatter
 // Example: NewIDValue("12345|deviceName")
 func NewIDValue(raw string) *idValue {
@@ -556,7 +550,7 @@ func WithManagedObjectPropertyFirstMatch(factory *cmdutil.Factory, fetcher Entit
 			}
 
 			moID := NewIDValue(v[0]).GetID()
-			mo, _, err := client.Inventory.GetManagedObject(WithDisabledDryRunContext(client), moID, nil)
+			mo, _, err := client.Inventory.GetManagedObject(c8y.WithDisabledDryRunContext(context.Background()), moID, nil)
 
 			value := mo.Item.Get(property)
 			if !value.Exists() {
@@ -734,7 +728,7 @@ func WithSoftwareVersionData(factory *cmdutil.Factory, flagSoftware, flagVersion
 
 		// Check for explicit managed object id
 		if IsID(version) {
-			mo, _, err := client.Inventory.GetManagedObject(WithDisabledDryRunContext(client), version, &c8y.ManagedObjectOptions{
+			mo, _, err := client.Inventory.GetManagedObject(c8y.WithDisabledDryRunContext(context.Background()), version, &c8y.ManagedObjectOptions{
 				WithParents: true,
 			})
 
@@ -750,7 +744,7 @@ func WithSoftwareVersionData(factory *cmdutil.Factory, flagSoftware, flagVersion
 		}
 
 		// Lookup version (and software if not already resolved)
-		versionCol, _, err := client.Software.GetSoftwareVersionsByName(WithDisabledDryRunContext(client), software, version, true, c8y.NewPaginationOptions(5))
+		versionCol, _, err := client.Software.GetSoftwareVersionsByName(c8y.WithDisabledDryRunContext(context.Background()), software, version, true, c8y.NewPaginationOptions(5))
 		if err != nil {
 			return "", "", err
 		}
@@ -860,7 +854,7 @@ func WithFirmwareVersionData(factory *cmdutil.Factory, flagFirmware, flagVersion
 
 		// Check for explicit managed object id
 		if IsID(version) {
-			mo, _, err := client.Inventory.GetManagedObject(WithDisabledDryRunContext(client), version, &c8y.ManagedObjectOptions{
+			mo, _, err := client.Inventory.GetManagedObject(c8y.WithDisabledDryRunContext(context.Background()), version, &c8y.ManagedObjectOptions{
 				WithParents: true,
 			})
 
@@ -876,7 +870,7 @@ func WithFirmwareVersionData(factory *cmdutil.Factory, flagFirmware, flagVersion
 		}
 
 		// Lookup version (and software if not already resolved)
-		versionCol, _, err := client.Firmware.GetFirmwareVersionsByName(WithDisabledDryRunContext(client), firmware, version, true, c8y.NewPaginationOptions(5))
+		versionCol, _, err := client.Firmware.GetFirmwareVersionsByName(c8y.WithDisabledDryRunContext(context.Background()), firmware, version, true, c8y.NewPaginationOptions(5))
 		if err != nil {
 			return "", "", err
 		}
@@ -942,7 +936,7 @@ func WithConfigurationFileData(factory *cmdutil.Factory, flagConfiguration, flag
 
 		// Check for explicit managed object id
 		if IsID(configuration) {
-			mo, _, err := client.Inventory.GetManagedObject(WithDisabledDryRunContext(client), configuration, &c8y.ManagedObjectOptions{
+			mo, _, err := client.Inventory.GetManagedObject(c8y.WithDisabledDryRunContext(context.Background()), configuration, &c8y.ManagedObjectOptions{
 				WithParents: true,
 			})
 
@@ -963,7 +957,7 @@ func WithConfigurationFileData(factory *cmdutil.Factory, flagConfiguration, flag
 			query += fmt.Sprintf(" and configurationType eq '%s'", configurationType)
 		}
 		col, _, err := client.Inventory.GetManagedObjects(
-			WithDisabledDryRunContext(client),
+			c8y.WithDisabledDryRunContext(context.Background()),
 			&c8y.ManagedObjectOptions{
 				Query:             query,
 				WithParents:       false,

--- a/pkg/c8yfetcher/childAdditionFetcher.go
+++ b/pkg/c8yfetcher/childAdditionFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 )
@@ -21,7 +22,7 @@ func NewChildAdditionFetcher(client *c8y.Client, parentID string) *ChildAddition
 
 func (f *ChildAdditionFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.client.Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.client),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -45,7 +46,7 @@ func (f *ChildAdditionFetcher) getByName(name string) ([]fetcherResultSet, error
 		query = f.Query(name)
 	}
 	mcol, _, err := f.client.Inventory.GetChildAdditions(
-		WithDisabledDryRunContext(f.client),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		f.parentID,
 		&c8y.ManagedObjectOptions{
 			Query:             query,

--- a/pkg/c8yfetcher/deviceCertificateFetcher.go
+++ b/pkg/c8yfetcher/deviceCertificateFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -36,7 +37,7 @@ func (f *DeviceCertificateFetcher) IsID(id string) bool {
 
 func (f *DeviceCertificateFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	cert, resp, err := f.Client().DeviceCertificate.GetCertificate(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -57,7 +58,7 @@ func (f *DeviceCertificateFetcher) getByID(id string) ([]fetcherResultSet, error
 func (f *DeviceCertificateFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	// check if already resolved, so we can save a lookup
 	col, _, err := f.Client().DeviceCertificate.GetCertificates(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.DeviceCertificateCollectionOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(100),
 		},

--- a/pkg/c8yfetcher/deviceFetcher.go
+++ b/pkg/c8yfetcher/deviceFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -20,7 +21,7 @@ func NewDeviceFetcher(factory *cmdutil.Factory) *DeviceFetcher {
 
 func (f *DeviceFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.Client().Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -40,7 +41,7 @@ func (f *DeviceFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *DeviceFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	mcol, _, err := f.Client().Inventory.GetDevicesByName(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		name,
 		c8y.NewPaginationOptions(5),
 	)

--- a/pkg/c8yfetcher/deviceGroupFetcher.go
+++ b/pkg/c8yfetcher/deviceGroupFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ func NewDeviceGroupFetcher(factory *cmdutil.Factory) *DeviceGroupFetcher {
 
 func (f *DeviceGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.Client().Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -42,7 +43,7 @@ func (f *DeviceGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *DeviceGroupFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	mcol, _, err := f.Client().Inventory.GetManagedObjects(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ManagedObjectOptions{
 			Query:             fmt.Sprintf("has(c8y_IsDeviceGroup) and name eq '%s'", name),
 			PaginationOptions: *c8y.NewPaginationOptions(5),

--- a/pkg/c8yfetcher/deviceProfileFetcher.go
+++ b/pkg/c8yfetcher/deviceProfileFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ func NewDeviceProfileFetcher(factory *cmdutil.Factory) *DeviceProfileFetcher {
 
 func (f *DeviceProfileFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.Client().Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -42,7 +43,7 @@ func (f *DeviceProfileFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *DeviceProfileFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	mcol, _, err := f.Client().Inventory.GetManagedObjects(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ManagedObjectOptions{
 			Query:             fmt.Sprintf("(type eq 'c8y_Profile') and name eq '%s'", name),
 			PaginationOptions: *c8y.NewPaginationOptions(5),

--- a/pkg/c8yfetcher/deviceServiceFetcher.go
+++ b/pkg/c8yfetcher/deviceServiceFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
@@ -26,7 +27,7 @@ func NewDeviceServiceFetcher(factory *cmdutil.Factory, device string) *DeviceSer
 
 				if !IsID(device) {
 					// Lookup software by name
-					moDevice, _, err := client.Inventory.GetDevicesByName(WithDisabledDryRunContext(client), device, &c8y.PaginationOptions{
+					moDevice, _, err := client.Inventory.GetDevicesByName(c8y.WithDisabledDryRunContext(context.Background()), device, &c8y.PaginationOptions{
 						PageSize: 5,
 					})
 					if err == nil && moDevice != nil && len(moDevice.ManagedObjects) > 0 {

--- a/pkg/c8yfetcher/firmwareVersionFetcher.go
+++ b/pkg/c8yfetcher/firmwareVersionFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
@@ -27,7 +28,7 @@ func NewFirmwareVersionFetcher(factory *cmdutil.Factory, firmware string, includ
 					firmwareID = firmware
 				} else {
 					// Lookup firmware by name
-					res, _, err := client.Firmware.GetFirmwareByName(WithDisabledDryRunContext(client), firmware, c8y.NewPaginationOptions(5))
+					res, _, err := client.Firmware.GetFirmwareByName(c8y.WithDisabledDryRunContext(context.Background()), firmware, c8y.NewPaginationOptions(5))
 					if err == nil && len(res.ManagedObjects) > 0 {
 						firmwareID = res.ManagedObjects[0].ID
 					}

--- a/pkg/c8yfetcher/hostedApplicationFetcher.go
+++ b/pkg/c8yfetcher/hostedApplicationFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -25,7 +26,7 @@ func NewHostedApplicationFetcher(factory *cmdutil.Factory, excludeParentTenant b
 
 func (f *HostedApplicationFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	app, resp, err := f.Client().Application.GetApplication(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -45,7 +46,7 @@ func (f *HostedApplicationFetcher) getByID(id string) ([]fetcherResultSet, error
 // getByName returns applications matching a given using regular expression
 func (f *HostedApplicationFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	col, _, err := f.Client().Application.GetApplications(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ApplicationOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(2000),
 

--- a/pkg/c8yfetcher/managedObjectFetcher.go
+++ b/pkg/c8yfetcher/managedObjectFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -23,7 +24,7 @@ func NewManagedObjectFetcher(factory *cmdutil.Factory) *ManagedObjectFetcher {
 
 func (f *ManagedObjectFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.Client().Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -47,7 +48,7 @@ func (f *ManagedObjectFetcher) getByName(name string) ([]fetcherResultSet, error
 		query = f.Query(name)
 	}
 	mcol, _, err := f.Client().Inventory.GetManagedObjects(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ManagedObjectOptions{
 			Query:             query,
 			PaginationOptions: *c8y.NewPaginationOptions(5),

--- a/pkg/c8yfetcher/microserviceFetcher.go
+++ b/pkg/c8yfetcher/microserviceFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
@@ -23,7 +24,7 @@ func NewMicroserviceFetcher(factory *cmdutil.Factory) *MicroserviceFetcher {
 
 func (f *MicroserviceFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	app, resp, err := f.Client().Application.GetApplication(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -43,7 +44,7 @@ func (f *MicroserviceFetcher) getByID(id string) ([]fetcherResultSet, error) {
 // getByName returns applications matching a given using regular expression
 func (f *MicroserviceFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	col, _, err := f.Client().Application.GetApplications(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ApplicationOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(2000),
 

--- a/pkg/c8yfetcher/roleFetcher.go
+++ b/pkg/c8yfetcher/roleFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -35,7 +36,7 @@ func (f *RoleFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	}
 
 	role, resp, err := f.Client().User.GetRole(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -66,7 +67,7 @@ func (f *RoleFetcher) getByName(name string) ([]fetcherResultSet, error) {
 		}, nil
 	}
 	roles, _, err := f.Client().User.GetRoles(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.RoleOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(100),
 		},

--- a/pkg/c8yfetcher/smartGroupFetcher.manual.go
+++ b/pkg/c8yfetcher/smartGroupFetcher.manual.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ func NewSmartGroupFetcher(factory *cmdutil.Factory) *SmartGroupFetcher {
 
 func (f *SmartGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	mo, resp, err := f.Client().Inventory.GetManagedObject(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 		nil,
 	)
@@ -42,7 +43,7 @@ func (f *SmartGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *SmartGroupFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	mcol, _, err := f.Client().Inventory.GetManagedObjects(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ManagedObjectOptions{
 			Query:             fmt.Sprintf("type eq 'c8y_DynamicGroup' and name eq '%s'", name),
 			PaginationOptions: *c8y.NewPaginationOptions(5),

--- a/pkg/c8yfetcher/softwareVersionFetcher.go
+++ b/pkg/c8yfetcher/softwareVersionFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
@@ -26,7 +27,7 @@ func NewSoftwareVersionFetcher(factory *cmdutil.Factory, software string) *Softw
 
 				if !IsID(software) {
 					// Lookup software by name
-					moSoftware, _, err := client.Software.GetSoftwareByName(WithDisabledDryRunContext(client), software, &c8y.PaginationOptions{
+					moSoftware, _, err := client.Software.GetSoftwareByName(c8y.WithDisabledDryRunContext(context.Background()), software, &c8y.PaginationOptions{
 						PageSize: 5,
 					})
 					if err == nil && moSoftware != nil && len(moSoftware.ManagedObjects) > 0 {

--- a/pkg/c8yfetcher/userFetcher.go
+++ b/pkg/c8yfetcher/userFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -24,7 +25,7 @@ func NewUserFetcher(factory *cmdutil.Factory) *UserFetcher {
 
 func (f *UserFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	user, resp, err := f.Client().User.GetUser(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -43,7 +44,7 @@ func (f *UserFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *UserFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	users, _, err := f.Client().User.GetUsers(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.UserOptions{
 			Username:          strings.ReplaceAll(name, "*", ""),
 			PaginationOptions: *c8y.NewPaginationOptions(5),

--- a/pkg/c8yfetcher/userGroupFetcher.go
+++ b/pkg/c8yfetcher/userGroupFetcher.go
@@ -1,6 +1,7 @@
 package c8yfetcher
 
 import (
+	"context"
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/matcher"
@@ -21,7 +22,7 @@ func NewUserGroupFetcher(factory *cmdutil.Factory) *UserGroupFetcher {
 
 func (f *UserGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	group, resp, err := f.Client().User.GetGroup(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		id,
 	)
 
@@ -40,7 +41,7 @@ func (f *UserGroupFetcher) getByID(id string) ([]fetcherResultSet, error) {
 
 func (f *UserGroupFetcher) getByName(name string) ([]fetcherResultSet, error) {
 	groups, _, err := f.Client().User.GetGroups(
-		WithDisabledDryRunContext(f.Client()),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.GroupOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(2000),
 		},

--- a/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
+++ b/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
@@ -285,7 +285,7 @@ func (n *CmdCreateHostedApplication) RunE(cmd *cobra.Command, args []string) err
 		// Get existing application
 		log.Infof("Getting existing application. id=%s", applicationID)
 		application, response, err = client.Application.GetApplication(
-			c8yfetcher.WithDisabledDryRunContext(client),
+			c8y.WithDisabledDryRunContext(context.Background()),
 			applicationID,
 		)
 

--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -203,6 +203,17 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 				client.Realtime.SetXSRFToken(client.GetXSRFToken())
 			}
 		}
+
+		if client.TenantName == "" {
+			// Set the tenant either from token, or by looking it up as the tenant is required for a lot of API calls
+			log.Debug("Looking up tenant name as it is not set (it is required by some API)")
+			client.TenantName = client.GetTenantName()
+
+			if client.TenantName == "" {
+				log.Warn("Failed to lookup tenant name. API calls which require the tenant name will not work!")
+			}
+		}
+
 		return client, nil
 	}
 }

--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -207,10 +208,10 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 		if client.TenantName == "" {
 			// Set the tenant either from token, or by looking it up as the tenant is required for a lot of API calls
 			log.Debug("Looking up tenant name as it is not set (it is required by some API)")
-			client.TenantName = client.GetTenantName()
+			client.TenantName = client.GetTenantName(c8y.WithDisabledDryRunContext(context.Background()))
 
 			if client.TenantName == "" {
-				log.Warn("Failed to lookup tenant name. API calls which require the tenant name will not work!")
+				log.Info("Failed to lookup tenant name. API calls which require the tenant name will not work!")
 			}
 		}
 

--- a/pkg/cmd/sessions/get/get.manual.go
+++ b/pkg/cmd/sessions/get/get.manual.go
@@ -66,7 +66,7 @@ func (n *CmdGetSession) RunE(cmd *cobra.Command, args []string) error {
 	// Support looking up a session which is only controlled via env variables
 	if sessionPath == "" && client != nil {
 		cfg.Persistent.Set("host", client.GetHostname())
-		cfg.Persistent.Set("tenant", client.GetTenantName())
+		cfg.Persistent.Set("tenant", client.TenantName)
 		cfg.Persistent.Set("username", client.GetUsername())
 
 		version := client.Version

--- a/pkg/cmd/sessions/selectsession/selectsession.go
+++ b/pkg/cmd/sessions/selectsession/selectsession.go
@@ -190,12 +190,15 @@ func SelectSession(io *iostreams.IOStreams, cfg *config.Config, log *logger.Logg
 	var idx int
 	var result string
 
-	if len(filteredSessions) == 1 {
+	switch len(filteredSessions) {
+	case 0:
+		return "", fmt.Errorf("no sessions found")
+	case 1:
 		log.Info("Only 1 session found. Selecting it automatically")
 		idx = 0
 		result = filteredSessions[0].Path
 		err = nil
-	} else {
+	default:
 		// Prevent wrapping errors as promptui expects all templates to only take
 		// up one line. When multiline templates are supported by promptui, then this can be removed
 		// https://github.com/manifoldco/promptui/issues/92

--- a/pkg/completion/application.go
+++ b/pkg/completion/application.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -19,7 +20,7 @@ func WithApplication(flagName string, clientFunc func() (*c8y.Client, error)) Op
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			items, _, err := client.Application.GetApplications(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.ApplicationOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},
@@ -51,7 +52,7 @@ func WithApplicationContext(flagName string, clientFunc func() (*c8y.Client, err
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			items, _, err := client.Application.GetApplications(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.ApplicationOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},
@@ -83,7 +84,7 @@ func WithHostedApplication(flagName string, clientFunc func() (*c8y.Client, erro
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			items, _, err := client.Application.GetApplications(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.ApplicationOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},
@@ -142,7 +143,7 @@ func WithMicroservice(flagName string, clientFunc func() (*c8y.Client, error)) O
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			items, _, err := client.Application.GetApplications(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.ApplicationOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},
@@ -184,7 +185,7 @@ func WithMicroserviceLoggers(flagName string, flagNameMicroserviceName string, c
 
 			values := []string{}
 			resp, err := client.SendRequest(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				c8y.RequestOptions{
 					Method: "GET",
 					Path:   "/service/" + microserviceName + "/loggers",
@@ -213,7 +214,7 @@ func WithMicroserviceLoggers(flagName string, flagNameMicroserviceName string, c
 
 func getMicroserviceByName(client *c8y.Client, name string) (string, error) {
 	apps, _, err := client.Application.GetApplicationsByName(
-		WithDisabledDryRunContext(client),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		name,
 		&c8y.ApplicationOptions{
 			Type:              c8y.ApplicationTypeMicroservice,
@@ -257,7 +258,7 @@ func getMicroserviceInstances(cmd *cobra.Command, flagApplicationID string, clie
 
 	pattern := "*" + toComplete + "*"
 	items, _, err := client.Inventory.GetManagedObjects(
-		WithDisabledDryRunContext(client),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		&c8y.ManagedObjectOptions{
 			Type:              "c8y_Application_" + deviceID,
 			PaginationOptions: *c8y.NewPaginationOptions(1),

--- a/pkg/completion/certificate.go
+++ b/pkg/completion/certificate.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -16,7 +17,7 @@ func WithDeviceCertificate(flagName string, clientFunc func() (*c8y.Client, erro
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			items, _, err := client.DeviceCertificate.GetCertificates(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.DeviceCertificateCollectionOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(100),
 				},

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -1,17 +1,8 @@
 package completion
 
 import (
-	"context"
-
-	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
 )
-
-func WithDisabledDryRunContext(c *c8y.Client) context.Context {
-	return c.Context.CommonOptions(c8y.CommonOptions{
-		DryRun: false,
-	})
-}
 
 // GetFlagStringValues get string slice from either a string slice or string flag
 func GetFlagStringValues(cmd *cobra.Command, name string) ([]string, error) {

--- a/pkg/completion/configuration.go
+++ b/pkg/completion/configuration.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -22,7 +23,7 @@ func WithConfiguration(flagName string, clientFunc func() (*c8y.Client, error)) 
 				PaginationOptions: *c8y.NewPaginationOptions(100),
 			}
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/device.go
+++ b/pkg/completion/device.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -18,7 +19,7 @@ func WithDevice(flagName string, clientFunc func() (*c8y.Client, error)) Option 
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.Inventory.GetDevicesByName(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				pattern,
 				c8y.NewPaginationOptions(100),
 			)
@@ -54,7 +55,7 @@ func WithAgent(flagName string, clientFunc func() (*c8y.Client, error)) Option {
 				PaginationOptions: *c8y.NewPaginationOptions(100),
 			}
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/deviceProfile.go
+++ b/pkg/completion/deviceProfile.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -22,7 +23,7 @@ func WithDeviceProfile(flagName string, clientFunc func() (*c8y.Client, error)) 
 				PaginationOptions: *c8y.NewPaginationOptions(100),
 			}
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/deviceService.go
+++ b/pkg/completion/deviceService.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -44,7 +45,7 @@ func WithDeviceService(flagService string, flagDevice string, clientFunc func() 
 			} else {
 				// lookup via name
 				items, _, err := client.Inventory.GetDevicesByName(
-					WithDisabledDryRunContext(client),
+					c8y.WithDisabledDryRunContext(context.Background()),
 					deviceName,
 					c8y.NewPaginationOptions(100),
 				)
@@ -61,7 +62,7 @@ func WithDeviceService(flagService string, flagDevice string, clientFunc func() 
 			query := fmt.Sprintf("type eq 'c8y_Service' and name eq '%s' and bygroupid(%s)", serviceNamePattern, deviceID)
 
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.ManagedObjectOptions{
 					Query:             query,
 					PaginationOptions: *c8y.NewPaginationOptions(100),

--- a/pkg/completion/devicegroup.go
+++ b/pkg/completion/devicegroup.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -22,7 +23,7 @@ func WithDeviceGroup(flagName string, clientFunc func() (*c8y.Client, error)) Op
 				PaginationOptions: *c8y.NewPaginationOptions(100),
 			}
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/deviceregistration.go
+++ b/pkg/completion/deviceregistration.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -18,7 +19,7 @@ func WithDeviceRegistrationRequest(flagName string, clientFunc func() (*c8y.Clie
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.DeviceCredentials.GetNewDeviceRequests(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.NewDeviceRequestOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(100),
 				},

--- a/pkg/completion/firmware.go
+++ b/pkg/completion/firmware.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -18,7 +19,7 @@ func WithFirmware(flagName string, clientFunc func() (*c8y.Client, error)) Optio
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.Firmware.GetFirmwareByName(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				pattern,
 				c8y.NewPaginationOptions(100),
 			)

--- a/pkg/completion/firmwareVersion.go
+++ b/pkg/completion/firmwareVersion.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ydata"
@@ -45,7 +46,7 @@ func WithFirmwareVersion(flagVersion string, flagNameFirmware string, clientFunc
 				} else {
 					// Lookup by name
 					packages, _, err := client.Inventory.GetManagedObjects(
-						WithDisabledDryRunContext(client),
+						c8y.WithDisabledDryRunContext(context.Background()),
 						&c8y.ManagedObjectOptions{
 							Query: fmt.Sprintf("$filter=(type eq '%s') and name eq '%s' $orderby=name,creationTime", "c8y_Firmware", firmwareName),
 						},
@@ -59,7 +60,7 @@ func WithFirmwareVersion(flagVersion string, flagNameFirmware string, clientFunc
 			}
 
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/firmwareVersionPatch.go
+++ b/pkg/completion/firmwareVersionPatch.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ydata"
@@ -45,7 +46,7 @@ func WithFirmwarePatch(flagVersion string, flagNameFirmware string, clientFunc f
 				} else {
 					// Lookup by name
 					packages, _, err := client.Inventory.GetManagedObjects(
-						WithDisabledDryRunContext(client),
+						c8y.WithDisabledDryRunContext(context.Background()),
 						&c8y.ManagedObjectOptions{
 							Query: fmt.Sprintf("(type eq '%s') and name eq '%s'", "c8y_Firmware", firmwareName),
 						},
@@ -59,7 +60,7 @@ func WithFirmwarePatch(flagVersion string, flagNameFirmware string, clientFunc f
 			}
 
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/measurements.go
+++ b/pkg/completion/measurements.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -26,7 +27,7 @@ func getSupportedSeries(cmd *cobra.Command, flagNameDevice string, client *c8y.C
 
 	if !c8ydata.IsID(deviceID) {
 		matchingDevices, _, err := client.Inventory.GetDevicesByName(
-			WithDisabledDryRunContext(client),
+			c8y.WithDisabledDryRunContext(context.Background()),
 			deviceID,
 			c8y.NewPaginationOptions(1),
 		)
@@ -41,7 +42,7 @@ func getSupportedSeries(cmd *cobra.Command, flagNameDevice string, client *c8y.C
 
 	pattern := "*" + toComplete + "*"
 	items, _, err := client.Inventory.GetSupportedSeries(
-		WithDisabledDryRunContext(client),
+		c8y.WithDisabledDryRunContext(context.Background()),
 		deviceID,
 	)
 

--- a/pkg/completion/notification2.go
+++ b/pkg/completion/notification2.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -17,7 +18,7 @@ func WithNotification2SubscriptionName(flagName string, clientFunc func() (*c8y.
 				return []string{err.Error()}, cobra.ShellCompDirectiveError
 			}
 			items, _, err := client.Notification2.GetSubscriptions(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.Notification2SubscriptionCollectionOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},
@@ -72,7 +73,7 @@ func WithNotification2SubscriptionId(flagName string, clientFunc func() (*c8y.Cl
 				return []string{err.Error()}, cobra.ShellCompDirectiveError
 			}
 			items, _, err := client.Notification2.GetSubscriptions(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.Notification2SubscriptionCollectionOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},

--- a/pkg/completion/role.go
+++ b/pkg/completion/role.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -16,7 +17,7 @@ func WithUserRole(flagName string, clientFunc func() (*c8y.Client, error)) Optio
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			items, _, err := client.User.GetRoles(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.RoleOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},

--- a/pkg/completion/smartgroup.go
+++ b/pkg/completion/smartgroup.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -22,7 +23,7 @@ func WithSmartGroup(flagName string, clientFunc func() (*c8y.Client, error)) Opt
 				PaginationOptions: *c8y.NewPaginationOptions(100),
 			}
 			items, _, err := client.Inventory.GetManagedObjects(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				opt,
 			)
 

--- a/pkg/completion/software.go
+++ b/pkg/completion/software.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -18,7 +19,7 @@ func WithSoftware(flagName string, clientFunc func() (*c8y.Client, error)) Optio
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.Software.GetSoftwareByName(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				pattern,
 				c8y.NewPaginationOptions(100),
 			)

--- a/pkg/completion/softwareVersion.go
+++ b/pkg/completion/softwareVersion.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -30,7 +31,7 @@ func WithSoftwareVersion(flagVersion string, flagNameSoftware string, clientFunc
 			}
 
 			items, _, err := client.Software.GetSoftwareVersionsByName(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				softwareName,
 				versionPattern,
 				true,

--- a/pkg/completion/systemoption.go
+++ b/pkg/completion/systemoption.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -18,7 +19,7 @@ func WithSystemOptionCategory(flagName string, clientFunc func() (*c8y.Client, e
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.TenantOptions.GetSystemOptions(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				c8y.NewPaginationOptions(200),
 			)
 
@@ -58,7 +59,7 @@ func WithSystemOptionKey(flagName string, flagNameCategory string, clientFunc fu
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.TenantOptions.GetSystemOptions(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				c8y.NewPaginationOptions(200),
 			)
 

--- a/pkg/completion/tenant.go
+++ b/pkg/completion/tenant.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -17,7 +18,7 @@ func WithTenantID(flagName string, clientFunc func() (*c8y.Client, error)) Optio
 				return []string{err.Error()}, cobra.ShellCompDirectiveDefault
 			}
 			tenants, _, err := client.Tenant.GetTenants(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				c8y.NewPaginationOptions(20),
 			)
 

--- a/pkg/completion/tenantoption.go
+++ b/pkg/completion/tenantoption.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -18,7 +19,7 @@ func WithTenantOptionCategory(flagName string, clientFunc func() (*c8y.Client, e
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.TenantOptions.GetOptions(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				c8y.NewPaginationOptions(200),
 			)
 
@@ -58,7 +59,7 @@ func WithTenantOptionKey(flagName string, flagNameCategory string, clientFunc fu
 
 			pattern := "*" + toComplete + "*"
 			items, _, err := client.TenantOptions.GetOptions(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				c8y.NewPaginationOptions(200),
 			)
 

--- a/pkg/completion/user.go
+++ b/pkg/completion/user.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -18,7 +19,7 @@ func WithUser(flagName string, clientFunc func() (*c8y.Client, error)) Option {
 			}
 
 			items, _, err := client.User.GetUsers(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.UserOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(2000),
 				},

--- a/pkg/completion/usergroup.go
+++ b/pkg/completion/usergroup.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -17,7 +18,7 @@ func WithUserGroup(flagName string, clientFunc func() (*c8y.Client, error)) Opti
 			}
 
 			items, _, err := client.User.GetGroups(
-				WithDisabledDryRunContext(client),
+				c8y.WithDisabledDryRunContext(context.Background()),
 				&c8y.GroupOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(100),
 				},

--- a/pkg/utilities/utilities.go
+++ b/pkg/utilities/utilities.go
@@ -114,6 +114,7 @@ func ClearEnvironmentVariables(shell ShellType) {
 		"C8Y_USERNAME",
 		"C8Y_PASSWORD",
 		"C8Y_TOKEN",
+		"C8Y_VERSION",
 		"C8Y_SESSION",
 		"C8Y_HEADER",
 		"C8Y_HEADER_AUTHORIZATION",


### PR DESCRIPTION
The following improvements were made regarding the way sessions were handled.

### feat(client): lookup tenant name if it is not set as it is required by some API calls

**Example**

In a CI environment, you can now leave the `C8Y_TENANT` environment variable out, and all the commands will just work. Previously an error would be returned saying that the tenant name is mandatory. 

```sh
export C8Y_HOST="example.c8y.com"
export C8Y_USERNAME="myuser"
export C8Y_PASSWORD="mys3cur3p0s@"

# This now works as the tenant name will be looked up automatically if needed
c8y users list
```

### fix(clear-session): remove C8Y_VERSION env variable

`C8Y_VERSION` variable will be removed (if it was set) after calling the shell function `clear-session`.

### feat(c8y sessions get): support loading session info from env variables

In a CI environment the session is generally controlled via environment variables rather than a session file. Now the `c8y sessions get` will return information about the session (including the tenant name which is looked up automatically)

```sh
export C8Y_HOST="example.c8y.com"
export C8Y_USERNAME="myuser"
export C8Y_PASSWORD="mys3cur3p0s@"

# This now works as the tenant name will be looked up automatically if needed
c8y sessions get
```

*Output*
```
| host                 | tenant      | username      | path       |
|----------------------|-------------|---------------|------------|
| example.c8y.com      | t12345      | myuser        |            |
```


### feat(session): don't prompt user if there are no session to select from

When using `set-session` (a shell function which just calls `c8y sessions set`), if no sessions are found, then the command will fail rather than waiting for user input. This following shows an example of the output.

```sh
set-session thisdoesnotmatch
2023-06-23T22:02:50.549+0200    ERROR   commandError: no sessions found
Set session failed
```