### PR TITLE
feat(linux): change default install location to support rpm-ostree

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,7 +98,7 @@ nfpms:
     license: MIT
     maintainer: Reuben Miller <reuben.d.miller@gmail.com>
     homepage: http://goc8ycli.netlify.app
-    bindir: /usr/local
+    bindir: /usr
     description: Cumulocity's unofficial command line tool
     section: utils
     priority: optional
@@ -122,7 +122,7 @@ nfpms:
         dst: /etc/bash_completion.d/c8y
       
       - src: ./output/zsh/_c8y
-        dst: /usr/local/share/zsh/site-functions/_c8y
+        dst: /usr/share/zsh/site-functions/_c8y
       
       - src: ./output/fish/c8y.fish
         dst: /usr/share/fish/vendor_completions.d/c8y.fish

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,8 +48,8 @@ tasks:
       - build-snapshot
     cmds:
       - |
-        if [ ! -f /usr/local/bin/c8y ]; then \
-          sudo ln -s "$(pwd)/tools/PSc8y/Dependencies/c8y.linux" /usr/local/bin/c8y; \
+        if [ ! -f /usr/bin/c8y ]; then \
+          sudo ln -s "$(pwd)/tools/PSc8y/Dependencies/c8y.linux" /usr/bin/c8y; \
         fi
         cp ./tools/shell/c8y.plugin.sh ~/
         echo "source ~/c8y.plugin.sh"  >> ~/.bashrc

--- a/tools/PSc8y/Public-manual/Install-ClientBinary.ps1
+++ b/tools/PSc8y/Public-manual/Install-ClientBinary.ps1
@@ -4,12 +4,12 @@ Function Install-ClientBinary {
 Install the Cumulocity cli binary (c8y)
 
 .DESCRIPTION
-Install the Cumulocity cli binary (c8y) so it is accessible from everywhere in consoles (assuming /usr/local/bin is in the $PATH variable)
+Install the Cumulocity cli binary (c8y) so it is accessible from everywhere in consoles (assuming /usr/bin is in the $PATH variable)
 
 .EXAMPLE
 Install-ClientBinary
 
-On Linux/MacOS, this installs the cumulocity binary to /usr/local/bin
+On Linux/MacOS, this installs the cumulocity binary to /usr/bin
 On Windows this will throw a warning
 
 .EXAMPLE
@@ -36,7 +36,7 @@ Install the Cumulocity binary to /usr/bin
 
     if ($IsMacOS -or $IsLinux) {
         if (!$InstallPath) {
-            $InstallPath = "/usr/local/bin"
+            $InstallPath = "/usr/bin"
         }
         $TargetBinary = "c8y"
         


### PR DESCRIPTION
Change default installation paths for linux packages (alpine linux, debian, rpm) to avoid using folders which are not immutable OS filesystems (e.g. rpm-ostree).

* c8y binary path: `/usr/local/bin/` -> `/usr/bin/`
* zsh completions path: `/usr/local/share/zsh/site-functions/` -> `/usr/share/zsh/site-functions/`
* 
**Notes**

* You may need to run `hash -r` to refresh the `c8y` binary location if you get an error about `/usr/local/bin/c8y` not existing.