### PR TITLE
feat(templates): improve jsonnet functions for merging and selecting data

### DIFF
--- a/tests/manual/template/input.json
+++ b/tests/manual/template/input.json
@@ -1,0 +1,11 @@
+{
+    "id": "1234",
+    "name": "testname",
+    "c8y_Firmware": {
+        "name": "linux",
+        "version": "1.0.0",
+        "url":"https://linux.com/linux.bin"
+    },
+    "c8y_IsDevice": {},
+    "c8y_SupportedOperations": ["c8y_Firmware"]
+}

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -101,7 +101,7 @@ tests:
   It provides a function to get an optional value:
     command: |
       c8y template execute --template "{nestedProp:{othervalue: 1}}" |
-        c8y devices update --id 0 --dry --dryFormat json --template "_.Get('nestedProp', input.value, {dummy: 2})" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.DeprecatedGet('nestedProp', input.value, {dummy: 2})" |
         c8y util show --select body --compact=false
     stdout:
       exactly: |
@@ -115,7 +115,7 @@ tests:
   
   It provides a function to get an optional value - test:
       command: |
-          echo '{"nestedProp":{"otherValue":1}}' | c8y devices update --id 0 --dry --template "_.Get('nestedProp', input.value, {dummy: 2})"
+          echo '{"nestedProp":{"otherValue":1}}' | c8y devices update --id 0 --dry --template "_.DeprecatedGet('nestedProp', input.value, {dummy: 2})"
       exit-code: 0
       stdout:
           line-count: 1
@@ -125,7 +125,7 @@ tests:
   It provides a function to get an optional value and returns a default value if not present:
     command: |
       c8y template execute --template "{nestedProp:{othervalue: 1}}" |
-        c8y devices update --id 0 --dry --dryFormat json --template "_.Get('nestedProp2', input.value, {dummy: 2})" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.DeprecatedGet('nestedProp2', input.value, {dummy: 2})" |
         c8y util show --select body --compact=false
     stdout:
       exactly: |

--- a/tests/manual/template/template_get.yml
+++ b/tests/manual/template/template_get.yml
@@ -5,7 +5,7 @@ tests:
   It provides a function to get an optional value:
     command: |
       c8y template execute --template "{nestedProp:{othervalue: 1}}" |
-        c8y devices update --id 0 --dry --dryFormat json --template "_.Get2(input.value, 'nestedProp', {dummy: 2})" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.Get(input.value, 'nestedProp', {dummy: 2})" |
         c8y util show --select body --compact=false
     stdout:
       exactly: |
@@ -18,7 +18,7 @@ tests:
   It provides a function to get nested optional values:
     command: |
       c8y template execute --template "{nestedProp:{othervalue: 1}}" |
-        c8y devices update --id 0 --dry --dryFormat json --template "{count: _.Get2(input.value, 'nestedProp.othervalue', 0), defaultCount: _.Get2(input.value, 'nestedProp.not.exist', -1)}" |
+        c8y devices update --id 0 --dry --dryFormat json --template "{count: _.Get(input.value, 'nestedProp.othervalue', 0), defaultCount: _.Get(input.value, 'nestedProp.not.exist', -1)}" |
         c8y util show --select body --compact=false
     stdout:
       exactly: |
@@ -32,7 +32,7 @@ tests:
   It provides a function to get an optional value and returns a default value if not present:
     command: |
       c8y template execute --template "{nestedProp:{othervalue: 1}}" |
-        c8y devices update --id 0 --dry --dryFormat json --template "_.Get2(input.value, 'nestedProp2', {dummy: 2})" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.Get(input.value, 'nestedProp2', {dummy: 2})" |
         c8y util show --select body --compact=false
     stdout:
       exactly: |

--- a/tests/manual/template/template_get.yml
+++ b/tests/manual/template/template_get.yml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+tests:
+
+  It provides a function to get an optional value:
+    command: |
+      c8y template execute --template "{nestedProp:{othervalue: 1}}" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.Get2(input.value, 'nestedProp', {dummy: 2})" |
+        c8y util show --select body --compact=false
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "othervalue": 1
+          }
+        }
+
+  It provides a function to get nested optional values:
+    command: |
+      c8y template execute --template "{nestedProp:{othervalue: 1}}" |
+        c8y devices update --id 0 --dry --dryFormat json --template "{count: _.Get2(input.value, 'nestedProp.othervalue', 0), defaultCount: _.Get2(input.value, 'nestedProp.not.exist', -1)}" |
+        c8y util show --select body --compact=false
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "count": 1,
+            "defaultCount": -1
+          }
+        }
+
+  It provides a function to get an optional value and returns a default value if not present:
+    command: |
+      c8y template execute --template "{nestedProp:{othervalue: 1}}" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.Get2(input.value, 'nestedProp2', {dummy: 2})" |
+        c8y util show --select body --compact=false
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "dummy": 2
+          }
+        }

--- a/tests/manual/template/template_merge.yml
+++ b/tests/manual/template/template_merge.yml
@@ -5,7 +5,7 @@ tests:
   It merges values array values:
     command: |
       c8y template execute --template "{nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
-      c8y template execute --template "_.Merge('nestedProp', input.value, {inputList+: ['newValue']})" --compact=false
+      c8y template execute --template "_.DeprecatedMerge('nestedProp', input.value, {inputList+: ['newValue']})" --compact=false
 
     exit-code: 0
     stdout:
@@ -20,7 +20,7 @@ tests:
   It merges values array values with any empty initial value:
     command: |
       c8y template execute --template "{}" |
-      c8y template execute --template "_.Merge('nestedProp', input.value, {inputList+: ['newValue']})" --compact=false
+      c8y template execute --template "_.DeprecatedMerge('nestedProp', input.value, {inputList+: ['newValue']})" --compact=false
 
     exit-code: 0
     stdout:
@@ -34,7 +34,7 @@ tests:
   It merges arrays when array is immediate key:
     command: |
       c8y template execute --template "{c8y_SupportedOperations:[]}" |
-      c8y template execute --template "_.Merge('c8y_SupportedOperations', input.value, ['newValue'])" --compact=false
+      c8y template execute --template "_.DeprecatedMerge('c8y_SupportedOperations', input.value, ['newValue'])" --compact=false
 
     exit-code: 0
     stdout:
@@ -46,7 +46,7 @@ tests:
   It merges an array when existing value does not exist:
     command: |
       c8y template execute --template "{}" |
-      c8y template execute --template "_.Merge('c8y_SupportedOperations', input.value, ['newValue'])" --compact=false
+      c8y template execute --template "_.DeprecatedMerge('c8y_SupportedOperations', input.value, ['newValue'])" --compact=false
 
     exit-code: 0
     stdout:
@@ -58,7 +58,7 @@ tests:
   It removes a nested fragment:
     command: |
       c8y template execute --template "{c8y_Model:{serialNumber:'123456789', otherValue: 'example'}}" |
-      c8y template execute --template "_.Merge('c8y_Model', input.value, {otherValue:: null})" --compact=false
+      c8y template execute --template "_.DeprecatedMerge('c8y_Model', input.value, {otherValue:: null})" --compact=false
 
     exit-code: 0
     stdout:

--- a/tests/manual/template/template_replace.yml
+++ b/tests/manual/template/template_replace.yml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+tests:
+  RecurseReplace replaces all strings fields based on a regex pattern:
+    command: |
+      c8y template execute --template "{nestedProp:{othervalue: 1, url:'https://helloworld.com'}}" |
+        c8y devices update --id 0 --dry --dryFormat json --template "_.RecurseReplace(input.value, 'https://.*.com', 'https://anotherworld.com')" |
+        c8y util show --select body --compact=false
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "nestedProp": {
+              "othervalue": 1,
+              "url": "https://anotherworld.com"
+            }
+          }
+        }

--- a/tests/manual/template/template_select.yml
+++ b/tests/manual/template/template_select.yml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+# Merge function
+tests:
+  It selects using a single level glob star:
+    command: |
+      c8y template execute --template "{name:'peter',nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
+      c8y template execute --template "_.Select(input.value, 'nestedProp.*')" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "nestedProp": {
+            "othervalue": "somevalue"
+          }
+        }
+  
+  It selects a root fragment based on wildcard match:
+    command: |
+      c8y template execute --template "{name:'peter'}" |
+      c8y template execute --template "_.Select(input.value, 'nam*')" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "name": "peter"
+        }

--- a/tests/manual/template/template_select.yml
+++ b/tests/manual/template/template_select.yml
@@ -1,6 +1,19 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
 # Merge function
 tests:
+  It selects only top level fragments:
+    command: |
+      c8y template execute --template "{id: '1234', name:'peter',nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
+      c8y template execute --template "_.Select(input.value, '*')" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "id": "1234",
+          "name": "peter"
+        }
+
   It selects using a single level glob star:
     command: |
       c8y template execute --template "{name:'peter',nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |

--- a/tests/manual/template/template_selectmerge.yml
+++ b/tests/manual/template/template_selectmerge.yml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+# Merge function
+tests:
+
+  It selects a root fragment:
+    command: |
+      c8y template execute --template "{name:'peter',nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
+      c8y template execute --template "_.Select(input.value, 'nestedProp', {})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "nestedProp": {
+            "inputList": ["existingValue"],
+            "othervalue": "somevalue"
+          }
+        }
+  
+  It selects a root fragment and uses a default value when it does not exist:
+    command: |
+      c8y template execute --template "{name:'peter'}" |
+      c8y template execute --template "_.Select(input.value, 'nestedProp', {custom: 'values'})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "nestedProp": {
+            "custom": "values"
+          }
+        }
+
+  It merges values array values:
+    command: |
+      c8y template execute --template "{nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
+      c8y template execute --template "_.SelectMerge(input.value, {nestedProp: {inputList+: ['newValue']}})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "nestedProp": {
+            "inputList": ["existingValue", "newValue"],
+            "othervalue": "somevalue"
+          }
+        }
+  
+  It merges values array values with any empty initial value:
+    command: |
+      c8y template execute --template "{}" |
+      c8y template execute --template "_.SelectMerge(input.value, {nestedProp: {inputList+: ['newValue']}})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "nestedProp": {
+            "inputList": ["newValue"]
+          }
+        }
+
+  It merges arrays when array is immediate key:
+    command: |
+      c8y template execute --template "{c8y_SupportedOperations:[]}" |
+      c8y template execute --template "_.SelectMerge(input.value, {c8y_SupportedOperations: ['newValue']})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "c8y_SupportedOperations": ["newValue"]
+        }
+  
+  It merges an array when existing value does not exist:
+    command: |
+      c8y template execute --template "{}" |
+      c8y template execute --template "_.SelectMerge(input.value, {c8y_SupportedOperations: ['newValue']})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "c8y_SupportedOperations": ["newValue"]
+        }
+  
+  It removes a nested fragment:
+    command: |
+      c8y template execute --template "{c8y_Model:{serialNumber:'123456789', otherValue: 'example'}}" |
+      c8y template execute --template "_.SelectMerge(input.value, {c8y_Model: {otherValue:: null}})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "c8y_Model": {
+            "serialNumber": "123456789"
+          }
+        }

--- a/tests/manual/template/template_selectmerge.yml
+++ b/tests/manual/template/template_selectmerge.yml
@@ -4,7 +4,7 @@ tests:
   It merges values array values:
     command: |
       c8y template execute --template "{nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
-      c8y template execute --template "_.SelectMerge(input.value, {nestedProp: {inputList+: ['newValue']}})" --compact=false
+      c8y template execute --template "_.SelectMerge(input.value, {nestedProp+: {inputList+: ['newValue']}})" --compact=false
 
     exit-code: 0
     stdout:
@@ -57,7 +57,7 @@ tests:
   It removes a nested fragment:
     command: |
       c8y template execute --template "{c8y_Model:{serialNumber:'123456789', otherValue: 'example'}}" |
-      c8y template execute --template "_.SelectMerge(input.value, {c8y_Model: {otherValue:: null}})" --compact=false
+      c8y template execute --template "_.SelectMerge(input.value, {c8y_Model+: {otherValue:: null}})" --compact=false
 
     exit-code: 0
     stdout:
@@ -67,3 +67,21 @@ tests:
             "serialNumber": "123456789"
           }
         }
+
+  It does not try to merge string values:
+    command: |
+      c8y template execute --template /Users/reubenmiller/dev/opensource/go-c8y-cli/tests/manual/template/input.json |
+      c8y template execute --template "_.SelectMerge(input.value, {name:null})" --compact=false
+
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "name": null
+        }
+
+# Use cases
+# Case 1: Updating a managed object: Only update the relevant fragment merge existing data. Merge data withint 
+# Case 2: Append items to an already existing array (e.g. append an item to the supported operations list)
+# Case 3: 
+# Open questions: Do a deep object merge by default? e.g. append to arrays or not?

--- a/tests/manual/template/template_selectmerge.yml
+++ b/tests/manual/template/template_selectmerge.yml
@@ -70,7 +70,7 @@ tests:
 
   It does not try to merge string values:
     command: |
-      c8y template execute --template /Users/reubenmiller/dev/opensource/go-c8y-cli/tests/manual/template/input.json |
+      c8y template execute --template ./manual/template/input.json |
       c8y template execute --template "_.SelectMerge(input.value, {name:null})" --compact=false
 
     exit-code: 0

--- a/tests/manual/template/template_selectmerge.yml
+++ b/tests/manual/template/template_selectmerge.yml
@@ -1,36 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
 # Merge function
 tests:
-
-  It selects a root fragment:
-    command: |
-      c8y template execute --template "{name:'peter',nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |
-      c8y template execute --template "_.Select(input.value, 'nestedProp', {})" --compact=false
-
-    exit-code: 0
-    stdout:
-      exactly: |
-        {
-          "nestedProp": {
-            "inputList": ["existingValue"],
-            "othervalue": "somevalue"
-          }
-        }
-  
-  It selects a root fragment and uses a default value when it does not exist:
-    command: |
-      c8y template execute --template "{name:'peter'}" |
-      c8y template execute --template "_.Select(input.value, 'nestedProp', {custom: 'values'})" --compact=false
-
-    exit-code: 0
-    stdout:
-      exactly: |
-        {
-          "nestedProp": {
-            "custom": "values"
-          }
-        }
-
   It merges values array values:
     command: |
       c8y template execute --template "{nestedProp: {inputList:['existingValue'], othervalue: 'somevalue'}}" |


### PR DESCRIPTION
New jsonnet functions are available to simplify common json body modifications.

To demonstrate this, let's assume we start with the given `input.value` object. The following example will show how to modify the input.value to produce a new output object.

```json
{
    "id": "1234",
    "name": "testname",
    "c8y_Firmware": {
        "name": "linux",
        "version": "1.0.0",
        "url":"https://linux.com/linux.bin"
    },
    "c8y_IsDevice": {},
    "c8y_SupportedOperations": ["c8y_Firmware"]
}
```

### _.Get(object, key, default=null) - Breaking change

`_.Get()` function signature and behaviour has been changed to be more consistent with a simple getter function (rather than a select). If you previously used this then you should use `_.Select()` instead (though I doubt many people did as the previous behaviour was a bit weird).

```sh
c8y template execute --template "{firmwareName: _.Get(input.value, 'c8y_Firmware.name'), firmwareCustomProp: _.Get(input.value, 'c8y_Firmware.other', 'myDefault')}"
```

**Output**

```json
{
  "firmwareCustomProp": "myDefault",
  "firmwareName": "linux"
}
```

### _.Has(object, key)

Check if an object has a given fragment/key. The fragment/key can use dot notation to represented nested fragments.

```sh
c8y template execute --template "{hasFirmware: _.Has(input.value, 'c8y_Firmware.name')}"
```

**Output**

```json
{
  "hasFirmware": true
}
```

### _.Select(object, properties='*')

Select/pick specific fragments from an object using the same select logic as the `--select` flag.

```sh
c8y template execute --template "_.Select(input.value, 'id,c8y_Firmware.name')"
```

**Output**

```json
{
  "c8y_Firmware": {
    "name": "linux"
  },
  "name": "testname"
}
```

### _.SelectMerge(a, b)

Merge an input object, but only include. This is perfect for doing partial updates of managed objects, as generally you only want to send the root fragments which have changed rather than the whole object. Jsonnet also supports complex/deep object merges which makes it very convenient to append or mix-in values from objects.

The example below shows how to append a new entry to the `c8y_SupportedOperations` array.

```sh
c8y template execute --template "_.SelectMerge(input.value, {c8y_SupportedOperations:['c8y_Command']})"
```

**Output**

```json
{
  "c8y_SupportedOperations": [
    "c8y_Firmware",
    "c8y_Command"
  ]
}
```


Or you can combine `_.Select` and `_.SelectMerge` to build an output object to suite your needs.


```sh
c8y template execute --template "_.Select(input.value, 'id') + _.SelectMerge(input.value, {c8y_SupportedOperations:['c8y_Command']})"
```

**Output**

```json
{
  "c8y_SupportedOperations": [
    "c8y_Firmware",
    "c8y_Command"
  ],
  "id": "1234"
}
```
