### PR TITLE
feat(set-session): option to always set C8Y_PASSWORD variable

### DIFF
--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -299,6 +299,10 @@ var updateSettingsOptions = map[string]argumentHandler{
 
 	// session
 	"session.defaultUsername": {"session.defaultUsername", "string", "settings.session.defaultUsername", []string{}, nil, cobra.ShellCompDirectiveDefault},
+	"session.alwaysIncludePassword": {"session.alwaysIncludePassword", "bool", config.SettingsSessionAlwaysIncludePassword, []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
 	// cache
 	"defaults.cache": {"defaults.cache", "bool", config.SettingsDefaultsCacheEnabled, []string{

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -274,6 +274,9 @@ const (
 	// SettingsLoginType preferred login type, i.e. BASIC, OAUTH_INTERNAL etc.
 	SettingsLoginType = "settings.login.type"
 
+	// SettingsSessionAlwaysIncludePassword should the password always be included in the session variables or not
+	SettingsSessionAlwaysIncludePassword = "settings.session.alwaysIncludePassword"
+
 	// Cache settings
 	// SettingsDefaultsCacheEnabled enable caching
 	SettingsDefaultsCacheEnabled = "settings.defaults.cache"
@@ -469,6 +472,9 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsCacheBodyPaths, ""),
 		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
+
+		// Session options
+		WithBindEnv(SettingsSessionAlwaysIncludePassword, false),
 
 		WithBindEnv(SettingsBrowser, ""),
 
@@ -942,6 +948,11 @@ func (c *Config) GetStringSlice(key string) []string {
 // GetDefaultUsername returns the default username
 func (c *Config) GetDefaultUsername() string {
 	return c.viper.GetString("settings.session.defaultUsername")
+}
+
+// AlwaysIncludePassword password when setting a session
+func (c *Config) AlwaysIncludePassword() bool {
+	return c.viper.GetBool(SettingsSessionAlwaysIncludePassword)
 }
 
 // CachePassphraseVariables return true if the passphrase variables should be persisted or not

--- a/pkg/utilities/utilities.go
+++ b/pkg/utilities/utilities.go
@@ -63,7 +63,7 @@ const (
 )
 
 func ShowClientEnvironmentVariables(cfg *config.Config, c8yclient *c8y.Client, shell ShellType) {
-	output := cfg.GetEnvironmentVariables(c8yclient, false)
+	output := cfg.GetEnvironmentVariables(c8yclient, cfg.AlwaysIncludePassword())
 	ShowEnvironmentVariables(output, shell)
 }
 


### PR DESCRIPTION
Option to always set the `C8Y_PASSWORD` environment variable when setting the session even when a token is being used.

Normally if the c8y host supports token authentication, then only the `C8Y_TOKEN` variable is set. However some other tooling does not support token based authentication. The option then sets  `C8Y_PASSWORD` in addition to `C8Y_TOKEN`.

Though this setting is deactivated by default, however it can be turned on per session using the following:

```sh
c8y settings update session.alwaysIncludePassword true
set-session
env | grep C8Y_PASSWORD
```

**Note**

The settings has no effect on the outgoing http requests, they will continue using the authentication type as before (e.g. token if available, or basic auth).