### PR TITLE
fix(assert count): logic error which resulted in the minimum result being ignored when maximum is set

### DIFF
--- a/pkg/c8ywaiter/alarms.go
+++ b/pkg/c8ywaiter/alarms.go
@@ -83,13 +83,7 @@ func (s *AlarmCount) Check(m interface{}) (done bool, err error) {
 			}
 		}
 
-		if s.Minimum > -1 {
-			done = count >= int(s.Minimum)
-		}
-
-		if s.Maximum > -1 {
-			done = count <= int(s.Maximum)
-		}
+		done = CompareCount(int64(count), s.Minimum, s.Maximum)
 
 		if !done {
 			err = cmderrors.NewAssertionError(&cmderrors.AssertionError{

--- a/pkg/c8ywaiter/compare.go
+++ b/pkg/c8ywaiter/compare.go
@@ -1,0 +1,12 @@
+package c8ywaiter
+
+func CompareCount(count, minimum, maximum int64) (done bool) {
+	if minimum > -1 && maximum > -1 {
+		done = count >= minimum && count <= maximum
+	} else if minimum > -1 {
+		done = count >= minimum
+	} else if maximum > -1 {
+		done = count <= maximum
+	}
+	return
+}

--- a/pkg/c8ywaiter/events.go
+++ b/pkg/c8ywaiter/events.go
@@ -72,13 +72,7 @@ func (s *EventCount) Check(m interface{}) (done bool, err error) {
 			}
 		}
 
-		if s.Minimum > -1 {
-			done = count >= int(s.Minimum)
-		}
-
-		if s.Maximum > -1 {
-			done = count <= int(s.Maximum)
-		}
+		done = CompareCount(int64(count), s.Minimum, s.Maximum)
 
 		if !done {
 			err = cmderrors.NewAssertionError(&cmderrors.AssertionError{

--- a/pkg/c8ywaiter/measurements.go
+++ b/pkg/c8ywaiter/measurements.go
@@ -74,13 +74,7 @@ func (s *MeasurementCount) Check(m interface{}) (done bool, err error) {
 			}
 		}
 
-		if s.Minimum > -1 {
-			done = count >= int(s.Minimum)
-		}
-
-		if s.Maximum > -1 {
-			done = count <= int(s.Maximum)
-		}
+		done = CompareCount(int64(count), s.Minimum, s.Maximum)
 
 		if !done {
 			err = cmderrors.NewAssertionError(&cmderrors.AssertionError{

--- a/pkg/c8ywaiter/operations.go
+++ b/pkg/c8ywaiter/operations.go
@@ -118,13 +118,7 @@ func (s *OperationCount) Check(m interface{}) (done bool, err error) {
 			}
 		}
 
-		if s.Minimum > -1 {
-			done = count >= int(s.Minimum)
-		}
-
-		if s.Maximum > -1 {
-			done = count <= int(s.Maximum)
-		}
+		done = CompareCount(int64(count), s.Minimum, s.Maximum)
 
 		if !done {
 			err = cmderrors.NewAssertionError(&cmderrors.AssertionError{


### PR DESCRIPTION
Fix logic bug 

Assuming your devices has 3 alarms, and using the following command to assert that the count of alarms is between 10 and 20 (inclusive).

```sh
c8y alarms assert count --device 12345 --minimum 10 --maximum 20 --strict
```

Before the fix, when combining minimum and maximum checks, the maximum would override the overall result (regardless if the minimum check failed).

**Before fix (output)**

```
12345
```

**After fix (output)**

```sh
2023-07-19T18:28:42.210+0200    ERROR   assertionError: alarmCount - wanted: {Minimum:10 Maximum:20}, got: 3, context: {ID:12345}
```