### PR TITLE
feat(console): provide console feedback for http calls with expected empty responses

### DIFF
--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -124,6 +124,8 @@ const (
 	// SettingsShowProgress show progress bar
 	SettingsShowProgress = "settings.defaults.progress"
 
+	SettingsForceTTY = "settings.defaults.forceTTY"
+
 	// SettingsDisableColor don't print progress bar
 	SettingsDisableProgress = "settings.defaults.noProgress"
 
@@ -472,6 +474,9 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsCacheBodyPaths, ""),
 		WithBindEnv(SettingsCacheMode, nil),
 		WithBindEnv(SettingsCacheDir, filepath.Join(os.TempDir(), "go-c8y-cli-cache")),
+
+		// Console options
+		WithBindEnv(SettingsForceTTY, false),
 
 		// Session options
 		WithBindEnv(SettingsSessionAlwaysIncludePassword, false),
@@ -1135,6 +1140,10 @@ func (c *Config) CompactJSON() bool {
 // ShowProgress show progress bar
 func (c *Config) ShowProgress() bool {
 	return c.viper.GetBool(SettingsShowProgress) && !c.DisableProgress()
+}
+
+func (c *Config) ForceTTY() bool {
+	return c.viper.GetBool(SettingsForceTTY)
 }
 
 func (c *Config) GetProgressBar(w io.Writer, enable bool) (progress *mpb.Progress) {

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -724,7 +724,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 				resp.Response.Request.Header.Get("Accept") == "") && resp.StatusCode() >= 200 && resp.StatusCode() < 400
 
 		if showMessage {
-			if r.IsTerminal && !r.Config.ShowProgress() {
+			if r.Config.ForceTTY() || (r.IsTerminal && !r.Config.ShowProgress()) {
 				cs := r.IO.ColorScheme()
 
 				actionText := ""

--- a/tests/manual/alarms/updateCollection/alarms_updateCollection.yaml
+++ b/tests/manual/alarms/updateCollection/alarms_updateCollection.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_DRY: false
+    C8Y_SETTINGS_DEFAULTS_FORCETTY: true
+
+tests:
+  It prints a confirmation on the console showing the update collection command was sent:
+    command: |
+      c8y alarms updateCollection -n --createdFrom -1d --severity CRITICAL --newStatus ACTIVE -f
+    exit-code: 0
+    stderr:
+      lines:
+        1: ✓ Updated /alarm/alarms => 200 OK


### PR DESCRIPTION
Commands which send a HTTP request that don't generally return any data (e.g. because it is more an asynchronous request to the server), will print a message to standard output to give an indication to the user that something was done. This is mostly useful when using such commands with piped input, now it should be more obvious to the user that the command did send a request or not (without looking at the activity log).

The message will be written to standard error but only when the output is detected as a tty console (e.g. not being piped or redirected to file).

**Technical details**

A human readable message will be printed to standard error if the HTTP response matches the following criteria and an output template has NOT been provided:

* status code == 204 or
* Response "Content-Type" Header is not set and the status code 200 - 399 (inclusive)


**Example: Update alarm collection**

Updating a collection of alarms will print a message on stderr.

```sh
c8y alarms updateCollection -n --createdFrom -1d --severity CRITICAL --newStatus ACTIVE -f
```

*Output*

```text
✓ Updated /alarm/alarms => 200 OK
```

Previously there would have been no output at all.

**Example: Update alarm collection also using outputTemplate**

Using the same command in the previous example, however this time a custom outputTemplate is used to display some meta information about the response (e.g. the duration). In this instance, `Updated /alarm/alarms => 200 OK` will not be shown in the output, because the command has opted for an output template which already shows some output to the user (so the user still has the feedback that they need).

```sh
c8y alarms updateCollection -n --createdFrom -1d --severity CRITICAL --newStatus ACTIVE -f --outputTemplate "{duration: response.duration}"
```

*Output*

```text
| duration   |
|------------|
| 155        |
```

