### PR TITLE
feat(outputTemplate): disable view logic when an outputTemplate is being used

### DIFF
--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1202,6 +1202,13 @@ func (c *Config) ViewOption() string {
 	if c.RawOutput() {
 		return ViewsOff
 	}
+
+	// If view is not set by the user, and an output template is being
+	// used, then turn off the views as the output template will most
+	// likely change the structure significantly
+	if !c.viper.IsSet(SettingsViewOption) && c.GetOutputTemplate() != "" {
+		return ViewsOff
+	}
 	return c.viper.GetString(SettingsViewOption)
 }
 


### PR DESCRIPTION
If you use the `--outputTemplate` flag, then the view logic will be turned off unless if provide the `--view` flag.

**Example: Use outputTemplate**

```sh
c8y inventory get --id 129203 --outputTemplate "{duration: response.duration, code:response.statusCode}"
```

*Output*

```text
| code       | duration   |
|------------|------------|
| 200        | 393        |
```

**Example: Activate the view logic with the outputTemplate**

You can opt into the view logic by using `--view auto`, or manually specifying the view. But remember the views will only 

```sh
c8y inventory get --id 129203 --outputTemplate "{duration: response.duration, code:response.statusCode}" --view mycustomview
```