### PR TITLE
chore(build): replaced deprecated goreleaser brew syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -160,7 +160,7 @@ brews:
     goarm: "6"
 
     # GitHub/GitLab repository to push the formula to
-    tap:
+    repository:
       owner: reubenmiller
       name: homebrew-go-c8y-cli
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Update goreleaser tab configuration to use `repository` property as defined by the [deprecation notice](https://goreleaser.com/deprecations/#brewstap)