### PR TITLE
feat(c8y util repeat*): Support repeating a randomized number of times between min and max

### DIFF
--- a/tests/manual/util/repeat/repeat.yaml
+++ b/tests/manual/util/repeat/repeat.yaml
@@ -171,3 +171,30 @@ tests:
         device-001
         device-001
         device-001
+
+  It repeats a variable amount of times using min and max:
+    command: |
+      echo "device" |
+        c8y util repeat --format "%s" --min 2 --max 3
+    exit-code: 0
+    stdout:
+      line-count-min: 2
+      line-count-max: 3
+
+  It repeats a variable amount of times only using min:
+    command: |
+      echo "device" |
+        c8y util repeat --format "%s" --min 2
+    exit-code: 0
+    stdout:
+      line-count-min: 2
+      line-count-max: 2
+
+  It repeats a variable amount of times only using max:
+    command: |
+      echo "device" |
+        c8y util repeat --format "%s" --max 2
+    exit-code: 0
+    stdout:
+      line-count-min: 1
+      line-count-max: 2

--- a/tests/manual/util/repeatcsv/util_repeatcsv.yaml
+++ b/tests/manual/util/repeatcsv/util_repeatcsv.yaml
@@ -81,3 +81,30 @@ tests:
                 {"body":{"source":{"id":"12345"},"text":"Alarm Reset drücken INAKTIV<br>Alarm Rücktür AAA offen INAKTIV","type":"machine_CustomEvent"}}
                 {"body":{"source":{"id":"12345"},"text":"Alarm Reset drücken GELÖSCHT<br>Alarm Rücktür AAA offen GELÖSCHT","type":"machine_CustomEvent"}}
                 {"body":{"source":{"id":"12345"},"text":"Alarm Sattelheizung1: Stoppen aktiv AKTIV","type":"machine_CustomEvent"}}
+
+    It repeats a variable amount of times using min and max:
+        command: |
+            echo "device01" > /tmp/util_repeatfile07.csv
+            c8y util repeatcsv /tmp/util_repeatfile07.csv --noHeader --min 2 --max 3
+        exit-code: 0
+        stdout:
+            line-count-min: 2
+            line-count-max: 3
+
+    It repeats a variable amount of times only using min:
+        command: |
+            echo "device01" > /tmp/util_repeatfile08.csv
+            c8y util repeatcsv /tmp/util_repeatfile08.csv --noHeader --min 2
+        exit-code: 0
+        stdout:
+            line-count-min: 2
+            line-count-max: 2
+
+    It repeats a variable amount of times only using max:
+        command: |
+            echo "device01" > /tmp/util_repeatfile09.csv
+            c8y util repeatcsv /tmp/util_repeatfile09.csv --noHeader --max 2
+        exit-code: 0
+        stdout:
+            line-count-min: 1
+            line-count-max: 2

--- a/tests/manual/util/repeatfile/util_repeatfile.yaml
+++ b/tests/manual/util/repeatfile/util_repeatfile.yaml
@@ -84,3 +84,30 @@ tests:
                 2: something device02
                 3: something device01
                 4: something device02
+
+    It repeats a variable amount of times using min and max:
+        command: |
+            echo "device01" > /tmp/util_repeatfile07.txt
+            c8y util repeatfile /tmp/util_repeatfile07.txt --min 2 --max 3
+        exit-code: 0
+        stdout:
+            line-count-min: 2
+            line-count-max: 3
+
+    It repeats a variable amount of times only using min:
+        command: |
+            echo "device01" > /tmp/util_repeatfile08.txt
+            c8y util repeatfile /tmp/util_repeatfile08.txt --min 2
+        exit-code: 0
+        stdout:
+            line-count-min: 2
+            line-count-max: 2
+
+    It repeats a variable amount of times only using max:
+        command: |
+            echo "device01" > /tmp/util_repeatfile09.txt
+            c8y util repeatfile /tmp/util_repeatfile09.txt --max 2
+        exit-code: 0
+        stdout:
+            line-count-min: 1
+            line-count-max: 2


### PR DESCRIPTION
Add support for `--min` and `--max` flags for the repeat util commands.

The new min and max flags have been added to the following commands:

* `c8y util repeat`
* `c8y util repeatcsv`
* `c8y util repeatfile`


**Example: c8y util repeat**

Repeat `test` 1 to 10 times (inclusive)

```sh
echo test | c8y util repeat --min 1 --max 10
```

**Example: c8y util repeatfile**

Repeat the contents of the file 1 to 10 times (inclusive). Note, the whole contents are repeated, not each row of the contents.

*file: input.txt*

```text
test1
test2
```

```sh
c8y util repeatfile input.txt --min 1 --max 2
```

**Example: c8y util repeatcsv**

Repeat the contents of a csv file 1 to 10 times (inclusive). Note, the whole contents are repeated, not each row of the contents.

*file: input.csv*

```text
test1
test2
```

```sh
c8y util repeatcsv input.csv --noHeader --min 1 --max 2
```
