### PR TITLE
fix(pagination): skip pagination when totalPages is set to 1

### DIFF
--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -72,7 +72,7 @@ func (r *RequestHandler) ProcessRequestAndResponse(requests []c8y.RequestOptions
 	req := requests[0]
 
 	// Modify request if special mode is being used
-	if commonOptions.IncludeAll || commonOptions.TotalPages > 0 {
+	if commonOptions.IncludeAll || commonOptions.TotalPages > 1 {
 		if isInventoryQuery(&req) {
 			tempURL, _ := url.Parse("https://dummy.com?" + req.Query.(string))
 			tempURL = optimizeManagedObjectsURL(tempURL, "0")
@@ -130,7 +130,7 @@ func (r *RequestHandler) ProcessRequestAndResponse(requests []c8y.RequestOptions
 		r.Logger.Errorf("request timed out after %s", r.Config.RequestTimeout())
 	}
 
-	if commonOptions.IncludeAll || commonOptions.TotalPages > 0 {
+	if commonOptions.IncludeAll || commonOptions.TotalPages > 1 {
 		if isInventoryQuery(&req) {
 			// TODO: Optimize implementation for inventory managed object queries to use the following
 			r.Logger.Info("Using inventory optimized query")


### PR DESCRIPTION
Bug which caused two pages to be returned instead of one when `--totalPages 1` is set by the user.

```sh
c8y alarms list --pageSize 1 --totalPages 1 --select id
```

**Before**

```sh
| id           |
|--------------|
| 3411200      |
| 3408494      |
```

**After**

```sh
| id           |
|--------------|
| 3411200      |
```