### PR TITLE
fix(software|firmware): filter software|firmware list by type

### DIFF
--- a/api/spec/json/firmwareVersions.json
+++ b/api/spec/json/firmwareVersions.json
@@ -102,6 +102,12 @@
               "value": "not(has(c8y_Patch))"
             },
             {
+              "name": "onlyIncludeVersions",
+              "type": "stringStatic",
+              "description": "Only include firmware like items otherwise if the user does not specify the firmware, then other items are returned",
+              "value": "type eq 'c8y_FirmwareBinary'"
+            },
+            {
               "name": "version",
               "type": "string",
               "description": "Filter by version",

--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -95,6 +95,12 @@
               "value": "not(has(c8y_Patch))"
             },
             {
+              "name": "onlyIncludeVersions",
+              "type": "stringStatic",
+              "description": "Only include software like items otherwise if the user does not specify the software, then other items are returned",
+              "value": "type eq 'c8y_SoftwareBinary'"
+            },
+            {
               "name": "version",
               "type": "string",
               "description": "Filter by version",

--- a/api/spec/yaml/firmwareVersions.yaml
+++ b/api/spec/yaml/firmwareVersions.yaml
@@ -81,6 +81,11 @@ commands:
             description: ""
             value: "not(has(c8y_Patch))"
 
+          - name: onlyIncludeVersions
+            type: stringStatic
+            description: "Only include firmware like items otherwise if the user does not specify the firmware, then other items are returned"
+            value: "type eq 'c8y_FirmwareBinary'"
+
           - name: version
             type: string
             description: Filter by version

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -75,6 +75,11 @@ commands:
             description: ""
             value: "not(has(c8y_Patch))"
 
+          - name: onlyIncludeVersions
+            type: stringStatic
+            description: "Only include software like items otherwise if the user does not specify the software, then other items are returned"
+            value: "type eq 'c8y_SoftwareBinary'"
+
           - name: version
             type: string
             description: Filter by version

--- a/pkg/cmd/firmware/versions/list/list.auto.go
+++ b/pkg/cmd/firmware/versions/list/list.auto.go
@@ -122,6 +122,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 				flags.WithStringValue("query", "query", "%s"),
 				c8yfetcher.WithFirmwareByNameFirstMatch(n.factory, args, "firmware", "firmware", "bygroupid(%s)"),
 				flags.WithStaticStringValue("ignorePatches", "not(has(c8y_Patch))"),
+				flags.WithStaticStringValue("onlyIncludeVersions", "type eq 'c8y_FirmwareBinary'"),
 				flags.WithStringValue("version", "version", "(c8y_Firmware.version eq '%s')"),
 				flags.WithStringValue("url", "url", "(c8y_Firmware.url eq '%s')"),
 			},

--- a/pkg/cmd/software/versions/list/list.auto.go
+++ b/pkg/cmd/software/versions/list/list.auto.go
@@ -119,6 +119,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 				flags.WithStringValue("query", "query", "%s"),
 				c8yfetcher.WithSoftwareByNameFirstMatch(n.factory, args, "software", "software", "bygroupid(%s)"),
 				flags.WithStaticStringValue("ignorePatches", "not(has(c8y_Patch))"),
+				flags.WithStaticStringValue("onlyIncludeVersions", "type eq 'c8y_SoftwareBinary'"),
 				flags.WithStringValue("version", "version", "(c8y_Software.version eq '%s')"),
 				flags.WithStringValue("url", "url", "(c8y_Software.url eq '%s')"),
 			},


### PR DESCRIPTION
fix(software|firmware): filter software|firmware list queries to specific types to prevent returning unrelated items when an explicit software|firmware name is not provided.

**Example: firmware version list**

The following now only returns firmware binaries (across multiple firmware entities)

```
c8y firmware versions list
```


**Example: software version list**

The following now only returns software binaries (across multiple software entities)

```
c8y software versions list
```