### PR TITLE
feat: enable HTTP compression by default

### DIFF
--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -71,7 +71,7 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 		httpClient := c8y.NewHTTPClient(
 			WithProxyDisabled(cfg.IgnoreProxy()),
 			c8y.WithInsecureSkipVerify(cfg.SkipSSLVerify()),
-			WithCompression(false),
+			WithCompression(cfg.ShouldUseCompression()),
 		)
 
 		cacheBodyPaths := cfg.CacheBodyKeys()

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -340,6 +340,12 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"false",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
+	// Use HTTP compression
+	"http.compression": {"http.compression", "bool", config.SettingsUseCompression, []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
 	// proxy
 	"defaults.proxy": {"defaults.proxy", "string", "settings.defaults.proxy", []string{}, nil, cobra.ShellCompDirectiveNoFileComp},
 

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -109,6 +109,9 @@ const (
 	// SettingsDryRunPattern list of methods which should be conditionally dry, i.e. "PUT POST DELETE"
 	SettingsDryRunPattern = "settings.defaults.dryPattern"
 
+	// SettingsUseCompression use compression for HTTP client
+	SettingsUseCompression = "settings.http.compression"
+
 	// SettingsDryRunFormat dry run output format. Controls how the dry run information is displayed
 	SettingsDryRunFormat = "settings.defaults.dryFormat"
 
@@ -441,6 +444,9 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsActivityLogEnabled, true),
 		WithBindEnv(SettingsActivityLogPath, path.Join(c.GetSessionHomeDir(), ActivityLogDirName)),
 		WithBindEnv(SettingsActivityLogMethodFilter, "GET PUT POST DELETE"),
+
+		// HTTP settings
+		WithBindEnv(SettingsUseCompression, true),
 
 		// Dry run options
 		WithBindEnv(SettingsDryRunPattern, ""),
@@ -1091,6 +1097,10 @@ func (c *Config) DryRunFormat() string {
 // GetDryRunPattern pattern used to check if a command should be run using dry run or not if dry run is activated
 func (c *Config) GetDryRunPattern() string {
 	return c.viper.GetString(SettingsDryRunPattern)
+}
+
+func (c *Config) ShouldUseCompression() bool {
+	return c.viper.GetBool(SettingsUseCompression)
 }
 
 // ShouldUseDryRun returns true of dry run should be applied to the command based on the type of method


### PR DESCRIPTION
Enable HTTP compression by default to reduce network transmission. Though compression will only be used if it is supported by the server (this happens transparently in the client).

Generally the user will not notice any difference as the decompression is done by the native go HTTP client so everything looks exactly the same as before, though there are less bytes being transmitted over the network.

You can still disable the compression if you really want to via the `c8y settings update` command:

```sh
c8y settings update http.compression false
```

The only way to notice if the response is being sent compressed (e.g. gzipped) is by using the verbose output (`--verbose`), and there will be a note on the "Response Length" indicating the size of the response when it was uncompressed. The original compressed response length is unknown as the go HTTP client does the decompression automatically and does not retain information about the actual real HTTP body size (unfortunately). Below shows an example of the log output which indicates that compression was used.

```text
2023-09-06T11:33:34.958+1000    INFO    Response time: 1047ms
2023-09-06T11:33:34.959+1000    INFO    Response Content-Type: application/vnd.com.nsn.cumulocity.managedobjectcollection+json;charset=UTF-8;ver=0.9
2023-09-06T11:33:34.959+1000    INFO    Response Length: 6.5KB (uncompressed)
```