### PR TITLE
chore: add zsh completion example

### DIFF
--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -34,6 +34,9 @@ func NewCmdCompletion() *CmdCompletion {
 	  $ c8y completion bash > /usr/local/etc/bash_completion.d/c8y
 	
 	Zsh:
+
+	  $ autoload -U compinit; compinit;
+	  $ source <(c8y completion zsh)
 	
 	  # If shell completion is not already enabled in your environment,
 	  # you will need to enable it.  You can execute the following once:


### PR DESCRIPTION
Add source example to import zsh completions to the `c8y completion zsh` command