### PR TITLE
fix: limit microservice named lookup during create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.14.10
+	github.com/reubenmiller/go-c8y v0.14.11
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.14.11
+	github.com/reubenmiller/go-c8y v0.14.12
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reubenmiller/go-c8y v0.14.10 h1:nmoCEXGGjM1uQK3Rh/w23en6F+tEf7Suxbq7dcytNcE=
-github.com/reubenmiller/go-c8y v0.14.10/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
+github.com/reubenmiller/go-c8y v0.14.11 h1:8dp055lpyd4Z5HNilhPlFbqUrin9G3Wb9Vr6d/6Jgu0=
+github.com/reubenmiller/go-c8y v0.14.11/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reubenmiller/go-c8y v0.14.11 h1:8dp055lpyd4Z5HNilhPlFbqUrin9G3Wb9Vr6d/6Jgu0=
-github.com/reubenmiller/go-c8y v0.14.11/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
+github.com/reubenmiller/go-c8y v0.14.12 h1:lohYRjAszRMpYHEu1wMl8NWLciIrrWwT/WkRfOvCnvw=
+github.com/reubenmiller/go-c8y v0.14.12/go.mod h1:UxNrFBdm/85thwq2z6nUA//Dy8qJaCg/Pkq/eEI6JQg=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -61,7 +61,10 @@ func NewCmdCreate(f *cmdutil.Factory) *CmdCreate {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create microservice",
-		Long:  `Create a new microservice or update the application binary of an existing microservice`,
+		Long: heredoc.Doc(`Create a new microservice or update the application binary of an existing microservice
+
+			Note: Named lookups of microservices will only include microservices which 
+		`),
 		Example: heredoc.Doc(`
 $ c8y microservices create --file ./myapp.zip
 Create new microservice
@@ -207,7 +210,10 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 
 	if applicationName != "" {
 
-		refs, err := c8yfetcher.FindMicroservices(n.factory, []string{applicationName}, true, "")
+		// Only lookup microservices in the current tenant, as managing microservices of subtenants is not allowed
+		// e.g. upload binary etc. Restricting the search means name conflicts will be avoided if
+		// subtenants also have the same application name deployed multiple times.
+		refs, err := c8yfetcher.FindMicroservices(n.factory, []string{applicationName}, true, "", true)
 
 		if err != nil {
 			return cmderrors.NewUserError(err)


### PR DESCRIPTION
Avoid matching against microservices of the same name found in subtenant which can not be managed from the parent tenant.

Running `c8y microservices create --file myapp.zip` will not match match against any microservices which are not owned by the current tenant (if the tenant id is known).