### PR TITLE
fix: parsing bug when using json dryFormat and the body is a json array

### DIFF
--- a/tests/scripts/setup.sh
+++ b/tests/scripts/setup.sh
@@ -253,4 +253,7 @@ create_devicecert () {
         c8y devicemanagement certificates create -n --name "$name" --file tests/testdata/trustedcert.pem
 }
 
+# Remove cache to avoid stale/invalid cache which makes debugging tests very difficult
+c8y cache delete
+
 setup


### PR DESCRIPTION
Fixing a small bug which resulted in the json dry format output being converted to a string instead of an array.

**Example**

Doing a dry run on a request where the body is a json array.

```
c8y api POST /some/api --template '[{"name":"foo"}]' --dry --dryFormat json | c8y util show --select body -o json
```

**Before**

```
{
  "body": "[{\"name\":\"foo\"}]\n"
}
```

**After**

```
{
  "body": [
    {
      "name": "foo"
    }
  ]
}
```