### PR TITLE
feat(extensions): add support for controlling the json body type, e.g. array or object

### DIFF
--- a/pkg/cmdparser/cmdparser.go
+++ b/pkg/cmdparser/cmdparser.go
@@ -724,6 +724,7 @@ type BodyOptions struct {
 	Options              []flags.GetOption
 	IsBinary             bool
 	Initialize           bool
+	DefaultValue         []byte
 	UploadProgressSource string
 }
 

--- a/pkg/cmdparser/runtime_command.go
+++ b/pkg/cmdparser/runtime_command.go
@@ -167,6 +167,12 @@ func (n *RuntimeCmd) Prepare(args []string) error {
 	case "formdata":
 		supportsFormData = true
 		subcmd.Body.Options = append(subcmd.Body.Options, flags.WithDataFlagValue())
+	case "jsonarray":
+		subcmd.Body.DefaultValue = []byte("[]")
+		subcmd.Body.Options = append(subcmd.Body.Options, flags.WithDataFlagValue())
+	case "jsonobject":
+		subcmd.Body.DefaultValue = []byte("{}")
+		subcmd.Body.Options = append(subcmd.Body.Options, flags.WithDataFlagValue())
 	default:
 		subcmd.Body.Options = append(subcmd.Body.Options, flags.WithDataFlagValue())
 	}
@@ -276,7 +282,12 @@ func (n *RuntimeCmd) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// body
-	body := mapbuilder.NewInitializedMapBuilder(n.options.Body.Initialize)
+	var body *mapbuilder.MapBuilder
+	if len(n.options.Body.DefaultValue) > 0 {
+		body = mapbuilder.NewMapBuilderWithInit(n.options.Body.DefaultValue)
+	} else {
+		body = mapbuilder.NewInitializedMapBuilder(n.options.Body.Initialize)
+	}
 	err = flags.WithBody(
 		cmd,
 		body,

--- a/tests/manual/extensions/example/body_basic_tests.yaml
+++ b/tests/manual/extensions/example/body_basic_tests.yaml
@@ -286,3 +286,19 @@ tests:
     stdout:
       json:
         body.mydata.foo.bar: "true"
+
+  jsonarray:
+    command: |
+      c8y kitchensink body jsonarray --name foo --version 1.0.0 |
+        c8y util show --select body -o json -c
+    stdout:
+      exactly: |
+        {"body":[{"name":"foo","version":"1.0.0"}]}
+
+  jsonobject:
+    command: |
+      c8y kitchensink body jsonobject --name foo --version 1.0.0 |
+        c8y util show --select body -o json -c
+    stdout:
+      exactly: |
+        {"body":{"0":{"name":"foo","version":"1.0.0"}}}

--- a/tests/testdata/extensions/c8y-kitchensink/api/body_basic.yaml
+++ b/tests/testdata/extensions/c8y-kitchensink/api/body_basic.yaml
@@ -209,3 +209,37 @@ commands:
       - name: mydata
         type: json_custom
         description: json
+
+  - name: jsonarray
+    path: inventory/managedObjects
+    description: Create object
+    method: POST
+    bodyContent:
+      type: jsonarray
+    body:
+      - name: name
+        type: string
+        property: 0.name
+        description: property of an array
+
+      - name: version
+        type: string
+        property: 0.version
+        description: property of an array
+
+  - name: jsonobject
+    path: inventory/managedObjects
+    description: Create object
+    method: POST
+    bodyContent:
+      type: jsonobject
+    body:
+      - name: name
+        type: string
+        property: 0.name
+        description: property of an array
+
+      - name: version
+        type: string
+        property: 0.version
+        description: property of an array

--- a/tools/schema/extensionCommands.json
+++ b/tools/schema/extensionCommands.json
@@ -592,7 +592,9 @@
                                 "description": "Body content type. Only used to identify binary contents",
                                 "enum": [
                                     "binary",
-                                    "formdata"
+                                    "formdata",
+                                    "jsonobject",
+                                    "jsonarray"
                                 ]
                             }
                         },


### PR DESCRIPTION
Support a new `contentType` in the extension definition to specify whether the json body should be an array or an object. This influences how the paths are interpreted in the parameter sections.

Two new types are supported under `.commands[].bodyContent.type`

* `jsonobject`
* `jsonarray`

These values have also been added to the json schema (to make it easier to consume.

Full example (snippet)

```
  - name: example
    path: inventory/managedObjects
    description: Create object
    method: POST
    bodyContent:
      type: jsonarray
    body:
      - name: name
        type: string
        property: 0.name
        description: property of an array

      - name: version
        type: string
        property: 0.version
        description: property of an array
```