### PR TITLE
fix(activitylog): fix typo in example

### DIFF
--- a/docs/go-c8y-cli/docs/cli/c8y/activitylog/c8y_activitylog_list.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/activitylog/c8y_activitylog_list.md
@@ -15,7 +15,7 @@ c8y activitylog list [flags]
 ### Examples
 
 ```
-$ c8y activitylog list --datFrom -1h
+$ c8y activitylog list --dateFrom -1h
 Show entries from the last hour
 
 $ c8y activitylog list --dateFrom -8h --filter "method match PUT|POST"

--- a/pkg/cmd/activitylog/list/list.manual.go
+++ b/pkg/cmd/activitylog/list/list.manual.go
@@ -33,7 +33,7 @@ func NewCmdList(f *cmdutil.Factory) *CmdList {
 		Short: "Get activity log entries",
 		Long:  `View activity log entries and filter for specific information`,
 		Example: heredoc.Doc(`
-		$ c8y activitylog list --datFrom -1h
+		$ c8y activitylog list --dateFrom -1h
 		Show entries from the last hour
 
 		$ c8y activitylog list --dateFrom -8h --filter "method match PUT|POST"


### PR DESCRIPTION
Fix typo in an example in the `c8y activitylog list` command.