### PR TITLE
fix(session create): fix handling of default type

### DIFF
--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -189,7 +189,7 @@ func (n *CmdCreate) promptArgs(cmd *cobra.Command, args []string) error {
 			"dev\tDevelopment mode (no restrictions)",
 			"qual\tQA mode (delete disabled)",
 			"prod\tProduction mode (read only)",
-		}, "dev")
+		}, "dev\tDevelopment mode (no restrictions)")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix a problem with the default type value used in the `c8y sessions create` where the default value used in the prompter was not valid.