### PR TITLE
feat: new command to manage go-c8y-cli helper installation

### DIFF
--- a/pkg/cmd/cli/cli.manual.go
+++ b/pkg/cmd/cli/cli.manual.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	cmdInstall "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/cli/install"
+	cmdProfile "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/cli/profile"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type SubCmdCLI struct {
+	*subcommand.SubCommand
+}
+
+func NewSubCommand(f *cmdutil.Factory) *SubCmdCLI {
+	ccmd := &SubCmdCLI{}
+
+	cmd := &cobra.Command{
+		Use:   "cli",
+		Short: "cli management commands",
+		Long:  `Commands used to managed go-c8y-cli`,
+	}
+
+	// Subcommands
+	cmd.AddCommand(cmdInstall.NewCmdInstall(f).GetCommand())
+	cmd.AddCommand(cmdProfile.NewCmdProfile(f).GetCommand())
+
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}

--- a/pkg/cmd/cli/install/install.manual.go
+++ b/pkg/cmd/cli/install/install.manual.go
@@ -1,0 +1,206 @@
+package install
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/cli/safeexec"
+	"github.com/mitchellh/go-homedir"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/spf13/cobra"
+)
+
+var ErrInstallFailed = errors.New("failed to install one or more profiles")
+var validShells = []string{"bash", "fish", "powershell", "zsh"}
+
+type CmdInstall struct {
+	*subcommand.SubCommand
+
+	shell   []string
+	factory *cmdutil.Factory
+}
+
+func NewCmdInstall(f *cmdutil.Factory) *CmdInstall {
+	ccmd := &CmdInstall{
+		factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install shell helpers",
+		Long:  `Install shell helpers such as set-session etc.`,
+		Example: heredoc.Doc(`
+			$ c8y cli install
+			Install helpers to all available shells
+
+			$ c8y cli install --shell zsh
+			Install zsh helpers
+
+			$ c8y cli install --shell zsh,bash
+			Install zsh and bash helpers
+		`),
+		RunE: ccmd.RunE,
+	}
+
+	cmd.Flags().StringSliceVar(&ccmd.shell, "shell", validShells, "Type of shell")
+
+	cmd.SilenceUsage = true
+
+	completion.WithOptions(
+		cmd,
+		completion.WithValidateSet("shell", validShells...),
+	)
+
+	cmdutil.DisableAuthCheck(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return err
+	}
+
+	shells := map[string]struct {
+		Name   string
+		Binary string
+	}{
+		"bash":       {Name: "bash", Binary: "bash"},
+		"zsh":        {Name: "zsh", Binary: "zsh"},
+		"powershell": {Name: "powershell", Binary: "pwsh"},
+		"fish":       {Name: "fish", Binary: "fish"},
+	}
+
+	var Errs []error
+	reloadRequired := false
+	for _, name := range n.shell {
+		shell, ok := shells[name]
+		if !ok {
+			cfg.Logger.Warningf("Skipping invalid shell type. name=%s", name)
+			continue
+		}
+
+		cfg.Logger.Debugf("Checking shell. name=%s, shell=%s", shell.Name, shell.Binary)
+		if _, err := safeexec.LookPath(shell.Binary); err == nil {
+			changed, installErr := n.InstallProfile(shell.Name)
+			if installErr != nil {
+				Errs = append(Errs, installErr)
+			}
+			reloadRequired = reloadRequired || changed
+		} else {
+			cfg.Logger.Debugf("Shell was not found. name=%s, shell=%s", shell.Name, shell.Binary)
+		}
+	}
+
+	if len(Errs) == 0 {
+		if reloadRequired {
+			fmt.Fprint(n.factory.IOStreams.ErrOut, "\nPlease reload your shell\n\n")
+		}
+		return nil
+	}
+
+	summaryErr := ErrInstallFailed
+	for _, err := range Errs {
+		summaryErr = fmt.Errorf("%w", err)
+	}
+	return summaryErr
+}
+
+func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
+	changed := false
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return changed, err
+	}
+	profilePath := ""
+	profileSnippet := ""
+
+	switch shell {
+	case "zsh":
+		profilePath = "~/.zshrc"
+		profileSnippet = "source <(c8y cli profile --shell zsh)"
+	case "bash":
+		profilePath = "~/.bashrc"
+		profileSnippet = "source <(c8y cli profile --shell bash)"
+	case "fish":
+		profilePath = "~/.config/fish/config.fish"
+		profileSnippet = "c8y cli profile --shell fish | source"
+	case "powershell":
+		profilePath = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
+		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
+	}
+
+	if profilePath == "" {
+		return changed, fmt.Errorf("profile path is empty")
+	}
+
+	expandedV, err := homedir.Expand(profilePath)
+	if err != nil {
+		return changed, err
+	}
+
+	// Create directory
+	if err := os.MkdirAll(filepath.Dir(expandedV), 0755); err != nil {
+		return changed, err
+	}
+
+	// Check if profile contains expected line
+	appendToProfile := true
+
+	if _, err := os.Stat(expandedV); !errors.Is(err, fs.ErrNotExist) {
+		file, err := os.Open(expandedV)
+		if err != nil {
+			return changed, err
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), profileSnippet) {
+				appendToProfile = false
+				break
+			}
+		}
+	} else {
+		cfg.Logger.Debugf("Profile file does not exist. path=%s", expandedV)
+	}
+
+	cs := n.factory.IOStreams.ColorScheme()
+	message := ""
+
+	if appendToProfile {
+		message = fmt.Sprintf("Added snippet to %s profile. path: %s", shell, expandedV)
+		cfg.Logger.Debugf("Adding snippet to %s", expandedV)
+		err = AppendToFile(expandedV, profileSnippet)
+		if err != nil {
+			return changed, err
+		}
+		changed = true
+	} else {
+		cfg.Logger.Debugf("Snippet already found in profile. path=%s", expandedV)
+		message = fmt.Sprintf("Already added snippet to %s profile. path: %s", shell, expandedV)
+	}
+
+	_, bErr := fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s %s\n", cs.SuccessIconWithColor(cs.Green), message)
+	return changed, bErr
+}
+
+func AppendToFile(p string, text string) error {
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(fmt.Sprintf("%s\n", text))
+	return err
+}

--- a/pkg/cmd/cli/profile/profile.manual.go
+++ b/pkg/cmd/cli/profile/profile.manual.go
@@ -1,0 +1,101 @@
+package profile
+
+import (
+	_ "embed"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/shell"
+	"github.com/spf13/cobra"
+)
+
+//go:embed scripts/plugin.ps1
+var scriptPowerShell string
+
+//go:embed scripts/plugin.sh
+var scriptBash string
+
+//go:embed scripts/plugin.sh
+var scriptZsh string
+
+//go:embed scripts/plugin.fish
+var scriptFish string
+
+type CmdProfile struct {
+	*subcommand.SubCommand
+
+	shell   string
+	factory *cmdutil.Factory
+}
+
+func NewCmdProfile(f *cmdutil.Factory) *CmdProfile {
+	ccmd := &CmdProfile{
+		factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Print shell profile script",
+		Long: heredoc.Doc(`
+			Print the shell profile script which contains helpers such as set-session etc.
+
+			This command can be used to load the associated shell helpers.
+		`),
+		Example: heredoc.Doc(`
+		## zsh
+			source <(c8y cli profile --shell zsh)
+		
+		## bash
+			source <(c8y cli profile --shell bash)
+
+		## fish
+			c8y cli profile --shell fish | source
+
+		## PowerShell
+
+			c8y cli profile --shell powershell | Out-String | Invoke-Expression
+		`),
+		RunE: ccmd.RunE,
+	}
+
+	cmd.Flags().StringVar(&ccmd.shell, "shell", "", "Type of shell")
+
+	cmd.SilenceUsage = true
+
+	completion.WithOptions(
+		cmd,
+		completion.WithValidateSet("shell", "bash", "zsh", "powershell", "fish"),
+	)
+
+	cmdutil.DisableAuthCheck(cmd)
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+func (n *CmdProfile) RunE(cmd *cobra.Command, args []string) error {
+	activeShell := n.shell
+	if n.shell == "" {
+		activeShell = shell.DetectShell("zsh")
+	}
+	var script *string
+
+	switch activeShell {
+	case "zsh":
+		script = &scriptZsh
+	case "bash":
+		script = &scriptBash
+	case "fish":
+		script = &scriptFish
+	case "powershell":
+		script = &scriptPowerShell
+	}
+
+	if script != nil {
+		n.GetCommand().Printf("%s\n", *script)
+	}
+
+	return nil
+}

--- a/pkg/cmd/cli/profile/scripts/plugin.fish
+++ b/pkg/cmd/cli/profile/scripts/plugin.fish
@@ -1,0 +1,81 @@
+#!/usr/bin/env fish
+
+if type -q c8y
+    c8y completion fish | source
+
+    # create session home folder (if it does not exist)
+    set sessionhome ( c8y settings list --select "session.home" --output csv )
+    if test ! -e "$sessionhome"
+        echo "creating folder"
+        mkdir -p "$sessionhome"
+    end
+end
+
+########################################################################
+# c8y helpers
+########################################################################
+
+# -----------
+# set-session
+# -----------
+# Description: Switch Cumulocity session interactively
+# Usage:
+#   set-session
+#
+function set-session --description "Switch Cumulocity session interactively"
+    set c8yenv ( c8y sessions set --noColor=false $argv )
+    if test $status -ne 0
+        echo "Set session failed"
+        return
+    end
+    echo "$c8yenv" | source
+end
+
+# -------------
+# clear-session
+# -------------
+# Description: Clear all cumulocity session variables
+# Usage:
+#   clear-session
+#
+function clear-session --description "Clear all cumulocity session variables"
+    c8y sessions clear | source
+end
+
+# -------------------
+# clear-c8ypassphrase
+# -------------------
+# Description: Clear the encryption passphrase environment variables
+# Usage:
+#   clear-c8ypassphrase
+#
+function clear-c8ypassphrase --description "Clear the encryption passphrase environment variables"
+    set -u C8Y_PASSPHRASE
+    set -u C8Y_PASSPHRASE_TEXT
+end
+
+# ----------------
+# set-c8ymode-xxxx
+# ----------------
+# Description: Set temporary mode by setting the environment variables
+# Usage:
+#   set-c8ymode-dev     (enable PUT, POST and DELETE)
+#   set-c8ymode-qual    (enable PUT, POST)
+#   set-c8ymode-prod    (disable PUT, POST and DELETE)
+#
+function set-c8ymode --description "Enable a c8y temporary mode by setting the environment variables"
+    c8y settings update --shell auto mode $argv[1] | source
+    echo (set_color green)"Enabled "$argv[1]" mode (temporarily)"(set_color normal)
+end
+
+function set-c8ymode-dev --description "Enable dev mode (All enabled)"
+    set-c8ymode dev
+end
+
+function set-c8ymode-qual --description "Enable qual mode (DELETE disabled)"
+    set-c8ymode qual
+end
+
+function set-c8ymode-prod --description "Enable prod mode (POST/PUT/DELETE disabled)"
+    set-c8ymode prod
+end

--- a/pkg/cmd/cli/profile/scripts/plugin.ps1
+++ b/pkg/cmd/cli/profile/scripts/plugin.ps1
@@ -1,0 +1,104 @@
+[cmdletbinding()]
+Param()
+
+if (Get-Command "c8y" -ErrorAction SilentlyContinue) {
+    c8y completion powershell | Out-String | Invoke-Expression
+}
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# PSReadline settings
+Set-PSReadLineOption -EditMode Windows
+Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete
+# Set-PSReadLineKeyHandler -Key Tab -Function Complete
+# Autocompletion for arrow keys
+Set-PSReadlineKeyHandler -Key UpArrow -Function HistorySearchBackward
+Set-PSReadlineKeyHandler -Key DownArrow -Function HistorySearchForward
+Set-PSReadLineOption -HistorySearchCursorMovesToEnd
+
+########################################################################
+# c8y helpers
+########################################################################
+
+Function set-session {
+<#
+.SYNOPSIS
+Switch Cumulocity session interactively
+
+.EXAMPLE
+Set-Session myhost
+
+Set session and only show session matching "myhost"
+#>
+    Param()
+
+    $c8yenv = c8y sessions set --noColor=false $args
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Set session failed"
+        return
+    }
+    $c8yenv | Out-String | Invoke-Expression
+}
+
+Function clear-session {
+<#
+.SYNOPSIS
+Clear all cumulocity session variables
+
+.EXAMPLE
+Clear-Session
+
+Clear session variables
+#>
+    [cmdletbinding()]
+    Param()
+    c8y sessions clear | Out-String | Invoke-Expression
+}
+
+Function clear-c8ypassphrase {
+<#
+.SYNOPSIS
+Clear the encryption passphrase environment variables
+
+.EXAMPLE
+clear-c8ypassphrase
+
+Clear encryption passphrase variables
+#>
+    [cmdletbinding()]
+    Param()
+    $env:C8Y_PASSPHRASE = $null
+    $env:C8Y_PASSPHRASE_TEXT = $null
+}
+
+Function set-c8ymode {
+<#
+.SYNOPSIS
+Enable a c8y temporary mode by setting the environment variables
+
+.EXAMPLE
+set-c8ymode dev
+
+Enable dev mode (enables POST, PUT and DELETE commands)
+#>
+    [cmdletbinding()]
+    Param(
+        # Mode
+        [Parameter(
+            Mandatory = $true,
+            Position = 0
+        )]
+        [ValidateSet("dev", "qual", "prod")]
+        [string]
+        $Mode,
+
+        [parameter(ValueFromRemainingArguments=$true)]
+        $Options
+    )
+    c8y settings update --shell auto mode $Mode $Options | source
+    Write-Host "Enabled "$Mode" mode (temporarily)" -ForegroundColor Green
+}
+
+Function set-c8ymode-dev () { set-c8ymode dev; }
+Function set-c8ymode-qual () { set-c8ymode qual; }
+Function set-c8ymode-prod () { set-c8ymode prod; }

--- a/pkg/cmd/cli/profile/scripts/plugin.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Force encoding
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
+C8Y_SHELL=bash
+if [ -n "$BASH_VERSION" ]; then
+    C8Y_SHELL=bash
+elif [ -n "$ZSH_VERSION" ]; then
+    C8Y_SHELL=zsh
+fi
+
+install_bash_dependencies() {
+    if [ ! -d "$HOME/.bash_completion.d" ]; then
+        mkdir -p "$HOME/.bash_completion.d"
+    fi
+
+    if [ ! -f "$HOME/.bash_completion.d/complete_alias" ]; then
+        echo "Installing bash completion for aliases"
+        curl -sfL https://raw.githubusercontent.com/cykerway/complete-alias/master/complete_alias \
+                > "$HOME/.bash_completion.d/complete_alias"
+    fi
+
+    # Enable completion for aliases
+    [ -f /usr/share/bash-completion/bash_completion ] && source /usr/share/bash-completion/bash_completion
+    [ -f "$HOME/.bash_completion.d/complete_alias" ] && source "$HOME/.bash_completion.d/complete_alias"
+
+    if [ -f "$(brew --prefix)/etc/bash_completion" ]; then
+        . "$(brew --prefix)/etc/bash_completion"
+    fi
+}
+
+init-c8y() {
+    if command -v c8y >/dev/null 2>&1; then
+        if [ "$C8Y_SHELL" = "zsh" ]; then
+
+            # homebrew only: Add completions folder to the fpath so zsh can find it
+            if command -v brew >/dev/null 2>&1; then
+                FPATH="$(brew --prefix)/share/zsh/site-functions:$FPATH"
+                chmod -R go-w "$(brew --prefix)/share"
+            fi
+
+            # init completions
+            autoload -U compinit; compinit
+
+            if [ -n "$ZSH_CUSTOM" ]; then
+                mkdir -p "$ZSH_CUSTOM/plugins/c8y"
+
+                if [ ! -f "$ZSH_CUSTOM/plugins/c8y/_c8y" ]; then
+                    c8y completion zsh > "$ZSH_CUSTOM/plugins/c8y/_c8y"
+                    echo "Updated c8y completions"
+                    source "$HOME/.zshrc"
+                fi
+            fi
+        fi
+
+        if [ "$C8Y_SHELL" = "bash" ]; then
+            install_bash_dependencies
+            source <(c8y completion bash)
+        fi
+    fi
+}
+
+init-c8y
+
+########################################################################
+# c8y helpers
+########################################################################
+# -----------
+# set-session
+# -----------
+# Description: Switch Cumulocity session interactively
+# Usage:
+#   set-session
+#
+set-session() {
+    c8yenv=$( c8y sessions set --noColor=false $@ )
+    code=$?
+    if [ $code -ne 0 ]; then
+        echo "Set session failed"
+        exit $code
+    fi
+    eval "$c8yenv"
+}
+
+# -------------
+# clear-session
+# -------------
+# Description: Clear all cumulocity session variables
+# Usage:
+#   clear-session
+#
+clear-session() {
+    c8yenv=$(c8y sessions clear)
+    eval "$c8yenv"
+}
+
+# -------------------
+# clear-c8ypassphrase
+# -------------------
+# Description: Clear the encryption passphrase environment variables
+# Usage:
+#   clear-c8ypassphrase
+#
+clear-c8ypassphrase() {
+    unset C8Y_PASSPHRASE
+    unset C8Y_PASSPHRASE_TEXT
+}
+
+# ----------------
+# set-c8ymode-xxxx
+# ----------------
+# Description: Set temporary mode by setting the environment variables
+# Usage:
+#   set-c8ymode-dev     (enable PUT, POST and DELETE)
+#   set-c8ymode-qual    (enable PUT, POST)
+#   set-c8ymode-prod    (disable PUT, POST and DELETE)
+#
+set-c8ymode() {
+    eval "$(c8y settings update --shell auto mode "$1")"
+    printf "\e[32mEnabled %s mode (temporarily)\e[0m\n" "$1";
+}
+set-c8ymode-dev() { set-c8ymode dev; }
+set-c8ymode-qual() { set-c8ymode qual; }
+set-c8ymode-prod() { set-c8ymode prod; }

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -26,6 +26,7 @@ import (
 	binariesCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/binaries"
 	bulkoperationsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/bulkoperations"
 	cacheCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/cache"
+	cliCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/cli"
 	completionCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/completion"
 	configurationCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/configuration"
 	currentapplicationCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/currentapplication"
@@ -295,6 +296,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 
 	// Child commands
 	commands := []*cobra.Command{
+		cliCmd.NewSubCommand(f).GetCommand(),
 		assertCmd.NewSubCommand(f).GetCommand(),
 		auditrecordsCmd.NewSubCommand(f).GetCommand(),
 		binariesCmd.NewSubCommand(f).GetCommand(),

--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -73,6 +73,7 @@ type CmdCreate struct {
 	noStorage      bool
 	encrypt        bool
 	allowInsecure  bool
+	prompt         bool
 
 	*subcommand.SubCommand
 
@@ -127,6 +128,7 @@ $ c8y sessions create --type prod --host "https://localhost:443" --insecure
 	cmd.Flags().BoolVar(&ccmd.noStorage, "noStorage", false, "Don't store any passwords or tokens in the session file")
 	cmd.Flags().BoolVar(&ccmd.encrypt, "encrypt", false, "Encrypt passwords and tokens (occurs when logging in)")
 	cmd.Flags().BoolVar(&ccmd.allowInsecure, "allowInsecure", false, "Allow insecure connection (e.g. when using self-signed certificates)")
+	cmd.Flags().BoolVar(&ccmd.prompt, "prompt", false, "Force prompting of missing information")
 
 	// Required flags
 	completion.WithOptions(cmd,
@@ -145,6 +147,10 @@ $ c8y sessions create --type prod --host "https://localhost:443" --insecure
 }
 
 func (n *CmdCreate) promptArgs(cmd *cobra.Command, args []string) error {
+	if n.prompt {
+		n.factory.IOStreams.SetStdoutTTY(true)
+		n.factory.IOStreams.SetStdinTTY(true)
+	}
 	if !n.factory.IOStreams.CanPrompt() {
 		return nil
 	}


### PR DESCRIPTION
New command to make it easier to install and use the shell helpers without any additional dependencies.

```
c8y cli
Manage go-c8y-cli commands

Usage:
  c8y cli [command]

Available Commands:
  install     Install shell helpers
  profile     Print shell profile script
```