### PR TITLE
feat(operations cancel): add new convenience command to cancel an operation

### DIFF
--- a/api/spec/json/devicecontrol.json
+++ b/api/spec/json/devicecontrol.json
@@ -307,6 +307,84 @@
       ]
     },
     {
+      "name": "cancelOperation",
+      "description": "Cancel operation",
+      "descriptionLong": "Cancel an operation. This is a convenience command to set an operation to the FAILED status along with a sensible default failure reason.\nNote: Cancelling an operation does not guarantee that any client that is already processing the operation will stop and in\nnormal circumstances this command should be used sparingly.\n",
+      "examples": {
+        "powershell": [
+          {
+            "description": "Cancel an operation",
+            "command": "Invoke-CancelOperation -Id {{ NewOperation }}"
+          },
+          {
+            "description": "Cancel multiple operations",
+            "beforeEach": [
+              "$Agent = PSc8y\\New-TestAgent",
+              "$Operation1 = PSc8y\\New-TestOperation -Device $Agent.id",
+              "$Operation2 = PSc8y\\New-TestOperation -Device $Agent.id"
+            ],
+            "command": "Get-OperationCollection -Device $Agent.id -Status PENDING | Invoke-CancelOperation -FailureReason \"manually cancelled\"",
+            "afterEach": [
+              "PSc8y\\Remove-ManagedObject -Id $Agent.id"
+            ]
+          }
+        ],
+        "go": [
+          {
+            "description": "Cancel an operation",
+            "command": "c8y operations cancel --id 12345",
+            "assertStdOut": {
+              "json": {
+                "method": "PUT",
+                "path": "/devicecontrol/operations/12345",
+                "body.status": "FAILED",
+                "body.failureReason": "User cancelled operation"
+              }
+            }
+          }
+        ]
+      },
+      "method": "PUT",
+      "path": "devicecontrol/operations/{id}",
+      "accept": "application/vnd.com.nsn.cumulocity.operation+json",
+      "alias": {
+        "go": "cancel",
+        "powershell": "Invoke-CancelOperation"
+      },
+      "body": [
+        {
+          "name": "status",
+          "type": "stringStatic",
+          "description": "Operation status",
+          "value": "FAILED"
+        },
+        {
+          "name": "failureReason",
+          "type": "string",
+          "required": false,
+          "default": "User cancelled operation",
+          "description": "Reason for the failure"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties describing the operation which will be performed on the device."
+        }
+      ],
+      "bodyRequiredKeys": [
+        "status"
+      ],
+      "pathParameters": [
+        {
+          "name": "id",
+          "type": "id[]",
+          "description": "Operation id",
+          "pipeline": true,
+          "required": true
+        }
+      ]
+    },
+    {
       "name": "deleteOperationCollection",
       "description": "Delete operation collection",
       "descriptionLong": "Delete a collection of operations using a set of filter criteria. Be careful when deleting operations.\n\nWhere possible update operations to FAILED (with a failure reason) instead of deleting them as it is easier to track.\n",

--- a/api/spec/yaml/devicecontrol.yaml
+++ b/api/spec/yaml/devicecontrol.yaml
@@ -221,6 +221,66 @@ commands:
         pipeline: true
         required: true
 
+  - name: cancelOperation
+    description: Cancel operation
+    descriptionLong: |
+      Cancel an operation. This is a convenience command to set an operation to the FAILED status along with a sensible default failure reason.
+      Note: Cancelling an operation does not guarantee that any client that is already processing the operation will stop and in
+      normal circumstances this command should be used sparingly.
+    examples:
+      powershell:
+        - description: Cancel an operation
+          command: Invoke-CancelOperation -Id {{ NewOperation }}
+
+        - description: Cancel multiple operations
+          beforeEach:
+            - $Agent = PSc8y\New-TestAgent
+            - $Operation1 = PSc8y\New-TestOperation -Device $Agent.id
+            - $Operation2 = PSc8y\New-TestOperation -Device $Agent.id
+          command: Get-OperationCollection -Device $Agent.id -Status PENDING | Invoke-CancelOperation -FailureReason "manually cancelled"
+          afterEach:
+            - PSc8y\Remove-ManagedObject -Id $Agent.id
+
+      go:
+        - description: Cancel an operation
+          command: c8y operations cancel --id 12345
+          assertStdOut:
+            json:
+                method: PUT
+                path: /devicecontrol/operations/12345
+                body.status: FAILED
+                body.failureReason: User cancelled operation
+
+    method: PUT
+    path: devicecontrol/operations/{id}
+    accept: application/vnd.com.nsn.cumulocity.operation+json
+    alias:
+        go: cancel
+        powershell: Invoke-CancelOperation
+    body:
+      - name: status
+        type: stringStatic
+        description: Operation status
+        value: FAILED
+
+      - name: failureReason
+        type: string
+        required: false
+        default: User cancelled operation
+        description: Reason for the failure
+
+      - name: data
+        type: json
+        description: Additional properties describing the operation which will be performed on the device.
+    bodyRequiredKeys:
+      - status
+    pathParameters:
+      - name: id
+        type: id[]
+        description: Operation id
+        pipeline: true
+        required: true
+
   - name: deleteOperationCollection
     description: Delete operation collection
     descriptionLong: |

--- a/pkg/cmd/operations/cancel/cancel.auto.go
+++ b/pkg/cmd/operations/cancel/cancel.auto.go
@@ -1,0 +1,177 @@
+// Code generated from specification version 1.0.0: DO NOT EDIT
+package cancel
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8yfetcher"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/mapbuilder"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+// CancelCmd command
+type CancelCmd struct {
+	*subcommand.SubCommand
+
+	factory *cmdutil.Factory
+}
+
+// NewCancelCmd creates a command to Cancel operation
+func NewCancelCmd(f *cmdutil.Factory) *CancelCmd {
+	ccmd := &CancelCmd{
+		factory: f,
+	}
+	cmd := &cobra.Command{
+		Use:   "cancel",
+		Short: "Cancel operation",
+		Long: `Cancel an operation. This is a convenience command to set an operation to the FAILED status along with a sensible default failure reason.
+Note: Cancelling an operation does not guarantee that any client that is already processing the operation will stop and in
+normal circumstances this command should be used sparingly.
+`,
+		Example: heredoc.Doc(`
+$ c8y operations cancel --id 12345
+Cancel an operation
+        `),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return f.UpdateModeEnabled()
+		},
+		RunE: ccmd.RunE,
+	}
+
+	cmd.SilenceUsage = true
+
+	cmd.Flags().StringSlice("id", []string{""}, "Operation id (required) (accepts pipeline)")
+	cmd.Flags().String("status", "", "Operation status")
+	cmd.Flags().String("failureReason", "User cancelled operation", "Reason for the failure")
+
+	completion.WithOptions(
+		cmd,
+	)
+
+	flags.WithOptions(
+		cmd,
+		flags.WithProcessingMode(),
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
+		flags.WithExtendedPipelineSupport("id", "id", true),
+	)
+
+	// Required flags
+
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}
+
+// RunE executes the command
+func (n *CancelCmd) RunE(cmd *cobra.Command, args []string) error {
+	cfg, err := n.factory.Config()
+	if err != nil {
+		return err
+	}
+	// Runtime flag options
+	flags.WithOptions(
+		cmd,
+		flags.WithRuntimePipelineProperty(),
+	)
+	client, err := n.factory.Client()
+	if err != nil {
+		return err
+	}
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
+	if err != nil {
+		return err
+	}
+
+	// query parameters
+	query := flags.NewQueryTemplate()
+	err = flags.WithQueryParameters(
+		cmd,
+		query,
+		inputIterators,
+		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+	)
+	if err != nil {
+		return cmderrors.NewUserError(err)
+	}
+
+	queryValue, err := query.GetQueryUnescape(true)
+
+	if err != nil {
+		return cmderrors.NewSystemError("Invalid query parameter")
+	}
+
+	// headers
+	headers := http.Header{}
+	err = flags.WithHeaders(
+		cmd,
+		headers,
+		inputIterators,
+		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetHeader(), nil }, "header"),
+		flags.WithProcessingModeValue(),
+	)
+	if err != nil {
+		return cmderrors.NewUserError(err)
+	}
+
+	// form data
+	formData := make(map[string]io.Reader)
+	err = flags.WithFormDataOptions(
+		cmd,
+		formData,
+		inputIterators,
+	)
+	if err != nil {
+		return cmderrors.NewUserError(err)
+	}
+
+	// body
+	body := mapbuilder.NewInitializedMapBuilder(true)
+	err = flags.WithBody(
+		cmd,
+		body,
+		inputIterators,
+		flags.WithDataFlagValue(),
+		flags.WithStaticStringValue("status", "FAILED"),
+		flags.WithStringValue("failureReason", "failureReason"),
+		cmdutil.WithTemplateValue(n.factory),
+		flags.WithTemplateVariablesValue(),
+		flags.WithRequiredProperties("status"),
+	)
+	if err != nil {
+		return cmderrors.NewUserError(err)
+	}
+
+	// path parameters
+	path := flags.NewStringTemplate("devicecontrol/operations/{id}")
+	err = flags.WithPathParameters(
+		cmd,
+		path,
+		inputIterators,
+		c8yfetcher.WithIDSlice(args, "id", "id"),
+	)
+	if err != nil {
+		return err
+	}
+
+	req := c8y.RequestOptions{
+		Method:       "PUT",
+		Path:         path.GetTemplate(),
+		Query:        queryValue,
+		Body:         body,
+		FormData:     formData,
+		Header:       headers,
+		IgnoreAccept: cfg.IgnoreAcceptHeader(),
+		DryRun:       cfg.ShouldUseDryRun(cmd.CommandPath()),
+	}
+
+	return n.factory.RunWithWorkers(client, cmd, &req, inputIterators)
+}

--- a/pkg/cmd/operations/operations.auto.go
+++ b/pkg/cmd/operations/operations.auto.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	cmdCancel "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/operations/cancel"
 	cmdCreate "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/operations/create"
 	cmdDeleteCollection "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/operations/deletecollection"
 	cmdGet "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/operations/get"
@@ -29,6 +30,7 @@ func NewSubCommand(f *cmdutil.Factory) *SubCmdOperations {
 	cmd.AddCommand(cmdGet.NewGetCmd(f).GetCommand())
 	cmd.AddCommand(cmdCreate.NewCreateCmd(f).GetCommand())
 	cmd.AddCommand(cmdUpdate.NewUpdateCmd(f).GetCommand())
+	cmd.AddCommand(cmdCancel.NewCancelCmd(f).GetCommand())
 	cmd.AddCommand(cmdDeleteCollection.NewDeleteCollectionCmd(f).GetCommand())
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)

--- a/tests/auto/devicecontrol/tests/operations_cancel.yaml
+++ b/tests/auto/devicecontrol/tests/operations_cancel.yaml
@@ -1,0 +1,10 @@
+tests:
+    operations_cancel_Cancel an operation:
+        command: c8y operations cancel --id 12345
+        exit-code: 0
+        stdout:
+            json:
+                body.failureReason: User cancelled operation
+                body.status: FAILED
+                method: PUT
+                path: /devicecontrol/operations/12345

--- a/tools/PSc8y/PSc8y.psd1
+++ b/tools/PSc8y/PSc8y.psd1
@@ -219,6 +219,7 @@ FunctionsToExport = @(
 	'Get-UserMembershipCollection',
 	'Install-FirmwareVersion',
 	'Install-SoftwareVersion',
+	'Invoke-CancelOperation',
 	'Invoke-UserLogout',
 	'New-Agent',
 	'New-Alarm',

--- a/tools/PSc8y/Public/Invoke-CancelOperation.ps1
+++ b/tools/PSc8y/Public/Invoke-CancelOperation.ps1
@@ -1,0 +1,82 @@
+﻿# Code generated from specification version 1.0.0: DO NOT EDIT
+Function Invoke-CancelOperation {
+<#
+.SYNOPSIS
+Cancel operation
+
+.DESCRIPTION
+Cancel an operation. This is a convenience command to set an operation to the FAILED status along with a sensible default failure reason.
+Note: Cancelling an operation does not guarantee that any client that is already processing the operation will stop and in
+normal circumstances this command should be used sparingly.
+
+
+.LINK
+https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/operations_cancel
+
+.EXAMPLE
+PS> Invoke-CancelOperation -Id {{ NewOperation }}
+
+Cancel an operation
+
+.EXAMPLE
+PS> Get-OperationCollection -Device $Agent.id -Status PENDING | Invoke-CancelOperation -FailureReason "manually cancelled"
+
+Cancel multiple operations
+
+
+#>
+    [cmdletbinding(PositionalBinding=$true,
+                   HelpUri='')]
+    [Alias()]
+    [OutputType([object])]
+    Param(
+        # Operation id (required)
+        [Parameter(Mandatory = $true,
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true)]
+        [object[]]
+        $Id,
+
+        # Reason for the failure
+        [Parameter()]
+        [string]
+        $FailureReason
+    )
+    DynamicParam {
+        Get-ClientCommonParameters -Type "Update", "Template"
+    }
+
+    Begin {
+
+        if ($env:C8Y_DISABLE_INHERITANCE -ne $true) {
+            # Inherit preference variables
+            Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+
+        $c8yargs = New-ClientArgument -Parameters $PSBoundParameters -Command "operations cancel"
+        $ClientOptions = Get-ClientOutputOption $PSBoundParameters
+        $TypeOptions = @{
+            Type = "application/vnd.com.nsn.cumulocity.operation+json"
+            ItemType = ""
+            BoundParameters = $PSBoundParameters
+        }
+    }
+
+    Process {
+
+        if ($ClientOptions.ConvertToPS) {
+            $Id `
+            | Group-ClientRequests `
+            | c8y operations cancel $c8yargs `
+            | ConvertFrom-ClientOutput @TypeOptions
+        }
+        else {
+            $Id `
+            | Group-ClientRequests `
+            | c8y operations cancel $c8yargs
+        }
+        
+    }
+
+    End {}
+}

--- a/tools/PSc8y/Tests/Invoke-CancelOperation.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Invoke-CancelOperation.auto.Tests.ps1
@@ -1,0 +1,33 @@
+﻿. $PSScriptRoot/imports.ps1
+
+Describe -Name "Invoke-CancelOperation" {
+    BeforeEach {
+        $TestOperation = PSc8y\New-TestOperation
+        $Agent = PSc8y\New-TestAgent
+        $Operation1 = PSc8y\New-TestOperation -Device $Agent.id
+        $Operation2 = PSc8y\New-TestOperation -Device $Agent.id
+
+    }
+
+    It "Cancel an operation" {
+        $Response = PSc8y\Invoke-CancelOperation -Id $TestOperation.id
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It "Cancel multiple operations" {
+        $Response = PSc8y\Get-OperationCollection -Device $Agent.id -Status PENDING | Invoke-CancelOperation -FailureReason "manually cancelled"
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+
+    AfterEach {
+        if ($TestOperation.deviceId) {
+            PSc8y\Remove-ManagedObject -Id $TestOperation.deviceId -ErrorAction SilentlyContinue
+        }
+        PSc8y\Remove-ManagedObject -Id $Agent.id
+
+    }
+}
+


### PR DESCRIPTION
Simple command to update an operation by setting the status to FAILED and using a standard failureReason.

**Example**

```sh
c8y operations list --device 1234 --status EXECUTING | c8y operations cancel
```

The above command will send the following body to the HTTP request:

```json
{
  "failureReason": "User cancelled operation",
  "status": "FAILED"
}
```