### PR TITLE
docs: note that users can only set their own passwords

### DIFF
--- a/api/spec/json/users.json
+++ b/api/spec/json/users.json
@@ -503,7 +503,7 @@
     {
       "name": "resetUserPassword",
       "description": "Reset user password",
-      "descriptionLong": "The password can be reset either by issuing a password reset email (default), or be specifying a new password.",
+      "descriptionLong": "The password can be reset either by issuing a password reset email (default), or be specifying a new password.\n\nNote: In more recent Cumulocity IoT versions,  you can't set a fixed password for another user.\n",
       "method": "PUT",
       "path": "user/{tenant}/users/{id}",
       "accept": "application/vnd.com.nsn.cumulocity.user+json",
@@ -518,6 +518,7 @@
             "beforeEach": [
               "$User = PSc8y\\New-TestUser"
             ],
+            "skipTest": false,
             "command": "Reset-UserPassword -Id $User.id -Dry",
             "afterEach": [
               "PSc8y\\Remove-User -Id $User.id"
@@ -525,13 +526,8 @@
           },
           {
             "description": "Resets a user's password by generating a new password",
-            "beforeEach": [
-              "$User = PSc8y\\New-TestUser"
-            ],
-            "command": "Reset-UserPassword -Id $User.id -NewPassword (New-RandomPassword)",
-            "afterEach": [
-              "PSc8y\\Remove-User -Id $User.id"
-            ]
+            "skipTest": true,
+            "command": "Reset-UserPassword -Id $User.id -NewPassword (New-RandomPassword)"
           }
         ],
         "go": [

--- a/api/spec/yaml/users.yaml
+++ b/api/spec/yaml/users.yaml
@@ -377,7 +377,10 @@ commands:
 
   - name: resetUserPassword
     description: Reset user password
-    descriptionLong: The password can be reset either by issuing a password reset email (default), or be specifying a new password.
+    descriptionLong: |
+      The password can be reset either by issuing a password reset email (default), or be specifying a new password.
+
+      Note: In more recent Cumulocity IoT versions,  you can't set a fixed password for another user.
     method: PUT
     path: user/{tenant}/users/{id}
     accept: 'application/vnd.com.nsn.cumulocity.user+json'
@@ -389,16 +392,14 @@ commands:
         - description: Resets a user's password by sending a reset email to the user
           beforeEach:
             - $User = PSc8y\New-TestUser
+          skipTest: false
           command: Reset-UserPassword -Id $User.id -Dry
           afterEach:
             - PSc8y\Remove-User -Id $User.id
 
         - description: Resets a user's password by generating a new password
-          beforeEach:
-            - $User = PSc8y\New-TestUser
+          skipTest: true
           command: Reset-UserPassword -Id $User.id -NewPassword (New-RandomPassword)
-          afterEach:
-            - PSc8y\Remove-User -Id $User.id
       go:
         - description: Update a user
           command: c8y users resetUserPassword --id "myuser"

--- a/docs/go-c8y-cli/docs/cli/c8y/users/c8y_users_resetUserPassword.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/users/c8y_users_resetUserPassword.md
@@ -8,6 +8,9 @@ Reset user password
 
 The password can be reset either by issuing a password reset email (default), or be specifying a new password.
 
+Note: In more recent Cumulocity IoT versions,  you can't set a fixed password for another user.
+
+
 ```
 c8y users resetUserPassword [flags]
 ```

--- a/docs/go-c8y-cli/docs/cli/psc8y/Users/Reset-UserPassword.md
+++ b/docs/go-c8y-cli/docs/cli/psc8y/Users/Reset-UserPassword.md
@@ -76,6 +76,8 @@ Reset-UserPassword
 ## DESCRIPTION
 The password can be reset either by issuing a password reset email (default), or be specifying a new password.
 
+Note: In more recent Cumulocity IoT versions,  you can't set a fixed password for another user.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/pkg/cmd/users/resetuserpassword/resetUserPassword.auto.go
+++ b/pkg/cmd/users/resetuserpassword/resetUserPassword.auto.go
@@ -32,7 +32,10 @@ func NewResetUserPasswordCmd(f *cmdutil.Factory) *ResetUserPasswordCmd {
 	cmd := &cobra.Command{
 		Use:   "resetUserPassword",
 		Short: "Reset user password",
-		Long:  `The password can be reset either by issuing a password reset email (default), or be specifying a new password.`,
+		Long: `The password can be reset either by issuing a password reset email (default), or be specifying a new password.
+
+Note: In more recent Cumulocity IoT versions,  you can't set a fixed password for another user.
+`,
 		Example: heredoc.Doc(`
 $ c8y users resetUserPassword --id "myuser"
 Update a user

--- a/tools/PSc8y/Public/Reset-UserPassword.ps1
+++ b/tools/PSc8y/Public/Reset-UserPassword.ps1
@@ -7,6 +7,9 @@ Reset user password
 .DESCRIPTION
 The password can be reset either by issuing a password reset email (default), or be specifying a new password.
 
+Note: In more recent Cumulocity IoT versions,  you can't set a fixed password for another user.
+
+
 .LINK
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/users_resetUserPassword
 

--- a/tools/PSc8y/Tests/Reset-UserPassword.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Reset-UserPassword.auto.Tests.ps1
@@ -6,13 +6,13 @@ Describe -Name "Reset-UserPassword" {
 
     }
 
-    It "Resets a user's password by sending a reset email to the user" {
+    It -Skip "Resets a user's password by sending a reset email to the user" {
         $Response = PSc8y\Reset-UserPassword -Id $User.id -Dry
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }
 
-    It "Resets a user's password by generating a new password" {
+    It -Skip "Resets a user's password by generating a new password" {
         $Response = PSc8y\Reset-UserPassword -Id $User.id -NewPassword (New-RandomPassword)
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
In more recent versions of Cumulocity IoT, admin users no longer get reset the password of other users. Instead they can only send the password reset email to them.