### PR TITLE
fix: handle special characters in select flag

### DIFF
--- a/pkg/flatten/unflatten.go
+++ b/pkg/flatten/unflatten.go
@@ -3,6 +3,7 @@ package flatten
 import (
 	"strings"
 
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/gjsonpath"
 	"github.com/tidwall/sjson"
 )
 
@@ -34,8 +35,7 @@ func UnflattenOrdered(data map[string]interface{}, keys []string) (output []byte
 	for _, k := range keys {
 		if v, ok := data[k]; ok {
 			k = strings.ReplaceAll(k, KeyPrefix, ":")
-
-			output, err = sjson.SetBytes(output, k, v)
+			output, err = sjson.SetBytes(output, gjsonpath.EscapePath(k), v)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/gjsonpath/gjsonpath.go
+++ b/pkg/gjsonpath/gjsonpath.go
@@ -1,0 +1,13 @@
+package gjsonpath
+
+import "strings"
+
+// EscapePath escapes a gjson/sjson path
+func EscapePath(s string) string {
+	// https://github.com/tidwall/sjson/blob/master/sjson.go#L47
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.ReplaceAll(s, "#", "\\#")
+	s = strings.ReplaceAll(s, "@", "\\@")
+	s = strings.ReplaceAll(s, "*", "\\*")
+	return strings.ReplaceAll(s, "?", "\\?")
+}

--- a/pkg/tableviewer/tableviewer.go
+++ b/pkg/tableviewer/tableviewer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/olekukonko/ts"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/gjsonpath"
 	"github.com/tidwall/gjson"
 )
 
@@ -44,7 +45,7 @@ type TableView struct {
 func (v *TableView) getValue(value gjson.Result) []string {
 	row := []string{}
 	for i, col := range v.Columns {
-		columnValue := strings.Trim(value.Get(col).Raw, "\"")
+		columnValue := strings.Trim(value.Get(gjsonpath.EscapePath(col)).Raw, "\"")
 
 		columnWidth := v.MaxColumnWidth
 		if i < len(v.ColumnWidths) {

--- a/tests/manual/common/output/output_table.yaml
+++ b/tests/manual/common/output/output_table.yaml
@@ -24,3 +24,20 @@ tests:
         |------------|----------------------|
         | ms03       |                      |
         |------------|----------------------|
+
+  It can display paths with special characters in a table \#340:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+    command: |
+      echo '{"with@at":"one","with#hash":"two","with|pipe":"three","with*star":"four","with?questionmark":"five"}' |
+        c8y util show --select "with@at,with#hash,with|pipe,with\*star,with?questionmark" -o table --noColor
+    exit-code: 0
+    stdout:
+      exactly: |
+        | with@at    | with#hash  | with|pipe  | with*star  | with?questionmark |
+        |------------|------------|------------|------------|-------------------|
+        | one        | two        | three      | four       | five              |

--- a/tests/manual/common/select/select_special_cases.yaml
+++ b/tests/manual/common/select/select_special_cases.yaml
@@ -25,3 +25,18 @@ tests:
     stdout:
       json:
         c8y_Dashboard.15426326034650895.name: test
+
+  It selects paths with special characters in their property names \#340:
+    command: |
+      echo '{"with@at":"one","with#hash":"two","with|pipe":"three","with*star":"four","with?questionmark":"five"}' |
+        c8y util show --select "with@at,with#hash,with|pipe,with\*star,with?questionmark" --compact=false -o json
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "with#hash": "two",
+          "with*star": "four",
+          "with?questionmark": "five",
+          "with@at": "one",
+          "with|pipe": "three"
+        }


### PR DESCRIPTION
Fix a bug where the path provided by the `--select` flag would not handle paths with special characters such as `@|#?*`.

See tests for more details.

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/340

**Example**

```sh
echo '{"with@at":"one","with#hash":"two","with|pipe":"three","with*star":"four","with?questionmark":"five"}' |
        c8y util show --select "with@at,with#hash,with|pipe,with\*star,with?questionmark" -o json
```

Now outputs the following (instead of `{}`):

```json
{
  "with#hash": "two",
  "with*star": "four",
  "with?questionmark": "five",
  "with@at": "one",
  "with|pipe": "three"
}
```
