### PR TITLE
fix(retry): disable retries by default

### DIFF
--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -456,7 +456,7 @@ func (c *Config) bindSettings() {
 
 		// HTTP settings
 		WithBindEnv(SettingsUseCompression, true),
-		WithBindEnv(SettingsHTTPMaxRetries, 3),
+		WithBindEnv(SettingsHTTPMaxRetries, 0),
 		WithBindEnv(SettingsHTTPRetryWaitMax, "50s"),
 		WithBindEnv(SettingsHTTPRetryWaitMin, "5s"),
 


### PR DESCRIPTION
Retrying HTTP requests with a body will cause the entire body to be read into memory.

Until the "in memory" behaviour is resolved, the default retries will be set to 0.

Users can still opt into the retries by using the global `--retries` flag.

```
c8y devices list --retries 3
```

Ref: #343