### PR TITLE
feat(pipeline): support reading pretty printed json

### DIFF
--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -1,0 +1,95 @@
+package stream
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"unicode"
+)
+
+// InputStreamer an input streamer which breaks down a buffer into input values
+type InputStreamer struct {
+	Buffer *bufio.Reader
+}
+
+func (r *InputStreamer) isJSONObject() (bool, error) {
+	c, _, err := r.Buffer.ReadRune()
+	if err == io.EOF {
+		return false, err
+	}
+	r.Buffer.UnreadRune()
+	return c == '{', err
+}
+
+func (r *InputStreamer) consumeWhitespace() error {
+	for {
+		c, _, err := r.Buffer.ReadRune()
+		if err == io.EOF {
+			return err
+		}
+		if !unicode.IsSpace(c) {
+			r.Buffer.UnreadRune()
+			break
+		}
+	}
+	return nil
+}
+
+// ReadJSONObject read the next JSON object
+func (r *InputStreamer) ReadJSONObject() ([]byte, error) {
+	out := bytes.Buffer{}
+	brackets := 0
+	var err error
+
+	if err := r.consumeWhitespace(); err != nil {
+		return nil, err
+	}
+
+	for {
+		c, _, rErr := r.Buffer.ReadRune()
+		if rErr == io.EOF {
+			err = io.EOF
+			break
+		}
+		switch c {
+		case '{':
+			brackets++
+		case '}':
+			brackets--
+		}
+		out.WriteRune(c)
+		if brackets == 0 {
+			break
+		}
+	}
+	return out.Bytes(), err
+}
+
+// ReadLine reads the next chunk of text until the next newline char
+func (r *InputStreamer) ReadLine() ([]byte, error) {
+	return r.Buffer.ReadBytes('\n')
+}
+
+// Read reads the next delimited value (either text or JSON object)
+func (r *InputStreamer) Read() (output []byte, err error) {
+	if err := r.consumeWhitespace(); err != nil {
+		return output, err
+	}
+
+	var isJSON bool
+	isJSON, err = r.isJSONObject()
+	if err != nil {
+		return output, err
+	}
+
+	if isJSON {
+		output, err = r.ReadJSONObject()
+	} else {
+		output, err = r.ReadLine()
+		output = bytes.TrimSpace(output)
+		if err != nil {
+			return output, err
+		}
+	}
+	return output, err
+}

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -45,6 +45,9 @@ func (r *InputStreamer) ReadJSONObject() ([]byte, error) {
 		return nil, err
 	}
 
+	// Simple json object parser
+	var prev rune
+	quote := 0
 	for {
 		c, _, rErr := r.Buffer.ReadRune()
 		if rErr == io.EOF {
@@ -52,15 +55,24 @@ func (r *InputStreamer) ReadJSONObject() ([]byte, error) {
 			break
 		}
 		switch c {
+		case '"':
+			if prev != '\\' {
+				quote = (quote + 1) % 2
+			}
 		case '{':
-			brackets++
+			if quote == 0 {
+				brackets++
+			}
 		case '}':
-			brackets--
+			if quote == 0 {
+				brackets--
+			}
 		}
 		out.WriteRune(c)
 		if brackets == 0 {
 			break
 		}
+		prev = c
 	}
 	return out.Bytes(), err
 }

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -134,10 +134,21 @@ func (r *InputStreamer) Read() (output []byte, err error) {
 		output, err = r.ReadJSONObject()
 	} else {
 		output, err = r.ReadLine()
-		output = bytes.TrimSpace(output)
 		if err != nil {
 			return output, err
 		}
+		output = r.formatLine(output)
 	}
 	return output, err
+}
+
+func (r *InputStreamer) formatLine(b []byte) []byte {
+	b = bytes.TrimSpace(b)
+
+	// If has surrounding quotes then strip them
+	// as it improves compatibility with jq output when not using the -r option, e.g. `echo '{"key":"1234"}' | jq '.key' | c8y util show`
+	if bytes.HasPrefix(b, []byte("\"")) && bytes.HasSuffix(b, []byte("\"")) {
+		b = bytes.Trim(b, "\"")
+	}
+	return b
 }

--- a/pkg/stream/stream_test.go
+++ b/pkg/stream/stream_test.go
@@ -45,7 +45,7 @@ func Test_Read_Simple(t *testing.T) {
 	input := strings.TrimSpace(`
 1
 
-2
+"2"
 3
 `)
 	s := newTestStreamer(input, false)

--- a/pkg/stream/stream_test.go
+++ b/pkg/stream/stream_test.go
@@ -21,10 +21,10 @@ func Test_ScanJSONObject_Consuming(t *testing.T) {
 	}{
 		{
 			Input: `
-	{"name":"1"}
+	{"name":"1 {literal \" value}"}
 		`,
 			Output: []string{
-				`{"name":"1"}`,
+				`{"name":"1 {literal \" value}"}`,
 			},
 			Error: nil,
 		},

--- a/pkg/stream/stream_test.go
+++ b/pkg/stream/stream_test.go
@@ -46,6 +46,7 @@ func Test_Read_Simple(t *testing.T) {
 1
 
 "2"
+ 1.23
 3
 `)
 	s := newTestStreamer(input, false)
@@ -64,6 +65,10 @@ func Test_Read_Simple(t *testing.T) {
 	obj, err = s.Read()
 	assert.Nil(t, err)
 	assert.Equal(t, "2", string(obj))
+
+	obj, err = s.Read()
+	assert.Nil(t, err)
+	assert.Equal(t, "1.23", string(obj))
 
 	obj, err = s.Read()
 	assert.ErrorIs(t, err, io.EOF)

--- a/pkg/stream/stream_test.go
+++ b/pkg/stream/stream_test.go
@@ -1,0 +1,74 @@
+package stream
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createBuffer(v string) *bufio.Reader {
+	return bufio.NewReader(strings.NewReader(v))
+}
+
+func Test_ScanJSONObject_Consuming(t *testing.T) {
+	data := []struct {
+		Input  string
+		Output []string
+		Error  error
+	}{
+		{
+			Input: `
+	{"name":"1"}
+		`,
+			Output: []string{
+				`{"name":"1"}`,
+			},
+			Error: nil,
+		},
+		{
+			Input: `
+	{"name":"1"}{"name":"2"}
+one
+two
+
+		`,
+			Output: []string{
+				`{"name":"1"}`,
+				`{"name":"2"}`,
+				`one`,
+				`two`,
+			},
+			Error: nil,
+		},
+		{
+			Input: `{"name":{"1":{"2":{"3":{"4":{"5":"value"}}}}}}{"name":"2"}
+
+		`,
+			Output: []string{
+				`{"name":{"1":{"2":{"3":{"4":{"5":"value"}}}}}}`,
+				`{"name":"2"}`,
+			},
+			Error: nil,
+		},
+		{
+			Input: `{"name":"1"`,
+			Output: []string{
+				`{"name":"1"`,
+			},
+			Error: io.EOF,
+		},
+	}
+	for _, testcase := range data {
+		s := InputStreamer{
+			Buffer: createBuffer(testcase.Input),
+		}
+
+		for _, iOutput := range testcase.Output {
+			out, _ := s.Read()
+			assert.Equal(t, iOutput, string(out))
+		}
+	}
+}

--- a/tests/manual/pipeline/mixed_pipeline.txt
+++ b/tests/manual/pipeline/mixed_pipeline.txt
@@ -1,6 +1,7 @@
 {"name": "device01"}{"name": "device02"}
     {"name": "device03"}
     device04
+"device05"
 {
-    "name": "device05"
+    "name": "device06"
 }

--- a/tests/manual/pipeline/mixed_pipeline.txt
+++ b/tests/manual/pipeline/mixed_pipeline.txt
@@ -1,0 +1,4 @@
+{"name": "device01"}{"name": "device02"}
+    {"name": "device03"}
+    device04
+device05

--- a/tests/manual/pipeline/mixed_pipeline.txt
+++ b/tests/manual/pipeline/mixed_pipeline.txt
@@ -1,4 +1,6 @@
 {"name": "device01"}{"name": "device02"}
     {"name": "device03"}
     device04
-device05
+{
+    "name": "device05"
+}

--- a/tests/manual/pipeline/piping_pretty_json.yaml
+++ b/tests/manual/pipeline/piping_pretty_json.yaml
@@ -23,3 +23,4 @@ tests:
         {"body":{"c8y_IsDevice":{},"name":"device03"}}
         {"body":{"c8y_IsDevice":{},"name":"device04"}}
         {"body":{"c8y_IsDevice":{},"name":"device05"}}
+        {"body":{"c8y_IsDevice":{},"name":"device06"}}

--- a/tests/manual/pipeline/piping_pretty_json.yaml
+++ b/tests/manual/pipeline/piping_pretty_json.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+#
+# Piping pretty printed json
+#
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET PUT POST
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
+
+tests:
+  It supports reading mixed piped input:
+    command: |
+      cat manual/pipeline/mixed_pipeline.txt |
+      c8y devices create --dry |
+        c8y util show --select body -o json -c
+    exit-code: 0
+    stdout:
+      exactly: |
+        {"body":{"c8y_IsDevice":{},"name":"device01"}}
+        {"body":{"c8y_IsDevice":{},"name":"device02"}}
+        {"body":{"c8y_IsDevice":{},"name":"device03"}}
+        {"body":{"c8y_IsDevice":{},"name":"device04"}}
+        {"body":{"c8y_IsDevice":{},"name":"device05"}}


### PR DESCRIPTION
Improve pipeline parsing to also accept pretty printed json objects, and also mixing between json objects and non json objects.

The following pipeline formats are now supported:

* pretty printed json
* multiple json objects on the same line, e.g. `{"name":"1"}{"name":"2"}`
* mixing json and text input
* trailing newline is no longer required when reading files
* lines with double quotes surrounding the string

**Example: Mixed input**

Given the following file `input.txt`

```
{"name": "device01"}{"name": "device02"}
    {"name": "device03"}
    device04
"device05"
{
    "name": "device06"
}
```

You can pipe the above file to c8y:

```sh
cat input.txt | c8y devices create --dry
```

Which will create 5 devices:

```
| id           | name          |
|--------------|---------------|
| 6424206      | device01      |
| 4924207      | device02      |
| 7822239      | device03      |
| 3422240      | device04      |
| 5223225      | device05      |
| 5264003      | device06      |
```

Previously, the previously more strict parsing would of only created 3 devices (as invalid lines would of been ignored)

```
| id           | name          |
|--------------|---------------|
| 6424206      | device01      |
| 7822239      | device03      |
| 3422240      | device04      |
```