### PR TITLE
feat(application list): add support for `tenant` and `hasVersions` filters

### DIFF
--- a/api/spec/json/applications.json
+++ b/api/spec/json/applications.json
@@ -78,6 +78,16 @@
           "name": "user",
           "type": "user[]",
           "description": "The ID of a user that has access to the applications."
+        },
+        {
+          "name": "tenant",
+          "type": "tenantname",
+          "description": "The ID of a tenant that either owns the application or is subscribed to the applications."
+        },
+        {
+          "name": "hasVersions",
+          "type": "boolean",
+          "description": "When set to true, the returned result contains applications with an applicationVersions field that is not empty. When set to false, the result will contain applications with an empty applicationVersions field."
         }
       ]
     },

--- a/api/spec/yaml/applications.yaml
+++ b/api/spec/yaml/applications.yaml
@@ -61,6 +61,13 @@ commands:
         type: user[]
         description: The ID of a user that has access to the applications.
 
+      - name: tenant
+        type: tenantname
+        description: The ID of a tenant that either owns the application or is subscribed to the applications.
+
+      - name: hasVersions
+        type: boolean
+        description: When set to true, the returned result contains applications with an applicationVersions field that is not empty. When set to false, the result will contain applications with an empty applicationVersions field.
 
   - name: newApplication
     description: Create application

--- a/pkg/cmd/applications/list/list.auto.go
+++ b/pkg/cmd/applications/list/list.auto.go
@@ -58,6 +58,8 @@ Check if a user has access to the cockpit application
 	cmd.Flags().String("providedFor", "", "The ID of a tenant that is subscribed to the applications but doesn't own them.")
 	cmd.Flags().String("subscriber", "", "The ID of a tenant that is subscribed to the applications.")
 	cmd.Flags().StringSlice("user", []string{""}, "The ID of a user that has access to the applications.")
+	cmd.Flags().String("tenant", "", "The ID of a tenant that either owns the application or is subscribed to the applications.")
+	cmd.Flags().Bool("hasVersions", false, "When set to true, the returned result contains applications with an applicationVersions field that is not empty. When set to false, the result will contain applications with an empty applicationVersions field.")
 
 	completion.WithOptions(
 		cmd,
@@ -67,6 +69,7 @@ Check if a user has access to the cockpit application
 		completion.WithTenantID("providedFor", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 		completion.WithTenantID("subscriber", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 		completion.WithUser("user", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithTenantID("tenant", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
@@ -77,6 +80,7 @@ Check if a user has access to the cockpit application
 		flags.WithPipelineAliases("owner", "tenant", "owner.tenant.id"),
 		flags.WithPipelineAliases("providedFor", "tenant", "owner.tenant.id"),
 		flags.WithPipelineAliases("subscriber", "tenant", "owner.tenant.id"),
+		flags.WithPipelineAliases("tenant", "tenant", "owner.tenant.id"),
 
 		flags.WithCollectionProperty("applications"),
 	)
@@ -121,6 +125,8 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("providedFor", "providedFor"),
 		flags.WithStringValue("subscriber", "subscriber"),
 		c8yfetcher.WithUserByNameFirstMatch(n.factory, args, "user", "user"),
+		flags.WithStringValue("tenant", "tenant"),
+		flags.WithBoolValue("hasVersions", "hasVersions", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tools/PSc8y/Public/Get-ApplicationCollection.ps1
+++ b/tools/PSc8y/Public/Get-ApplicationCollection.ps1
@@ -52,7 +52,17 @@ Get applications
         # The ID of a user that has access to the applications.
         [Parameter()]
         [object[]]
-        $User
+        $User,
+
+        # The ID of a tenant that either owns the application or is subscribed to the applications.
+        [Parameter()]
+        [string]
+        $Tenant,
+
+        # When set to true, the returned result contains applications with an applicationVersions field that is not empty. When set to false, the result will contain applications with an empty applicationVersions field.
+        [Parameter()]
+        [switch]
+        $HasVersions
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"


### PR DESCRIPTION
Add support for the `--tenant <name>` and `--hasVersions` flags when listing applications.

Most notably `--hasVersions` can be used to only return applications which are "versioned enabled", e.g. applications from the new(ish) Cumulocity Extensions.

```sh
c8y applications list --hasVersions
```