### PR TITLE
feat(microservices): support updating roles property from a given microservice manifest file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.14.13
+	github.com/reubenmiller/go-c8y v0.14.14
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.14.13 h1:CK00MpLOfk15x8HD1tSxoTCtwWn83Rg57pLR2Clzkbg=
-github.com/reubenmiller/go-c8y v0.14.13/go.mod h1:ydYE0HPlY3NZSCWeiMQ4KsUukbfuzyfTSGZYmnTW+m4=
+github.com/reubenmiller/go-c8y v0.14.14 h1:no82rLOqB/DG1F6LoRXV8fi/bt2guc6WUQk+33aPzu4=
+github.com/reubenmiller/go-c8y v0.14.14/go.mod h1:5F2Z5V0A1dkaSva48iVxLUuDE866rvSe8zi3fAPxZ6Y=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -71,6 +71,9 @@ Create new microservice
 
 $ c8y microservices create --name my-application --file ./myapp.zip
 Create or update a microservice using an explicit name
+
+$ c8y microservices create --file ./manifest/cumulocity.json
+Create or update an existing microservice using it's manifest file. This will set the requiredRoles and roles defined in the given manifest file
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -35,7 +35,7 @@ type Manifest struct {
 	Name          string   `json:"name"`
 	Version       string   `json:"version"`
 	RequiredRoles []string `json:"requiredRoles"`
-	Roles         []string `json:"roles"`
+	Roles         []string `json:"roles,omitempty"`
 }
 
 type CmdCreate struct {
@@ -292,10 +292,16 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 		// will be hosted outside of the platform
 		//
 		// Read the Cumulocity.json file, and upload
-		log.Infof("updating application details [id=%s], requiredRoles=%s", application.ID, strings.Join(applicationDetails.Manifest.RequiredRoles, ","))
+		log.Infof(
+			"updating application details [id=%s], requiredRoles=%s, roles=%s",
+			application.ID,
+			strings.Join(applicationDetails.Manifest.RequiredRoles, ","),
+			strings.Join(applicationDetails.Manifest.Roles, ","),
+		)
 		if !dryRun {
 			_, response, err = client.Application.Update(context.Background(), application.ID, &c8y.Application{
 				RequiredRoles: applicationDetails.Manifest.RequiredRoles,
+				Roles:         applicationDetails.Manifest.Roles,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Support setting roles which are defined in a Microservice's manifest file.

Previously the `requiredRoles` were updated, but the `roles` were ignored.

**Example: Create microservice placeholder using a manifest file**

```sh
c8y microservices create --file ./cumulocity.json
```