### PR TITLE
feat: hide sensitive info by default

### DIFF
--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -484,7 +484,7 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsViewColumnPadding, 15),
 		WithBindEnv(SettingsViewRowMode, "truncate"),
 
-		WithBindEnv(SettingsLoggerHideSensitive, false),
+		WithBindEnv(SettingsLoggerHideSensitive, true),
 
 		WithBindEnv(SettingsCacheMethods, "GET PUT POST DELETE"),
 		WithBindEnv(SettingsCacheKeyHost, true),

--- a/tests/manual/applications/createHostedApplication/applications_createHostedApplication.yaml
+++ b/tests/manual/applications/createHostedApplication/applications_createHostedApplication.yaml
@@ -7,27 +7,27 @@ config:
 tests:
     Create hosted (web) application overriding an existing application:
         command: |
-          c8y applications createHostedApplication --name devicemanagement --dry
+          c8y applications createHostedApplication --name cockpit --dry
         exit-code: 0
         stdout:
             json:
                 method: POST
                 path: /application/applications
-                body.name: devicemanagement
-                body.contextPath: devicemanagement
-                body.key: devicemanagement-application-key
+                body.name: cockpit
+                body.contextPath: cockpit
+                body.key: cockpit-application-key
                 body.type: HOSTED
                 body.resourcesUrl: /
 
     Create hosted (web) application from folder:
         command: |
-          c8y applications createHostedApplication --name devicemanagement --file "./manual/applications/createHostedApplication/simple-helloworld" --dry --skipUpload
+          c8y applications createHostedApplication --name cockpit --file "./manual/applications/createHostedApplication/simple-helloworld" --dry --skipUpload
         exit-code: 0
         stdout:
             json:
                 method: POST
                 path: /application/applications
-                body.name: devicemanagement
+                body.name: cockpit
                 body.contextPath: custom-app
                 body.key: custom-app-key
                 body.type: HOSTED


### PR DESCRIPTION
Change the default value of `logger.hideSensitive`  to `true` to reduce accidental exposure of credentials when people are screen sharing.

If you are unhappy with the new default value, then you can add the following to your shell profile:

```sh
# zsh/bash/fish
eval "$(c8y settings update logger.hideSensitive false --shell auto)"

# powershell
c8y settings update logger.hideSensitive false --shell powershell | invoke-expression
```