### PR TITLE
feat(set-session): ignore existing token if it is not valid for a minimum duration

### DIFF
--- a/docs/go-c8y-cli/docs/configuration/settings.md
+++ b/docs/go-c8y-cli/docs/configuration/settings.md
@@ -417,6 +417,10 @@ Enable `UPDATE` commands. If set to `false` then all `UPDATE` related commands w
 
 Default username which is used when creating a new command via `c8y sessions create`
 
+### session.tokenValidFor: string
+
+The minimum duration (e.g. `8h`) that a token should be valid for in order to reuse it. You can control when to renew it when setting the active session, and ignore the token if it is to expire soon based on the duration.
+
 ### storage.storepassword: boolean
 
 Enable storage of your password in your session file. Disable if you do not want to store sensitive information to file. However this means you will be prompted for your password when you select a session via `set-session`.

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require github.com/hashicorp/go-version v1.6.0
 
 require (
 	github.com/cli/browser v1.3.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3
 )

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -303,6 +303,13 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"true",
 		"false",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
+	"session.tokenValidFor": {"session.tokenValidFor", "string", config.SettingsSessionTokenValidFor, []string{
+		"1h",
+		"8h",
+		"24h",
+		"48h",
+		"7d",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
 	// cache
 	"defaults.cache": {"defaults.cache", "bool", config.SettingsDefaultsCacheEnabled, []string{

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -291,6 +291,9 @@ const (
 	// SettingsSessionAlwaysIncludePassword should the password always be included in the session variables or not
 	SettingsSessionAlwaysIncludePassword = "settings.session.alwaysIncludePassword"
 
+	// SettingsSessionTokenValidFor interval which the token must be valid for in order to reuse it
+	SettingsSessionTokenValidFor = "settings.session.tokenValidFor"
+
 	// Cache settings
 	// SettingsDefaultsCacheEnabled enable caching
 	SettingsDefaultsCacheEnabled = "settings.defaults.cache"
@@ -498,6 +501,7 @@ func (c *Config) bindSettings() {
 
 		// Session options
 		WithBindEnv(SettingsSessionAlwaysIncludePassword, false),
+		WithBindEnv(SettingsSessionTokenValidFor, "8h"),
 
 		WithBindEnv(SettingsBrowser, ""),
 
@@ -976,6 +980,17 @@ func (c *Config) GetDefaultUsername() string {
 // AlwaysIncludePassword password when setting a session
 func (c *Config) AlwaysIncludePassword() bool {
 	return c.viper.GetBool(SettingsSessionAlwaysIncludePassword)
+}
+
+// TokenValidFor minimum validity of a token in order to reuse it
+func (c *Config) TokenValidFor() time.Duration {
+	value := c.viper.GetString(SettingsSessionTokenValidFor)
+	duration, err := flags.GetDuration(value, true, time.Second)
+	if err != nil {
+		c.Logger.Warnf("Invalid duration. value=%s, err=%s", duration, err)
+		return 0
+	}
+	return duration
 }
 
 // CachePassphraseVariables return true if the passphrase variables should be persisted or not


### PR DESCRIPTION
Control if an existing token should be reused or not by enforcing a minimum validity period. If the token is not valid for at least the given duration, then it will be ignored. This reduces the situations where 

The default `session.tokenValidFor` value is `8h`.

**Example**

Set a custom token validity period to 24 hours.

```sh
c8y settings update session.tokenValidFor 24h
```

When activating a session, the following warning will be displayed if the token is ignored if the token is not valid for at least 24 hours.

```sh
set-session my session
WARN    Ignoring existing token as it will expire soon. minimumValidFor=24h0m0s, tokenExpiresAt=2024-04-29T10:07:41+02:00
```
