### PR TITLE
fix(data): show error when --data mixes data types

### DIFF
--- a/tests/manual/common/flag_data.yaml
+++ b/tests/manual/common/flag_data.yaml
@@ -64,3 +64,11 @@ tests:
             "subtypes": ["linuxA", "linuxB"]
           }
         }
+
+  It should not panic when mixing data types:
+    command: |
+      c8y devices create -n --data one=1 --data one.two=null --dry
+    exit-code: 101
+    stderr:
+      not-contains:
+        - panic


### PR DESCRIPTION
Invalid shorthand json provided by the user on `--data` no longer panics. Instead an more helpful error message is given to the user.

Previously the following would cause a panic because the `one` property is being used to assing both a number and an object.

**Example**

Below shows the new behaviour (e.g. error message instead of a panci):

```sh
c8y devices create -n --data one=1 --data one.two=null --dry
```

```text
2024-05-18T23:17:04.910+0200    ERROR   commandError: json error: data parameter does not contain valid json or shorthand json. Invalid shorthand JSON: mixed types detected. trying to assign an object to a float64. path=one
```