### PR TITLE
feat(table view): Support metric number mode to display very small and large numbers concisely

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require github.com/hashicorp/go-version v1.6.0
 
 require (
 	github.com/cli/browser v1.3.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -408,6 +408,7 @@ func Initialize() (*root.CmdRoot, error) {
 		MinEmptyValueColumnWidth: configHandler.ViewColumnEmptyValueMinWidth(),
 		ColumnPadding:            configHandler.ViewColumnPadding(),
 		RowMode:                  configHandler.ViewRowMode(),
+		NumberFormatter:          configHandler.GetTableViewNumberFormatter(),
 	}
 	consoleHandler = console.NewConsole(rootCmd.OutOrStdout(), tableOptions, func(s []string) []byte {
 		return getOutputHeaders(consoleHandler, configHandler, s)

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -59,6 +59,11 @@ func (h argumentHandler) GetValue(rawValue string) interface{} {
 			return v
 		}
 		return nil
+	case "float64":
+		if v, err := strconv.ParseFloat(rawValue, 64); err == nil {
+			return v
+		}
+		return nil
 	default:
 		return rawValue
 	}
@@ -391,6 +396,34 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"20",
 		"25",
 		"30",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	//
+	// Table view number format
+	//
+	"views.numberFormat": {"views.numberFormat", "string", config.SettingsViewNumberFormat, []string{
+		"none",
+		"metric",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"views.metric.precision": {"views.metric.precision", "int", config.SettingsViewNumbersMetricPrecision, []string{
+		"2",
+		"3",
+		"4",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"views.metric.rangeMin": {"views.metric.rangeMin", "float64", config.SettingsViewNumbersMetricActivateRangeMin, []string{
+		"0.00001",
+		"0.001",
+		"0.1",
+		"1",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"views.metric.rangeMax": {"views.metric.rangeMax", "float64", config.SettingsViewNumbersMetricActivateRangeMax, []string{
+		"1000",
+		"10000",
+		"100000\tdefault",
+		"1000000",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
 	// extensions

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonUtilities"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/numbers"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/tableviewer"
 	"github.com/tidwall/pretty"
 )
@@ -45,6 +46,9 @@ type TableOptions struct {
 
 	// Row mode (truncate or wrap)
 	RowMode string
+
+	// NumberFormatter formatting used when rendering numbers
+	NumberFormatter numbers.NumberFormatter
 }
 
 // NewConsole create a new console writer
@@ -54,13 +58,17 @@ func NewConsole(w io.Writer, tableOptions *TableOptions, header func([]string) [
 	columnPadding := 15
 	minEmptyWidth := 0
 	rowMode := ""
+	var numberFormatter numbers.NumberFormatter
+
 	if tableOptions != nil {
 		minColumnWidth = tableOptions.MinColumnWidth
 		maxColumnWidth = tableOptions.MaxColumnWidth
 		columnPadding = tableOptions.ColumnPadding
 		minEmptyWidth = tableOptions.MinEmptyValueColumnWidth
 		rowMode = tableOptions.RowMode
+		numberFormatter = tableOptions.NumberFormatter
 	}
+
 	return &Console{
 		out:    w,
 		header: header,
@@ -72,6 +80,7 @@ func NewConsole(w io.Writer, tableOptions *TableOptions, header func([]string) [
 			MinEmptyValueColumnWidth: minEmptyWidth,
 			EnableColor:              false,
 			RowMode:                  rowMode,
+			NumberFormatter:          numberFormatter,
 		},
 		Format: config.OutputTable,
 	}

--- a/pkg/numbers/numbers.go
+++ b/pkg/numbers/numbers.go
@@ -1,0 +1,51 @@
+package numbers
+
+import "github.com/dustin/go-humanize"
+
+type NumberFormatter interface {
+	Display(float64, string, string) string
+}
+
+type RawNumber struct{}
+
+func (rawNum *RawNumber) Display(v float64, raw string, unit string) string {
+	return raw
+}
+
+type NumberWithCommas struct{}
+
+func (rawNum *NumberWithCommas) Display(v float64, raw string, unit string) string {
+	return humanize.Commaf(v)
+}
+
+type NumberViewOptions struct {
+	Precision        int
+	ActivateRangeMin float64
+	ActivateRangeMax float64
+}
+
+func NewNumberViewOptions(precision int, rangeMin float64, rangeMax float64) *NumberViewOptions {
+	return &NumberViewOptions{
+		Precision:        precision,
+		ActivateRangeMin: rangeMin,
+		ActivateRangeMax: rangeMax,
+	}
+}
+
+func (num *NumberViewOptions) GetPrecision() int {
+	if num.Precision < 0 {
+		return 2
+	}
+	return num.Precision
+}
+
+func (num *NumberViewOptions) Display(v float64, raw string, unit string) string {
+	if num.IsVerySmallOrVeryLarge(v) {
+		return humanize.SIWithDigits(v, num.Precision, unit)
+	}
+	return raw
+}
+
+func (num *NumberViewOptions) IsVerySmallOrVeryLarge(v float64) bool {
+	return v <= num.ActivateRangeMin || v >= num.ActivateRangeMax
+}

--- a/pkg/tableviewer/tableviewer.go
+++ b/pkg/tableviewer/tableviewer.go
@@ -33,6 +33,7 @@ type TableView struct {
 	Out                      io.Writer
 	Columns                  []string
 	ColumnWidths             []int
+	ColumnAlignments         []int
 	MinColumnWidth           int
 	MinEmptyValueColumnWidth int
 	MaxColumnWidth           int
@@ -46,6 +47,13 @@ type TableView struct {
 
 func (v *TableView) getValue(value gjson.Result) []string {
 	row := []string{}
+
+	addAlignments := false
+	if v.ColumnAlignments == nil {
+		v.ColumnAlignments = make([]int, 0)
+		addAlignments = true
+	}
+
 	for i, col := range v.Columns {
 		node := value.Get(gjsonpath.EscapePath(col))
 
@@ -267,6 +275,7 @@ func (v *TableView) Render(jsonData []byte, withHeader bool) {
 
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetColumnAlignment(v.ColumnAlignments)
 
 	wrapEnabled := v.RowMode == RowModeWrap
 

--- a/tests/manual/common/output/numbers.jsonl
+++ b/tests/manual/common/output/numbers.jsonl
@@ -1,0 +1,13 @@
+{"value":0.000000000001,"storageSize":0.000000000001}
+{"value":0.000000001,"storageSize":0.000000001}
+{"value":0.000001,"storageSize":0.000001}
+{"value":10,"storageSize":10}
+{"value":110,"storageSize":110}
+{"value":3000,"storageSize":3000}
+{"value":10000,"storageSize":10000}
+{"value":50000,"storageSize":50000}
+{"value":9999999,"storageSize":9999999}
+{"value":123456789,"storageSize":123456789}
+{"value":1234567.501202,"storageSize":1234567.501202}
+{"value":2038373478888889,"storageSize":2038373478888889}
+{"value":203837347888,"storageSize":203837347888}

--- a/tests/manual/common/output/output_table.yaml
+++ b/tests/manual/common/output/output_table.yaml
@@ -41,3 +41,98 @@ tests:
         | with@at    | with#hash  | with|pipe  | with*star  | with?questionmark |
         |------------|------------|------------|------------|-------------------|
         | one        | two        | three      | four       | five              |
+
+  It can display very small and very large numbers using a metric prefix:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+    command: |
+      cat manual/common/output/numbers.jsonl |
+        c8y util show --select "value" --output table
+    exit-code: 0
+    stdout:
+      exactly: |
+        | value      |
+        |------------|
+        |        1 p |
+        |        1 n |
+        |        1 µ |
+        |         10 |
+        |        110 |
+        |       3000 |
+        |      10000 |
+        |      50000 |
+        |     9.99 M |
+        |   123.45 M |
+        |     1.23 M |
+        |     2.03 P |
+        |   203.83 G |
+
+  It can control the precision and min/max range of the metric prefix:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+        C8Y_SETTINGS_VIEWS_NUMBERFORMAT: metric
+        C8Y_SETTINGS_VIEWS_METRIC_PRECISION: 3
+        C8Y_SETTINGS_VIEWS_METRIC_RANGEMIN: 0.00000001
+        C8Y_SETTINGS_VIEWS_METRIC_RANGEMAX: 100000
+    command: |
+      cat manual/common/output/numbers.jsonl |
+        c8y util show --select "value" --output table
+    exit-code: 0
+    stdout:
+      exactly: |
+        | value      |
+        |------------|
+        |        1 p |
+        |        1 n |
+        |   0.000001 |
+        |         10 |
+        |        110 |
+        |       3000 |
+        |      10000 |
+        |      50000 |
+        |    9.999 M |
+        |  123.456 M |
+        |    1.234 M |
+        |    2.038 P |
+        |  203.837 G |
+
+  It can use no number formatter:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+        C8Y_SETTINGS_VIEWS_NUMBERFORMAT: none
+        C8Y_SETTINGS_VIEWS_METRIC_PRECISION: 3
+        C8Y_SETTINGS_VIEWS_METRIC_RANGEMIN: 0.00000001
+        C8Y_SETTINGS_VIEWS_METRIC_RANGEMAX: 100000
+    command: |
+      cat manual/common/output/numbers.jsonl |
+        c8y util show --select "value" --output table
+    exit-code: 0
+    stdout:
+      exactly: |
+        | value      |
+        |------------|
+        |      1e-12 |
+        |       1e-9 |
+        |   0.000001 |
+        |         10 |
+        |        110 |
+        |       3000 |
+        |      10000 |
+        |      50000 |
+        |    9999999 |
+        |  123456789 |
+        | 1234567.5… |
+        | 203837347… |
+        | 203837347… |


### PR DESCRIPTION
New table view number formatting mode to help display very small or very large numbers in a more human readable format. The new `metric` number format is enable by default as it makes large numbers more readable, and it makes more efficient usage of the table column width.

In addition to the new number format mode, numbers are now aligned to the right of the column (rather than left). This should also make the numbers more readable (at least via western conventions).

**Example**

Given the input data set:

**file: large-num.jsonl**

```json
{"value":0.000000000001,"storageSize":0.000000000001}
{"value":0.000000001,"storageSize":0.000000001}
{"value":0.000001,"storageSize":0.000001}
{"value":10,"storageSize":10}
{"value":110,"storageSize":110}
{"value":3000,"storageSize":3000}
{"value":10000,"storageSize":10000}
{"value":50000,"storageSize":50000}
{"value":9999999,"storageSize":9999999}
{"value":123456789,"storageSize":123456789}
{"value":1234567.501202,"storageSize":1234567.501202}
{"value":2038373478888889,"storageSize":2038373478888889}
{"value":203837347888,"storageSize":203837347888}
```

When using the metric number mode in the table view, the above numbers will be displayed as follows:

```sh
% cat large-num.jsonl | c8y util show --select value
| value      |
|------------|
|        1 p |
|        1 n |
|        1 µ |
|         10 |
|        110 |
|       3000 |
|      10000 |
|      50000 |
|     9.99 M |
|   123.45 M |
|     1.23 M |
|     2.03 P |
|   203.83 G |
```

**Controlling the number format**

You can turn off the default `metric` number format mode by using the following setting:

```sh
# Use old number mode (e.g. no number formatting)
c8y settings update views.numberFormat none

# Use metric number mode
c8y settings update views.numberFormat metric
```

The metric mode can be controlled by the following settings:

```sh
# Change number of decimal places to use
c8y settings update views.metric.precision 3

# Change min-max range
# When a number is inside the range, the metric prefix will not be added
c8y settings update views.metric.rangeMin 0.00000001
c8y settings update views.metric.rangeMax 1000000
```

**Additional info**

Check out the [metric prefix format](https://en.wikipedia.org/wiki/Metric_prefix) for more details about what each prefix means.