### PR TITLE
build: update deprecated goreleaser syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        version: latest
+        version: '~> v1'
         install-only: true
 
     - name: Install Task

--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        version: latest
+        version: '~> v1'
         install-only: true
 
     - name: Install Task

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
-          version: latest
+          version: '~> v1'
           install-only: true
 
       - name: Publish Release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -174,7 +174,7 @@ brews:
       email: reuben.d.miller@gmail.com
 
     # Folder inside the repository to put the formula.
-    folder: Formula
+    directory: Formula
 
     # Caveats for the user of your binary.
     caveats: |


### PR DESCRIPTION
Address goreleaser deprecation warning:

```
DEPRECATED:  brews.folder  should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info
```