### PR TITLE
fix(notification2): avoid panic due to concurrent socket writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.16.0
+	github.com/reubenmiller/go-c8y v0.19.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.16.0 h1:z/aZ46kzzsOsR/bKkq9psOFa7DINkVXo0J8RBfnPnGI=
-github.com/reubenmiller/go-c8y v0.16.0/go.mod h1:l62OddfIaFxv+OosDiPTKu54B2qKgiQ9MRr2xM8WKTI=
+github.com/reubenmiller/go-c8y v0.19.1 h1:qXxfO0wheWewziAuNZjPzetcDZKo2yTlSeb57oAdliE=
+github.com/reubenmiller/go-c8y v0.19.1/go.mod h1:bNJLF+fokWDpztGiX5CsbEY5F8c3h9Wwu6c2uHdG0S8=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Update go-c8y lib which includes a fix to avoid concurrent socket writes in the notifications2 client.