### PR TITLE
docs: fix type in set sessions example

### DIFF
--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_set.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_set.md
@@ -15,7 +15,7 @@ c8y sessions set [flags]
 ### Examples
 
 ```
-$ eval $( c8y session set )
+$ eval $( c8y sessions set )
 Set a session interactively
 
 $ eval $( c8y sessions set --sessionFilter "company dev" )

--- a/docs/go-c8y-cli/docs/concepts/sessions.md
+++ b/docs/go-c8y-cli/docs/concepts/sessions.md
@@ -338,7 +338,7 @@ c8y sessions set --shell=auto --session "/my/path/session.json" | Out-String | I
 </Tabs>
 
 :::info
-`set-session` is a small helper function (for each supported shell) which wraps the call to `c8y session set` and sets the returned environment variables which are then read by subsequent calls to `c8y`.
+`set-session` is a small helper function (for each supported shell) which wraps the call to `c8y sessions set` and sets the returned environment variables which are then read by subsequent calls to `c8y`.
 :::
 
 ### Switching session for a single command

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -45,7 +45,7 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 		Short: "Set Cumulocity session",
 		Long:  `Set a session, login and test the session and get either OAuth2 token, or using two factor authentication`,
 		Example: heredoc.Doc(`
-			$ eval $( c8y session set )
+			$ eval $( c8y sessions set )
 			Set a session interactively
 
 			$ eval $( c8y sessions set --sessionFilter "company dev" )

--- a/pkg/cmd/software/versions/create/create.manual.go
+++ b/pkg/cmd/software/versions/create/create.manual.go
@@ -179,6 +179,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 	var resp *c8y.Response
 	var respErr error
 	bounded := inputIterators.Total > 0
+	// TODO: Use new generic worker setup and execute both path and body!
 	for {
 		softwareID, _, err := path.Execute(false)
 		if err != nil {


### PR DESCRIPTION
Fix a type in the `c8y sessions set` example where `session` was used instead of `sessions`.