### PR TITLE
feat(sessions): add alias for sessions subcommand

### DIFF
--- a/pkg/cmd/sessions/sessions.manual.go
+++ b/pkg/cmd/sessions/sessions.manual.go
@@ -22,9 +22,10 @@ func NewSubCommand(f *cmdutil.Factory) *sessionsCmd {
 	ccmd := &sessionsCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "sessions",
-		Short: "Cumulocity sessions",
-		Long:  `Manage Cumulocity sessions`,
+		Use:     "sessions",
+		Aliases: []string{"session"},
+		Short:   "Cumulocity sessions",
+		Long:    `Manage Cumulocity sessions`,
 	}
 
 	// Subcommands


### PR DESCRIPTION
Support an alias for `c8y sessions` which allows calling the subcommand using `c8y session`. The change was triggered by some inconsistency within examples both in the code an documentation, so adding the alias would ensure the documentation is correct (although inconsistent).

**Example**

The following command are not both valid:

```sh
c8y sessions
c8y session
```