### PR TITLE
feat(microservice): strip auto index suffixes from microservice filenames when parsing

### DIFF
--- a/pkg/artifact/artifact.go
+++ b/pkg/artifact/artifact.go
@@ -10,6 +10,13 @@ func ParseName(file string) string {
 	baseFileName := filepath.Base(file)
 	fileExt := filepath.Ext(baseFileName)
 	baseFileName = baseFileName[0 : len(baseFileName)-len(fileExt)]
+
+	// Strip suffixes which are added by OS's when downloading file which already exists in the
+	// target directory.
+	// e.g. "./cloud-http-proxy (1).zip"
+	suffixRegex := regexp.MustCompile(`\s+\(\d+\)$`)
+	baseFileName = suffixRegex.ReplaceAllString(baseFileName, "")
+
 	versionRegex := regexp.MustCompile(`([_-]v?\d+\.\d+\.\d+(-SNAPSHOT)?)?$`)
 	return versionRegex.ReplaceAllString(baseFileName, "")
 }

--- a/pkg/artifact/artifact_test.go
+++ b/pkg/artifact/artifact_test.go
@@ -1,0 +1,32 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Filename(t *testing.T) {
+	cases := []struct {
+		Filename string
+		Expected string
+	}{
+		{
+			Filename: "./cloud-http-proxy (1).zip",
+			Expected: "cloud-http-proxy",
+		},
+		{
+			Filename: "./helloworld3-0.0.1-SNAPSHOT.zip",
+			Expected: "helloworld3",
+		},
+		{
+			Filename: "./helloworld3-0.0.1-SNAPSHOT (100).zip",
+			Expected: "helloworld3",
+		},
+	}
+
+	for _, testcase := range cases {
+		actual := ParseName(testcase.Filename)
+		assert.Equal(t, testcase.Expected, actual)
+	}
+}


### PR DESCRIPTION
If the given microservice file ends with `\s+(\d+)$`, then it will be stripped when parsing the application name from the filename.

The ` (N)` suffix is typically added by Operating Systems (or browers?) when downloading a file and the filename already exists in the target directory.

So the following will now work:

```sh
c8y microservices create --file ./cloud-http-proxy\ \(1\).zip
```

Where the application name will be parsed as `cloud-http-proxy`.