### PR TITLE
fix(set-session): only write json output if user provides --output json

### DIFF
--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -221,7 +221,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		Username:   handler.C8Yclient.Username,
 	}
 
-	outputFormat := cfg.GetOutputFormatWithDefault(config.OutputUnknown).String()
+	outputFormat := cfg.GetOutputFormatWithDefault(cmd, config.OutputUnknown).String()
 
 	// Write session details to stderr (for humans)
 	if outputFormat != config.OutputJSON.String() {

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1449,12 +1449,15 @@ func (c *Config) GetOutputFormat() OutputFormat {
 }
 
 // GetOutputFormat Get output format type, i.e. json, csv, table etc.
-func (c *Config) GetOutputFormatWithDefault(fallback OutputFormat) OutputFormat {
-	if c.RawOutput() {
-		return OutputJSON
+func (c *Config) GetOutputFormatWithDefault(cmd *cobra.Command, fallback OutputFormat) OutputFormat {
+	if !cmd.Flags().Changed("output") {
+		return fallback
 	}
-	format := c.viper.GetString(SettingsOutputFormat)
-	return fallback.FromString(format)
+	value, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return fallback
+	}
+	return fallback.FromString(value)
 }
 
 // IsCSVOutput check if csv output is enabled


### PR DESCRIPTION
Fix a bug with `set-session` (e.g. `c8y sessions set`), where it was assuming json output because the output was being written to a variable. This meant the existing `set-session` command would break as it would expect the stdout to be shell string (and not json!).