### PR TITLE
fix(session): fix handling of non-file based sessions

### DIFF
--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -195,7 +195,7 @@ func GetVariablesFromSession(session *CumulocitySession, client *c8y.Client, set
 	}
 
 	output := map[string]interface{}{
-		// "C8Y_SESSION":              c.GetSessionFile(),
+		"C8Y_SESSION":              "",
 		"C8Y_URL":                  host,
 		"C8Y_BASEURL":              host,
 		"C8Y_HOST":                 host,
@@ -208,6 +208,13 @@ func GetVariablesFromSession(session *CumulocitySession, client *c8y.Client, set
 		"C8Y_PASSWORD":             password,
 		"C8Y_HEADER_AUTHORIZATION": authHeaderValue,
 		"C8Y_HEADER":               authHeader,
+	}
+
+	// Favor older path style over sessionUri to help with backwards compatibility
+	if session.Path != "" {
+		output["C8Y_SESSION"] = session.Path
+	} else if session.SessionUri != "" {
+		output["C8Y_SESSION"] = session.SessionUri
 	}
 	return output
 }

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -251,3 +251,11 @@ func ClearEnvironmentVariables(shell utilities.ShellType) {
 func ClearProcessEnvironment() {
 	utilities.ClearProcessEnvironment(GetSessionEnvKeys())
 }
+
+func IsSessionFilePath(path string) bool {
+	if path == "" {
+		return false
+	}
+	path = strings.TrimPrefix(path, "file://")
+	return !strings.Contains(path, "://")
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/activitylogger"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ydefaults"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
 	activityLogCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/activitylog"
 	agentsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/agents"
 	alarmsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/alarms"
@@ -815,7 +816,9 @@ func (c *CmdRoot) checkSessionExists(cmd *cobra.Command, args []string) error {
 	if sessionFile != "" {
 		log.Infof("Loaded session: %s", cfg.HideSensitiveInformationIfActive(client, sessionFile))
 		if _, err := os.Stat(sessionFile); err != nil {
-			log.Warnf("Failed to verify session file. %s", err)
+			if c8ysession.IsSessionFilePath(sessionFile) {
+				log.Warnf("Failed to verify session file. %s", err)
+			}
 		}
 	}
 

--- a/pkg/cmd/sessions/get/get.manual.go
+++ b/pkg/cmd/sessions/get/get.manual.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -64,7 +65,7 @@ func (n *CmdGetSession) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Support looking up a session which is only controlled via env variables
-	if sessionPath == "" && client != nil {
+	if !c8ysession.IsSessionFilePath(sessionPath) && client != nil {
 		cfg.Persistent.Set("host", client.GetHostname())
 		cfg.Persistent.Set("tenant", client.TenantName)
 		cfg.Persistent.Set("username", client.GetUsername())

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -284,6 +284,10 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Clear any existing session file.
+	// If the user wants to load from a file, then use the --from-file option
+	cfg.ClearSessionFile()
+
 	if strings.EqualFold(n.Provider, ProviderTypeAuto) {
 		//
 		// Try guessing a sensible default

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1864,6 +1864,10 @@ func SupportsFileExtension(p string) bool {
 	return false
 }
 
+func (c *Config) ClearSessionFile() {
+	c.sessionFile = ""
+}
+
 func (c *Config) SetSessionFile(path string) {
 	if _, fileErr := os.Stat(path); fileErr != nil {
 		home := c.GetSessionHomeDir()
@@ -1901,6 +1905,7 @@ func (c *Config) GetSessionFile(overrideSession ...string) string {
 		sessionFile = os.Getenv("C8Y_SESSION")
 	}
 
+	sessionFile = strings.TrimPrefix(sessionFile, "file://")
 	if _, fileErr := os.Stat(sessionFile); fileErr != nil {
 		home := c.GetSessionHomeDir()
 		c.Logger.Debugf("Resolving session %s in %s", sessionFile, home)


### PR DESCRIPTION
Fix both the setting and reading of the current session which was broken by the changes in 2.42.0 which introduced the `c8y sessions login` command.

Fixes

* Setting a session via `c8y sessions login` will allow users to run `c8y sessions get` as normal, and it will display session information even if the C8Y_SESSION env variable is not set.
* Set C8Y_SESSION environment variable to either a path and if that is not set, use the sessionUri