### PR TITLE
fix: fix handling of encrypted sessions

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -781,9 +781,11 @@ func (c *CmdRoot) Configure(disableEncryptionCheck, forceVerbose, forceDebug boo
 			return c.client, nil
 		}
 		client, err := factory.CreateCumulocityClient(c.Factory, c.SessionFile, c.SessionUsername, c.SessionPassword, disableEncryptionCheck)()
-		if c.SessionUsername != "" || c.SessionPassword != "" {
-			client.AuthorizationMethod = c8y.AuthMethodBasic
-			c.log.Debug("Forcing basic authentication as user provided username/password")
+		if client != nil {
+			if c.SessionUsername != "" || c.SessionPassword != "" {
+				client.AuthorizationMethod = c8y.AuthMethodBasic
+				c.log.Debug("Forcing basic authentication as user provided username/password")
+			}
 		}
 
 		if c.log != nil {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -189,7 +189,15 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 				// Command "listAssets" is deprecated,
 				fmt.Fprintf(f.IOStreams.ErrOut, "Command \"%s\" is deprecated, %s\n", cmd.CommandPath(), notice)
 			}
-			return ccmd.checkSessionExists(cmd, args)
+			cmdErr := ccmd.checkSessionExists(cmd, args)
+
+			if cmdErr != nil {
+				logg, logErr := f.Logger()
+				if logg != nil && logErr == nil {
+					logg.Warnf("Check existing session failed. %s", cmdErr)
+				}
+			}
+			return cmdErr
 		},
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -508,7 +508,6 @@ func ConvertToCobraCommands(f *cmdutil.Factory, cmd *cobra.Command, extensions [
 	// Enable flag parsing when using tab completion, otherwise disable it
 	// as it affects passing the arguments to the extension binary
 	disableFlagParsing := !isTabCompletionCommand()
-	_ = disableFlagParsing
 
 	log, err := f.Logger()
 	if err != nil {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -75,6 +75,9 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 		completion.WithValidateSet("shell", "auto", "bash", "zsh", "fish", "powershell"),
 		completion.WithValidateSet("loginType", c8y.AuthMethodOAuth2Internal, c8y.AuthMethodBasic),
 	)
+	// Disable the encryption check, as the login handler will take care
+	// of checking the encryption
+	cmdutil.DisableEncryptionCheck(cmd)
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
 	return ccmd

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -170,6 +170,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 				}
 			} else {
 				log.Infof("Ignoring invalid token")
+				client.SetToken("")
 			}
 		}
 	}

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -134,7 +134,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		if n.LoginType == c8y.AuthMethodBasic {
 			cfg.Logger.Infof("Clearing any existing token when using %s auth", c8y.AuthMethodBasic)
 			os.Unsetenv("C8Y_TOKEN")
-			if cfg.MustGetToken() != "" {
+			if cfg.MustGetToken(false) != "" {
 				cfg.SetToken("")
 				n.onSave(nil)
 			}
@@ -160,7 +160,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		client.SetToken("")
 	} else {
 		// Check if token is valid for the minimum period
-		if tok := cfg.MustGetToken(); tok != "" {
+		if tok := cfg.MustGetToken(true); tok != "" {
 			shouldBeValidFor := cfg.TokenValidFor()
 			expiresSoon, expiresAt := ShouldRenewToken(tok, shouldBeValidFor)
 
@@ -262,7 +262,7 @@ func hasChanged(client *c8y.Client, cfg *config.Config) bool {
 		return true
 	}
 
-	if client.Token != "" && client.Token != cfg.MustGetToken() && cfg.StoreToken() {
+	if client.Token != "" && client.Token != cfg.MustGetToken(false) && cfg.StoreToken() {
 		return true
 	}
 

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -754,7 +754,7 @@ func (c Config) GetEnvironmentVariables(client *c8y.Client, setPassword bool) ma
 	c8yVersion := c.GetCumulocityVersion()
 	username := c.GetUsername()
 	password := c.MustGetPassword()
-	token := c.MustGetToken()
+	token := c.MustGetToken(false)
 	authHeaderValue := ""
 	authHeader := ""
 
@@ -949,10 +949,12 @@ func (c *Config) MustGetPassword() string {
 }
 
 // MustGetToken returns the decrypted token if there are no encryption errors, otherwise it will return an encrypted value
-func (c *Config) MustGetToken() string {
+func (c *Config) MustGetToken(silent bool) string {
 	decryptedValue, err := c.GetToken()
 	if err != nil {
-		c.Logger.Warningf("Could not decrypt token. %s", err)
+		if !silent {
+			c.Logger.Warningf("Could not decrypt token. %s", err)
+		}
 	}
 	return decryptedValue
 }
@@ -1039,7 +1041,7 @@ func (c *Config) bindEnv(name string, defaultValue interface{}) error {
 // DecryptSession decrypts a session (as long as the encryption passphrase has already been provided)
 func (c *Config) DecryptSession() error {
 	c.SetPassword(c.MustGetPassword())
-	c.SetToken(c.MustGetToken())
+	c.SetToken(c.MustGetToken(false))
 	return c.WritePersistentConfig()
 }
 


### PR DESCRIPTION
Fix various problems when dealing with an encrypted session as seen in https://github.com/reubenmiller/go-c8y-cli/issues/392

* Allow tab completion to still function even a session is not configured or if a session is set but not decrypted
* Don't fail if encrypted credentials are detected on client setup, as this prevents the set-session from being able to prompt the user for their encryption passphrase
