### PR TITLE
feat: independent session banner setting

### DIFF
--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -117,25 +117,36 @@ func PrintSessionInfo(w io.Writer, client *c8y.Client, cfg *config.Config, sessi
 	label := labelS.SprintfFunc()
 	value := color.New(color.FgWhite).SprintFunc()
 	header := color.New(color.FgCyan).SprintFunc()
+	maybeHideMessage := func(client *c8y.Client, message string) string {
+		return message
+	}
+	hideInfo := cfg.HideSessionBanner()
+	if hideInfo {
+		maybeHideMessage = cfg.HideSensitiveInformation
+	}
 
-	labelS.Fprintf(w, "---------------------  Cumulocity Session  ---------------------\n")
-	if session.SessionUri != "" {
-		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "source"), header(cfg.HideSensitiveInformationIfActive(client, session.SessionUri)))
+	if hideInfo {
+		labelS.Fprintf(w, "---------------------  Cumulocity Session (sensitive info is hidden)  ---------------------\n")
 	} else {
-		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "path"), header(cfg.HideSensitiveInformationIfActive(client, session.Path)))
+		labelS.Fprintf(w, "---------------------  Cumulocity Session  ---------------------\n")
+	}
+	if session.SessionUri != "" {
+		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "source"), header(maybeHideMessage(client, session.SessionUri)))
+	} else {
+		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "path"), header(maybeHideMessage(client, session.Path)))
 	}
 	if session.Description != "" {
-		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "description")), value(cfg.HideSensitiveInformationIfActive(client, session.Host)))
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "description")), value(maybeHideMessage(client, session.Host)))
 	}
 
-	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "host")), value(cfg.HideSensitiveInformationIfActive(client, session.Host)))
+	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "host")), value(maybeHideMessage(client, session.Host)))
 	if session.Tenant != "" {
-		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "tenant")), value(cfg.HideSensitiveInformationIfActive(client, session.Tenant)))
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "tenant")), value(maybeHideMessage(client, session.Tenant)))
 	}
 	if session.Version != "" {
-		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "version")), value(cfg.HideSensitiveInformationIfActive(client, session.Version)))
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "version")), value(maybeHideMessage(client, session.Version)))
 	}
-	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "username")), value(cfg.HideSensitiveInformationIfActive(client, session.Username)))
+	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "username")), value(maybeHideMessage(client, session.Username)))
 	fmt.Fprintf(w, "\n")
 }
 

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -130,10 +130,11 @@ func PrintSessionInfo(w io.Writer, client *c8y.Client, cfg *config.Config, sessi
 	} else {
 		labelS.Fprintf(w, "---------------------  Cumulocity Session  ---------------------\n")
 	}
+	// Always show the source of the session
 	if session.SessionUri != "" {
-		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "source"), header(maybeHideMessage(client, session.SessionUri)))
+		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "source"), header(session.SessionUri))
 	} else {
-		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "path"), header(maybeHideMessage(client, session.Path)))
+		fmt.Fprintf(w, "\n    %s: %s\n\n\n", label("%s", "path"), header(session.Path))
 	}
 	if session.Description != "" {
 		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "description")), value(maybeHideMessage(client, session.Host)))

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -370,6 +370,8 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 	session.Path = cfg.GetSessionFile()
 
 	// Write session details to stderr (for humans)
+	cs := n.factory.IOStreams.ColorScheme()
+	fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
 	if !n.NoBanner {
 		c8ysession.PrintSessionInfo(n.SubCommand.GetCommand().ErrOrStderr(), client, cfg, *session)
 	}

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -251,7 +251,11 @@ func (n *CmdLogin) FromFile(file string, format string) (*c8ysession.CumulocityS
 		return nil, err
 	}
 
-	return n.FromViper(v)
+	session, err := n.FromViper(v)
+	if session.SessionUri == "" {
+		session.SessionUri = "file://" + file
+	}
+	return session, err
 }
 
 func (n *CmdLogin) FromReader(r io.Reader, format string) (*c8ysession.CumulocitySession, error) {

--- a/pkg/cmd/sessions/selectsession/selectsession.go
+++ b/pkg/cmd/sessions/selectsession/selectsession.go
@@ -122,7 +122,7 @@ func SelectSession(io *iostreams.IOStreams, cfg *config.Config, log *logger.Logg
 	funcMap["highlight"] = customStyle()
 
 	funcMap["hide"] = func(v interface{}) string {
-		if cfg.HideSensitive() {
+		if cfg.HideSessionBanner() {
 			return "*****"
 		}
 		return fmt.Sprintf("%v", v)
@@ -131,7 +131,7 @@ func SelectSession(io *iostreams.IOStreams, cfg *config.Config, log *logger.Logg
 	funcMap["hideUser"] = func(v interface{}) string {
 		msg := fmt.Sprintf("%v", v)
 
-		if !cfg.HideSensitive() {
+		if !cfg.HideSessionBanner() {
 			return msg
 		}
 		if os.Getenv("USERNAME") != "" {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -29,6 +29,7 @@ type CmdSet struct {
 	LoginType     string
 	Shell         string
 	ClearToken    bool
+	NoBanner      bool
 	sessionFilter string
 
 	*subcommand.SubCommand
@@ -69,6 +70,7 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 	cmd.Flags().StringVar(&ccmd.TFACode, "tfaCode", "", "Two Factor Authentication code")
 	cmd.Flags().StringVar(&ccmd.Shell, "shell", defaultShell, "Shell type to return the environment variables")
 	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL or BASIC. When set to BASIC, any existing token will be cleared")
+	cmd.Flags().BoolVar(&ccmd.NoBanner, "no-banner", false, "Don't show the session banner")
 	cmd.Flags().BoolVar(&ccmd.ClearToken, "clear", false, "Clear any existing tokens")
 
 	completion.WithOptions(
@@ -236,7 +238,9 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	if outputFormat != config.OutputJSON.String() {
 		cs := n.factory.IOStreams.ColorScheme()
 		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
-		c8ysession.PrintSessionInfo(n.SubCommand.GetCommand().ErrOrStderr(), client, cfg, *session)
+		if !n.NoBanner {
+			c8ysession.PrintSessionInfo(n.factory.IOStreams.ErrOut, client, cfg, *session)
+		}
 	}
 
 	if outputFormat == config.OutputUnknown.String() {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -1,6 +1,7 @@
 package login
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -233,6 +234,8 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 
 	// Write session details to stderr (for humans)
 	if outputFormat != config.OutputJSON.String() {
+		cs := n.factory.IOStreams.ColorScheme()
+		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
 		c8ysession.PrintSessionInfo(n.SubCommand.GetCommand().ErrOrStderr(), client, cfg, *session)
 	}
 

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -3,6 +3,7 @@ package login
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -123,12 +124,15 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		// the user is most likely switching session so does not want to inherit any environment variables
 		// set from the last instance.
 		// But this has a side effect that you can't control the profile handing via environment variables when using the interact session selection
+		allowedEnvValues := []string{"C8Y_SETTINGS_SESSION_HIDE"}
 		env_prefix := strings.ToUpper(config.EnvSettingsPrefix)
 		for _, env := range os.Environ() {
 			if strings.HasPrefix(env, env_prefix) && !strings.HasPrefix(env, config.EnvPassphrase) && !strings.HasPrefix(env, config.EnvSessionHome) {
 				parts := strings.SplitN(env, "=", 2)
 				if len(parts) == 2 {
-					os.Unsetenv(parts[0])
+					if !slices.Contains(allowedEnvValues, parts[0]) {
+						os.Unsetenv(parts[0])
+					}
 				}
 			}
 		}

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -316,6 +316,12 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"7d",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
+	// Hide session info when setting a session
+	"session.hide": {"session.hide", "bool", "settings.session.hide", []string{
+		"true",
+		"false",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
 	// cache
 	"defaults.cache": {"defaults.cache", "bool", config.SettingsDefaultsCacheEnabled, []string{
 		"true",

--- a/tests/manual/sessions/login/session_login.yaml
+++ b/tests/manual/sessions/login/session_login.yaml
@@ -26,3 +26,31 @@ tests:
         version: r/^.+$
         username: r/^.+$
         token: r/^.+$
+
+  It does not hide sensitive info in the session banner by default:
+    command: |
+      c8y sessions login --from-env
+    exit-code: 0
+    stderr:
+      not-contains:
+        - "{host}"
+        - "{tenant}"
+        - "{username}"
+        - "hidden"
+
+  It hides sensitive information in the session banner:
+    command: |
+      c8y sessions login --from-env
+    exit-code: 0
+    config:
+      retries: 0
+      inherit-env: false
+      env:
+        C8Y_SETTINGS_SESSION_HIDE: true
+    stderr:
+      contains:
+        - "✓ Session is now active"
+        - ---------------------  Cumulocity Session (sensitive info is hidden)  ---------------------
+        - "host         : {host}"
+        - "tenant       : {tenant}"
+        - "username     : {username}"


### PR DESCRIPTION
Control the display of the session banner when setting a new session independently to the "logger.hideSensitive" setting.

In go-c8y-cli [v2.40.0](https://github.com/reubenmiller/go-c8y-cli/releases/tag/v2.40.0), the default value of the "logger.hideSensitive" setting was change from `false` to `true` in order to prevent leakage of sensitive information when users are screensharing. However the new default value had negative user impact as it would obfuscate the session information when a user is activating a session (e.g. via `set-session`) which resulted in the user being unsure if the session activate was successful and unsure which session was selected.

Providing feedback to the user when setting a session is critical in most cases as it ensure they have the correct context (e.g. target Cumulocity instance) before they start interacting with the Cumulocity instance.

Given this background, a new setting has been created to control the display of the session information when activating a session, and the default value is to display the session information (e.g. host, tenant, username etc.).

**Example**

If you want to hide the displayed session information you have two options:

**Option 1: Hide the session banner information**

```sh
# Add this to your sehll profile for
eval "$(c8y settings update session.hide true --shell auto)"

# Or you can update for a specific session (after you have set the session)
# then setting the session will not print sensitive session information
c8y settings update session.hide true
```

**Option 2: Skip printing of the entire banner when setting a session**

You can add the `--no-banner` flag when setting the session, which will skip the printing of the session banner. The user will still get feedback that the command successfully activated a session by a simple message containing no sensitive information.

```sh
set-session --no-banner
```

*Output*

```
$ set-session --no-banner
✓ Session is now active
```
