### PR TITLE
feat: ignore basic auth header if empty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.19.1
+	github.com/reubenmiller/go-c8y v0.20.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.19.1 h1:qXxfO0wheWewziAuNZjPzetcDZKo2yTlSeb57oAdliE=
-github.com/reubenmiller/go-c8y v0.19.1/go.mod h1:bNJLF+fokWDpztGiX5CsbEY5F8c3h9Wwu6c2uHdG0S8=
+github.com/reubenmiller/go-c8y v0.20.1 h1:zBmqAMfbhlosy2iqPMghe3qytEOALtwLITpgNAkXKUw=
+github.com/reubenmiller/go-c8y v0.20.1/go.mod h1:bNJLF+fokWDpztGiX5CsbEY5F8c3h9Wwu6c2uHdG0S8=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/c8yfetcher/deviceCertificateFetcher.go
+++ b/pkg/c8yfetcher/deviceCertificateFetcher.go
@@ -38,6 +38,7 @@ func (f *DeviceCertificateFetcher) IsID(id string) bool {
 func (f *DeviceCertificateFetcher) getByID(id string) ([]fetcherResultSet, error) {
 	cert, resp, err := f.Client().DeviceCertificate.GetCertificate(
 		c8y.WithDisabledDryRunContext(context.Background()),
+		f.Client().TenantName,
 		id,
 	)
 
@@ -59,6 +60,7 @@ func (f *DeviceCertificateFetcher) getByName(name string) ([]fetcherResultSet, e
 	// check if already resolved, so we can save a lookup
 	col, _, err := f.Client().DeviceCertificate.GetCertificates(
 		c8y.WithDisabledDryRunContext(context.Background()),
+		f.Client().TenantName,
 		&c8y.DeviceCertificateCollectionOptions{
 			PaginationOptions: *c8y.NewPaginationOptions(100),
 		},

--- a/pkg/completion/certificate.go
+++ b/pkg/completion/certificate.go
@@ -18,6 +18,7 @@ func WithDeviceCertificate(flagName string, clientFunc func() (*c8y.Client, erro
 			}
 			items, _, err := client.DeviceCertificate.GetCertificates(
 				c8y.WithDisabledDryRunContext(context.Background()),
+				client.TenantName,
 				&c8y.DeviceCertificateCollectionOptions{
 					PaginationOptions: *c8y.NewPaginationOptions(100),
 				},

--- a/tests/manual/sessions/sessions_set.yaml
+++ b/tests/manual/sessions/sessions_set.yaml
@@ -205,3 +205,24 @@ tests:
         - panic
       contains:
         - A c8y session has not been loaded. Please create or activate a session and try again
+
+  It supports requests without authorization and only setting C8Y_HOST:
+    command: |
+      env -i PATH="$PATH" C8Y_HOST="http://localhost:8001/c8y" \
+        c8y inventory list --pageSize 1 --dry --dryFormat json -c=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "url": "http://localhost:8001/c8y/inventory/managedObjects?pageSize=1",
+          "host": "http://localhost:8001",
+          "pathEncoded": "/c8y/inventory/managedObjects?pageSize=1",
+          "path": "/c8y/inventory/managedObjects",
+          "query": "pageSize=1",
+          "method": "GET",
+          "headers": {
+            "Accept": "application/json"
+          },
+          "shell": "curl -X 'GET' -H 'Accept: application/json' 'http://{host}/c8y/inventory/managedObjects?pageSize=1'",
+          "powershell": "curl -X 'GET' -H 'Accept: application/json' 'http://{host}/c8y/inventory/managedObjects?pageSize=1'"
+        }


### PR DESCRIPTION
Update go-c8y library to include a fix where the `Authorization` header should be ignored if the username or password is empty.

This enables usage with thin-edge.io by just specifying one environment variable `C8Y_HOST`:

```sh
C8Y_HOST=http://localhost:8001/c8y c8y software list

# or exporting the env variable
export C8Y_HOST=http://localhost:8001/c8y
c8y software list
```