### PR TITLE
fix(set-session): preserve encryption env variables and any C8Y_SETTINGS variables

### DIFF
--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -126,18 +126,16 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		// But this has a side effect that you can't control the profile handing via environment variables when using the interact session selection
 		allowedEnvValues := []string{
 			"C8Y_SETTINGS_SESSION_HIDE",
-			// Also preserve encryption settings
+			// Preserve encryption settings
 			"C8Y_PASSPHRASE",
 			"C8Y_PASSPHRASE_TEXT",
-			"C8Y_SETTINGS_ENCRYPTION_ENABLED",
-			"C8Y_SETTINGS_ENCRYPTION_CACHEPASSPHRASE",
 		}
 		env_prefix := strings.ToUpper(config.EnvSettingsPrefix)
 		for _, env := range os.Environ() {
 			if strings.HasPrefix(env, env_prefix) && !strings.HasPrefix(env, config.EnvPassphrase) && !strings.HasPrefix(env, config.EnvSessionHome) {
 				parts := strings.SplitN(env, "=", 2)
 				if len(parts) == 2 {
-					if !slices.Contains(allowedEnvValues, parts[0]) {
+					if !slices.Contains(allowedEnvValues, parts[0]) && !strings.HasPrefix("C8Y_SETTINGS_", parts[0]) {
 						os.Unsetenv(parts[0])
 					}
 				}

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -124,7 +124,14 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		// the user is most likely switching session so does not want to inherit any environment variables
 		// set from the last instance.
 		// But this has a side effect that you can't control the profile handing via environment variables when using the interact session selection
-		allowedEnvValues := []string{"C8Y_SETTINGS_SESSION_HIDE"}
+		allowedEnvValues := []string{
+			"C8Y_SETTINGS_SESSION_HIDE",
+			// Also preserve encryption settings
+			"C8Y_PASSPHRASE",
+			"C8Y_PASSPHRASE_TEXT",
+			"C8Y_SETTINGS_ENCRYPTION_ENABLED",
+			"C8Y_SETTINGS_ENCRYPTION_CACHEPASSPHRASE",
+		}
 		env_prefix := strings.ToUpper(config.EnvSettingsPrefix)
 		for _, env := range os.Environ() {
 			if strings.HasPrefix(env, env_prefix) && !strings.HasPrefix(env, config.EnvPassphrase) && !strings.HasPrefix(env, config.EnvSessionHome) {


### PR DESCRIPTION
Respect existing the following env variable types when using `set-session`:

* Encryption env variables (e.g. cached passphrase and text)
* Any other c8y settings, e.g. `C8Y_SETTINGS_*` env variables

By preserving the env variables, it allows user to still enforce global configuration via settings in their local shell profile.