### PR TITLE
feat(software): add softwareType flag to software create/update/list commands

### DIFF
--- a/api/spec/json/software.json
+++ b/api/spec/json/software.json
@@ -34,7 +34,12 @@
           },
           {
             "description": "Get a list of software packages starting with \"python3\"",
-            "command": "c8y software list --name \"python3*\"",
+            "command": "c8y software list --name \"python3*\" --softwareType apt",
+            "skipTest": true
+          },
+          {
+            "description": "List all software packages of a given software type",
+            "command": "c8y software list --softwareType rpm",
             "skipTest": true
           }
         ]
@@ -84,6 +89,12 @@
               "type": "string",
               "description": "Filter by deviceType",
               "format": "(c8y_Filter.type eq '%s')"
+            },
+            {
+              "name": "softwareType",
+              "type": "string",
+              "description": "Filter by softwareType",
+              "format": "(softwareType eq '%s')"
             },
             {
               "name": "description",
@@ -147,15 +158,15 @@
         "go": [
           {
             "description": "Create a software package",
-            "command": "c8y software create --name \"python3-requests\" --description \"python requests library\""
+            "command": "c8y software create --name \"python3-requests\" --description \"python requests library\" --softwareType apt"
           },
           {
             "description": "Create a software package which is only applicable for a specific device type",
-            "command": "c8y software create --name \"python3-requests\" --description \"python requests library\" --deviceType \"c8y_Linux\""
+            "command": "c8y software create --name \"python3-requests\" --description \"python requests library\" --deviceType \"c8y_Linux\" --softwareType apt"
           },
           {
             "description": "Create the same software package for multiple device types",
-            "command": "echo -e \"c8y_Linux\\nc8y_MacOS\" | c8y software create --name \"python3-requests\" --description \"python requests library\"",
+            "command": "echo -e \"c8y_Linux\\nc8y_MacOS\" | c8y software create --name \"python3-requests\" --description \"python requests library\"  --softwareType rpm",
             "assertStdOut": {
               "line-count": 2,
               "json": {
@@ -166,7 +177,8 @@
                 "..1.method": "POST",
                 "..1.body.name": "python3-requests",
                 "..1.body.description": "python requests library",
-                "..1.body.c8y_Filter.type": "c8y_MacOS"
+                "..1.body.c8y_Filter.type": "c8y_MacOS",
+                "..1.body.softwareType": "rpm"
               }
             }
           },
@@ -198,6 +210,11 @@
           "type": "string",
           "required": false,
           "description": "Description of the software package"
+        },
+        {
+          "name": "softwareType",
+          "type": "string",
+          "description": "Software type"
         },
         {
           "name": "deviceType",
@@ -362,6 +379,11 @@
           "type": "string",
           "required": false,
           "description": "Description of the software package"
+        },
+        {
+          "name": "softwareType",
+          "type": "string",
+          "description": "Software type"
         },
         {
           "name": "deviceType",

--- a/api/spec/yaml/software.yaml
+++ b/api/spec/yaml/software.yaml
@@ -29,7 +29,11 @@ commands:
           skipTest: true
         
         - description: Get a list of software packages starting with "python3"
-          command: c8y software list --name "python3*"
+          command: c8y software list --name "python3*" --softwareType apt
+          skipTest: true
+
+        - description: List all software packages of a given software type
+          command: c8y software list --softwareType rpm
           skipTest: true
 
     queryParameters:
@@ -69,6 +73,11 @@ commands:
             type: string
             description: Filter by deviceType
             format: (c8y_Filter.type eq '%s')
+
+          - name: softwareType
+            type: string
+            description: Filter by softwareType
+            format: (softwareType eq '%s')
 
           - name: description
             type: string
@@ -115,13 +124,13 @@ commands:
 
       go:
         - description: Create a software package
-          command: c8y software create --name "python3-requests" --description "python requests library"
+          command: c8y software create --name "python3-requests" --description "python requests library" --softwareType apt
         
         - description: Create a software package which is only applicable for a specific device type
-          command: c8y software create --name "python3-requests" --description "python requests library" --deviceType "c8y_Linux"
+          command: c8y software create --name "python3-requests" --description "python requests library" --deviceType "c8y_Linux" --softwareType apt
         
         - description: Create the same software package for multiple device types
-          command: echo -e "c8y_Linux\nc8y_MacOS" | c8y software create --name "python3-requests" --description "python requests library"
+          command: echo -e "c8y_Linux\nc8y_MacOS" | c8y software create --name "python3-requests" --description "python requests library"  --softwareType rpm
           assertStdOut:
             line-count: 2
             json:
@@ -133,6 +142,7 @@ commands:
               ..1.body.name: python3-requests
               ..1.body.description: python requests library
               ..1.body.c8y_Filter.type: c8y_MacOS
+              ..1.body.softwareType: rpm
 
         - description: Create a software package and create a new version
           skipTest: true
@@ -153,6 +163,10 @@ commands:
         type: string
         required: false
         description: Description of the software package
+
+      - name: softwareType
+        type: string
+        description: Software type
 
       - name: deviceType
         type: string
@@ -273,7 +287,11 @@ commands:
         type: string
         required: false
         description: Description of the software package
-      
+
+      - name: softwareType
+        type: string
+        description: Software type
+
       - name: deviceType
         type: string
         property: c8y_Filter.type

--- a/pkg/cmd/software/create/create.auto.go
+++ b/pkg/cmd/software/create/create.auto.go
@@ -33,13 +33,13 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 		Short: "Create software package",
 		Long:  `Create a new software package (managedObject)`,
 		Example: heredoc.Doc(`
-$ c8y software create --name "python3-requests" --description "python requests library"
+$ c8y software create --name "python3-requests" --description "python requests library" --softwareType apt
 Create a software package
 
-$ c8y software create --name "python3-requests" --description "python requests library" --deviceType "c8y_Linux"
+$ c8y software create --name "python3-requests" --description "python requests library" --deviceType "c8y_Linux" --softwareType apt
 Create a software package which is only applicable for a specific device type
 
-$ echo -e "c8y_Linux\nc8y_MacOS" | c8y software create --name "python3-requests" --description "python requests library"
+$ echo -e "c8y_Linux\nc8y_MacOS" | c8y software create --name "python3-requests" --description "python requests library"  --softwareType rpm
 Create the same software package for multiple device types
 
 $ c8y software create --name "python3-requests" | c8y software versions create --version "1.0.0" --file "python3-requests.deb"
@@ -55,6 +55,7 @@ Create a software package and create a new version
 
 	cmd.Flags().String("name", "", "name")
 	cmd.Flags().String("description", "", "Description of the software package")
+	cmd.Flags().String("softwareType", "", "Software type")
 	cmd.Flags().String("deviceType", "", "Device type filter. Only allow software to be applied to devices of this type (accepts pipeline)")
 
 	completion.WithOptions(
@@ -148,6 +149,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("name", "name"),
 		flags.WithStringValue("description", "description"),
+		flags.WithStringValue("softwareType", "softwareType"),
 		flags.WithStringValue("deviceType", "c8y_Filter.type"),
 		flags.WithDefaultTemplateString(`
 {type: 'c8y_Software', c8y_Global:{}}`),

--- a/pkg/cmd/software/list/list.auto.go
+++ b/pkg/cmd/software/list/list.auto.go
@@ -37,8 +37,11 @@ func NewListCmd(f *cmdutil.Factory) *ListCmd {
 $ c8y software list
 Get a list of software packages
 
-$ c8y software list --name "python3*"
+$ c8y software list --name "python3*" --softwareType apt
 Get a list of software packages starting with "python3"
+
+$ c8y software list --softwareType rpm
+List all software packages of a given software type
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil
@@ -53,6 +56,7 @@ Get a list of software packages starting with "python3"
 	cmd.Flags().String("orderBy", "name", "Order by. e.g. _id asc or name asc or creationTime.date desc")
 	cmd.Flags().String("name", "", "Filter by name")
 	cmd.Flags().String("deviceType", "", "Filter by deviceType")
+	cmd.Flags().String("softwareType", "", "Filter by softwareType")
 	cmd.Flags().String("description", "", "Filter by description")
 	cmd.Flags().Bool("skipChildrenNames", false, "Don't include the child devices names in the response. This can improve the API response because the names don't need to be retrieved")
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
@@ -118,6 +122,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 				flags.WithStaticStringValue("software", "(type eq 'c8y_Software')"),
 				flags.WithStringValue("name", "name", "(name eq '%s')"),
 				flags.WithStringValue("deviceType", "deviceType", "(c8y_Filter.type eq '%s')"),
+				flags.WithStringValue("softwareType", "softwareType", "(softwareType eq '%s')"),
 				flags.WithStringValue("description", "description", "(description eq '%s')"),
 			},
 			"query",

--- a/pkg/cmd/software/update/update.auto.go
+++ b/pkg/cmd/software/update/update.auto.go
@@ -48,6 +48,7 @@ Update a software package
 	cmd.Flags().StringSlice("id", []string{""}, "Software package (managedObject) id (required) (accepts pipeline)")
 	cmd.Flags().String("newName", "", "New software package name")
 	cmd.Flags().String("description", "", "Description of the software package")
+	cmd.Flags().String("softwareType", "", "Software type")
 	cmd.Flags().String("deviceType", "", "Device type filter. Only allow software to be applied to devices of this type")
 
 	completion.WithOptions(
@@ -141,6 +142,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("newName", "name"),
 		flags.WithStringValue("description", "description"),
+		flags.WithStringValue("softwareType", "softwareType"),
 		flags.WithStringValue("deviceType", "c8y_Filter.type"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),

--- a/tests/auto/software/tests/software_create.yaml
+++ b/tests/auto/software/tests/software_create.yaml
@@ -1,11 +1,12 @@
 tests:
     software_create_Create a software package:
-        command: c8y software create --name "python3-requests" --description "python requests library"
+        command: c8y software create --name "python3-requests" --description "python requests library" --softwareType apt
         exit-code: 0
         stdout:
             json:
                 body.description: python requests library
                 body.name: python3-requests
+                body.softwareType: apt
                 method: POST
                 path: /inventory/managedObjects
     software_create_Create a software package and create a new version:
@@ -19,17 +20,18 @@ tests:
                 method: POST
                 path: /inventory/managedObjects
     software_create_Create a software package which is only applicable for a specific device type:
-        command: c8y software create --name "python3-requests" --description "python requests library" --deviceType "c8y_Linux"
+        command: c8y software create --name "python3-requests" --description "python requests library" --deviceType "c8y_Linux" --softwareType apt
         exit-code: 0
         stdout:
             json:
                 body.c8y_Filter.type: c8y_Linux
                 body.description: python requests library
                 body.name: python3-requests
+                body.softwareType: apt
                 method: POST
                 path: /inventory/managedObjects
     software_create_Create the same software package for multiple device types:
-        command: $TEST_SHELL -c 'echo -e "c8y_Linux\nc8y_MacOS" | c8y software create --name "python3-requests" --description "python requests library"'
+        command: $TEST_SHELL -c 'echo -e "c8y_Linux\nc8y_MacOS" | c8y software create --name "python3-requests" --description "python requests library"  --softwareType rpm'
         exit-code: 0
         stdout:
             json:
@@ -40,8 +42,10 @@ tests:
                 ..1.body.c8y_Filter.type: c8y_MacOS
                 ..1.body.description: python requests library
                 ..1.body.name: python3-requests
+                ..1.body.softwareType: rpm
                 ..1.method: POST
                 body.description: python requests library
                 body.name: python3-requests
+                body.softwareType: rpm
                 method: POST
                 path: /inventory/managedObjects

--- a/tests/auto/software/tests/software_list.yaml
+++ b/tests/auto/software/tests/software_list.yaml
@@ -8,7 +8,7 @@ tests:
                 method: GET
                 path: /inventory/managedObjects
     software_list_Get a list of software packages starting with "python3":
-        command: c8y software list --name "python3*"
+        command: c8y software list --name "python3*" --softwareType apt
         exit-code: 0
         skip: true
         stdout:
@@ -17,3 +17,14 @@ tests:
                 path: /inventory/managedObjects
             contains:
                 - name=python3*
+                - softwareType=apt
+    software_list_List all software packages of a given software type:
+        command: c8y software list --softwareType rpm
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                method: GET
+                path: /inventory/managedObjects
+            contains:
+                - softwareType=rpm

--- a/tools/PSc8y/Public/Get-SoftwareCollection.ps1
+++ b/tools/PSc8y/Public/Get-SoftwareCollection.ps1
@@ -48,6 +48,11 @@ Get a list of software packages
         [string]
         $DeviceType,
 
+        # Filter by softwareType
+        [Parameter()]
+        [string]
+        $SoftwareType,
+
         # Filter by description
         [Parameter()]
         [string]

--- a/tools/PSc8y/Public/New-Software.ps1
+++ b/tools/PSc8y/Public/New-Software.ps1
@@ -32,6 +32,11 @@ Create a software package
         [string]
         $Description,
 
+        # Software type
+        [Parameter()]
+        [string]
+        $SoftwareType,
+
         # Device type filter. Only allow software to be applied to devices of this type
         [Parameter(ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]

--- a/tools/PSc8y/Public/Update-Software.ps1
+++ b/tools/PSc8y/Public/Update-Software.ps1
@@ -44,6 +44,11 @@ Update a software package (using pipeline)
         [string]
         $Description,
 
+        # Software type
+        [Parameter()]
+        [string]
+        $SoftwareType,
+
         # Device type filter. Only allow software to be applied to devices of this type
         [Parameter()]
         [string]


### PR DESCRIPTION
Add a `softwareType` flag to the `c8y software create/update/list` commands to make it easier to create software packages of a specific type, and to query for them.

**Examples**

```sh
# create
c8y software create --name python3 --softwareType apt

# update
c8y software update --id 1234 --softwareType rpm

# list
c8y software update --softwareType rpm
```