### PR TITLE
docs: remove the wording Unofficial as the product is mature now

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,7 +99,7 @@ nfpms:
     maintainer: Reuben Miller <reuben.d.miller@gmail.com>
     homepage: http://goc8ycli.netlify.app
     bindir: /usr
-    description: Cumulocity's unofficial command line tool
+    description: Cumulocity IoT command line tool
     section: utils
     priority: optional
     file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
@@ -200,7 +200,7 @@ brews:
         source <profile>
 
     homepage: "https://goc8ycli.netlify.app/"
-    description: "Cumulocity's unofficial command line tool"
+    description: "Cumulocity IoT command line tool"
     license: "MIT"
 
     dependencies:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 
-Unofficial Cumulocity IoT Command Line Tool
+Cumulocity IoT Command Line Tool
 
 Supported on
 

--- a/docs/go-c8y-cli/docs/demo.mdx
+++ b/docs/go-c8y-cli/docs/demo.mdx
@@ -6,7 +6,7 @@ slug: /
 ---
 import Video from '@site/src/components/video';
 
-Welcome to the Unofficial Cumulocity REST CLI Tool.
+Welcome to the Cumulocity IoT CLI Tool.
 
 <Video
   videoSrcURL="https://asciinema.org/a/413796/iframe?speed=1.0&autoplay=false&size=small&rows=30"

--- a/docs/go-c8y-cli/docusaurus.config.js
+++ b/docs/go-c8y-cli/docusaurus.config.js
@@ -22,7 +22,7 @@ const baseUrl = `${process.env.BASE_URL || '/'}`;
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 (module.exports = {
   title: 'Cumulocity IoT CLI',
-  tagline: 'Unofficial Cumulocity IoT Command Line Interface',
+  tagline: 'Cumulocity IoT Command Line Interface',
   url: 'https://reubenmiller.github.io',
   baseUrl,
   onBrokenLinks: isDev ? 'warn' : 'throw',


### PR DESCRIPTION
go-c8y-cli is now used by more and more people (also in production), so the word "Unofficial" does not really do it justice. Removing the wording for more neutral language.

But for the sake of transparency, I (the author, Reuben Miller), work for Cumulocity IoT, however this project is maintained both in and out of my work time, so it is still not an "officially" supported by Cumulocity IoT in terms of maintaince contracts, however there are many people that actively use the project and bugs are fixed generally very quickly :)