### PR TITLE
fix(c8y microservices create): stop execution on binary upload errors

### DIFF
--- a/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
+++ b/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
@@ -316,8 +316,7 @@ func (n *CmdCreateHostedApplication) RunE(cmd *cobra.Command, args []string) err
 			n.factory.IOStreams.WaitForProgressIndicator()
 
 			if err != nil {
-				// handle error
-				n.SubCommand.GetCommand().PrintErrf("failed to upload file. %s", err)
+				return fmt.Errorf("failed to upload file. path=%s, err=%s", zipfile, err)
 			} else {
 				applicationBinaryID = resp.JSON("id").String()
 			}

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -281,8 +281,7 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 			n.factory.IOStreams.WaitForProgressIndicator()
 
 			if err != nil {
-				// handle error
-				n.SubCommand.GetCommand().PrintErrf("failed to upload file. %s", err)
+				return fmt.Errorf("failed to upload file. path=%s, err=%s", n.file, err)
 			}
 		}
 	} else {


### PR DESCRIPTION
Stop the execution if the uploading of the microservice or hosted application binary fails. Previously the error was just logged and execution would continue, giving the false impression that the upload worked (as the user would see the output from the follow up requests).

Affected commands:

* `c8y microservices create`
* `c8y applications createHostedApplication`
