### PR TITLE
feat: increase default timeout from 60s to 600s

### DIFF
--- a/docs/go-c8y-cli/docs/configuration/settings.md
+++ b/docs/go-c8y-cli/docs/configuration/settings.md
@@ -85,7 +85,7 @@ c8y settings list --select "**" --output json
     "sessionusername": "",
     "silentexit": false,
     "silentstatuscodes": "",
-    "timeout": "60s",
+    "timeout": "600s",
     "totalpages": 0,
     "verbose": false,
     "view": "auto",

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -261,7 +261,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	cmd.PersistentFlags().StringArray("filter", nil, "Apply a client side filter to response before returning it to the user")
 	cmd.PersistentFlags().StringArray("select", nil, "Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'")
 	cmd.PersistentFlags().String("view", defaultView, "Use views when displaying data on the terminal. Disable using --view off")
-	cmd.PersistentFlags().String("timeout", "60s", "Request timeout duration, i.e. 60s, 2m")
+	cmd.PersistentFlags().String("timeout", "600s", "Request timeout duration, i.e. 60s, 2m")
 
 	// output
 	cmd.PersistentFlags().StringP("output", "o", defaultOutputFormat, "Output format i.e. table, json, csv, csvheader")


### PR DESCRIPTION
Increase the default timeout from 60s to 600s to cater for large(ish) microservice uploads where 60s is sometimes not enough on slower connections.

See https://github.com/reubenmiller/go-c8y-cli/issues/402