### PR TITLE
fix: update go-c8y lib to fix notifications2 connect/reconnect errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/google/go-jsonnet v0.20.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/gorilla/websocket v1.5.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/karrick/tparse/v2 v2.8.2
 	github.com/manifoldco/promptui v0.9.0
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.20.1
+	github.com/reubenmiller/go-c8y v0.20.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.20.2
+	github.com/reubenmiller/go-c8y v0.20.3
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.20.2 h1:jzIC/o7tVenJza5n97Zq6q/Yij/nAFJJ2/PfgVXs2VY=
-github.com/reubenmiller/go-c8y v0.20.2/go.mod h1:UmSCgL79kUoGuYGCuAhDsXVB4LZtYBAQckxRNQG9mzs=
+github.com/reubenmiller/go-c8y v0.20.3 h1:p+RZMeBqUA1qdPdhPaaMR7EEgWNXrN4CUfqehKpX0fw=
+github.com/reubenmiller/go-c8y v0.20.3/go.mod h1:UmSCgL79kUoGuYGCuAhDsXVB4LZtYBAQckxRNQG9mzs=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
-github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
-github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
@@ -157,8 +157,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.20.1 h1:zBmqAMfbhlosy2iqPMghe3qytEOALtwLITpgNAkXKUw=
-github.com/reubenmiller/go-c8y v0.20.1/go.mod h1:bNJLF+fokWDpztGiX5CsbEY5F8c3h9Wwu6c2uHdG0S8=
+github.com/reubenmiller/go-c8y v0.20.2 h1:jzIC/o7tVenJza5n97Zq6q/Yij/nAFJJ2/PfgVXs2VY=
+github.com/reubenmiller/go-c8y v0.20.2/go.mod h1:UmSCgL79kUoGuYGCuAhDsXVB4LZtYBAQckxRNQG9mzs=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
+++ b/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
@@ -151,7 +151,7 @@ func (n *SubscribeCmd) RunE(cmd *cobra.Command, args []string) error {
 	for {
 		select {
 		case msg := <-messagesCh:
-			cfg.Logger.Infof("Received message: (action=%s, description=%s) %s", msg.Action, msg.Description, msg.Payload)
+			cfg.Logger.Infof("Received message: (id=%s, action=%s, description=%s) %s", msg.Identifier, msg.Action, msg.Description, msg.Payload)
 
 			if len(n.ActionTypes) == 0 {
 				isMatch = true


### PR DESCRIPTION
Fixes to the `c8y notification2` commands regarding the websocket connection to Cumulocity IoT and the parsing of the messages.

Changes include:

* Fix message parsing bug which was caused by failing to allocate memory during parsing which resulted in corrupted message parsing (fields were mixed). This would result in corrupted ack messages which the server would then disconnect the client, and a reconnection loop would start.
* Update websocket library to prevent `use of closed network connection` errors
* Explicitly close websocket before reconnecting