### PR TITLE
feat(tenantoptions): allow setting tenant option with an explicit empty value

### DIFF
--- a/api/spec/json/tenantOptions.json
+++ b/api/spec/json/tenantOptions.json
@@ -78,7 +78,7 @@
         },
         {
           "name": "value",
-          "type": "string",
+          "type": "stringAny",
           "description": "Value of option"
         },
         {
@@ -234,7 +234,7 @@
       "body": [
         {
           "name": "value",
-          "type": "string",
+          "type": "stringAny",
           "description": "New value"
         },
         {

--- a/api/spec/json/tenantOptions.json
+++ b/api/spec/json/tenantOptions.json
@@ -89,8 +89,7 @@
       ],
       "bodyRequiredKeys": [
         "category",
-        "key",
-        "value"
+        "key"
       ]
     },
     {
@@ -243,9 +242,6 @@
           "type": "json",
           "description": "Additional properties"
         }
-      ],
-      "bodyRequiredKeys": [
-        "value"
       ]
     },
     {

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -214,6 +214,7 @@
         "uipluginversion",
         "queryExpression",
         "string",
+        "stringAny",
         "stringStatic",
         "inventoryChildType",
         "source",

--- a/api/spec/yaml/tenantOptions.yaml
+++ b/api/spec/yaml/tenantOptions.yaml
@@ -63,7 +63,7 @@ commands:
         description: Key of option
 
       - name: value
-        type: string
+        type: stringAny
         description: Value of option
 
       - name: data
@@ -175,7 +175,7 @@ commands:
 
     body:
       - name: value
-        type: string
+        type: stringAny
         description: New value
 
       - name: data

--- a/api/spec/yaml/tenantOptions.yaml
+++ b/api/spec/yaml/tenantOptions.yaml
@@ -73,7 +73,6 @@ commands:
     bodyRequiredKeys:
       - "category"
       - "key"
-      - "value"
 
   - name: getTenantOption
     description: Get tenant option
@@ -182,9 +181,6 @@ commands:
       - name: data
         type: json
         description: Additional properties
-
-    bodyRequiredKeys:
-      - value
 
   - name: updateTenantOptionBulk
     description: Update multiple tenant options

--- a/cmd/gen-tests/main.go
+++ b/cmd/gen-tests/main.go
@@ -365,7 +365,7 @@ func getParameterValue(cmd *cobra.Command, parameter *models.Parameter) (value s
 		}
 	// case "applications":
 	// 	fallthrough
-	case "string", "application":
+	case "string", "application", "stringAny":
 		v, err := cmd.Flags().GetString(parameter.Name)
 		if err == nil {
 			value = v

--- a/pkg/cmd/tenantoptions/create/create.auto.go
+++ b/pkg/cmd/tenantoptions/create/create.auto.go
@@ -141,10 +141,10 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("category", "category"),
 		flags.WithStringValue("key", "key"),
-		flags.WithStringValue("value", "value"),
+		flags.WithAnyStringValue("value", "value"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
-		flags.WithRequiredProperties("category", "key", "value"),
+		flags.WithRequiredProperties("category", "key"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/tenantoptions/update/update.auto.go
+++ b/pkg/cmd/tenantoptions/update/update.auto.go
@@ -139,10 +139,9 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		body,
 		inputIterators,
 		flags.WithDataFlagValue(),
-		flags.WithStringValue("value", "value"),
+		flags.WithAnyStringValue("value", "value"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
-		flags.WithRequiredProperties("value"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmdparser/cmdparser.go
+++ b/pkg/cmdparser/cmdparser.go
@@ -245,7 +245,7 @@ func AddFlag(cmd *CmdOptions, p *models.Parameter, factory *cmdutil.Factory) err
 		return nil
 	}
 	switch p.Type {
-	case "string", "stringStatic", "devicerequest", "json_custom", "directory", "softwareName", "softwareversionName", "softwareDetails", "firmwareName", "firmwareversionName", "firmwarepatchName", "firmwareDetails", "binaryUploadURL", "inventoryChildType", "subscriptionName", "subscriptionId", "file", "attachment", "fileContents", "fileContentsAsString", "certificatefile":
+	case "string", "stringAny", "stringStatic", "devicerequest", "json_custom", "directory", "softwareName", "softwareversionName", "softwareDetails", "firmwareName", "firmwareversionName", "firmwarepatchName", "firmwareDetails", "binaryUploadURL", "inventoryChildType", "subscriptionName", "subscriptionId", "file", "attachment", "fileContents", "fileContentsAsString", "certificatefile":
 		cmd.Command.Flags().StringP(p.Name, p.ShortName, p.Default, p.GetDescription())
 
 	case "json":
@@ -402,6 +402,9 @@ func GetOption(cmd *CmdOptions, p *models.Parameter, factory *cmdutil.Factory, a
 
 	case "string", "source", "tenantname", "devicerequest", "subscriptionName", "subscriptionId", "applicationname", "microserviceinstance", "microservicename", "softwareName", "softwareversionName", "firmwareName", "firmwareversionName", "firmwarepatchName", "uipluginversion":
 		opts = append(opts, flags.WithStringValue(p.Name, targetProp, p.Format))
+
+	case "stringAny":
+		opts = append(opts, flags.WithAnyStringValue(p.Name, targetProp, p.Format))
 
 	case "stringStatic":
 		opts = append(opts, flags.WithStaticStringValue(p.Name, p.Value))

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -1207,7 +1207,7 @@ Function Get-C8yGoArgs {
             }
         }
 
-        "string" {
+        { $_ -in "string", "stringAny" } {
             $SetFlag = if ($UseOption) {
                 'cmd.Flags().StringP("{0}", "{1}", "{2}", "{3}")' -f $Name, $OptionName, $Default, $Description
             } else {

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -71,6 +71,9 @@
         # string
         "string" = "flags.WithStringValue(`"${prop}`", `"${queryParam}`"$FormatValue),"
 
+        # stringAny string value (allow users to set an empty string value)
+        "stringAny" = "flags.WithAnyStringValue(`"${prop}`", `"${queryParam}`"$FormatValue),"
+
         # stringStatic
         "stringStatic" = "flags.WithStaticStringValue(`"${prop}`", `"$FixedValue`"),"
 

--- a/scripts/build-powershell/New-C8yPowershellArguments.ps1
+++ b/scripts/build-powershell/New-C8yPowershellArguments.ps1
@@ -112,6 +112,7 @@
         "softwareversionName" { "object[]"; break }
         "source" { "object"; break }
         "string" { "string"; break }
+        "stringAny" { "string"; break }
         "strings" { "string"; break }
         "subscriptionId" { "string"; break }
         "subscriptionName" { "string"; break }

--- a/tests/manual/tenantoptions/tenantoptions_create.yaml
+++ b/tests/manual/tenantoptions/tenantoptions_create.yaml
@@ -1,0 +1,29 @@
+tests:
+    It creates a tenant option with an empty string value:
+        command: >
+          c8y tenantoptions create --category measurement.series.latestvalue --key c8y_Temperature.T --value "" --dry --dryFormat json |
+           c8y util show --select body -c=false --output json
+        exit-code: 0
+        stdout:
+            exactly: |
+                {
+                  "body": {
+                    "category": "measurement.series.latestvalue",
+                    "key": "c8y_Temperature.T",
+                    "value": ""
+                  }
+                }
+    
+    It creates a tenant option without a value:
+        command: >
+            c8y tenantoptions create --category measurement.series.latestvalue --key c8y_Temperature.T --dry --dryFormat json |
+            c8y util show --select body -c=false --output json
+        exit-code: 0
+        stdout:
+            exactly: |
+                {
+                  "body": {
+                    "category": "measurement.series.latestvalue",
+                    "key": "c8y_Temperature.T"
+                  }
+                }

--- a/tests/manual/tenantoptions/tenantoptions_update.yaml
+++ b/tests/manual/tenantoptions/tenantoptions_update.yaml
@@ -1,0 +1,24 @@
+tests:
+    It creates a tenant option with an empty string value:
+        command: >
+          c8y tenantoptions update --category measurement.series.latestvalue --key c8y_Power.V --value "" --dry --dryFormat json |
+           c8y util show --select body -c=false --output json
+        exit-code: 0
+        stdout:
+            exactly: |
+                {
+                  "body": {
+                    "value": ""
+                  }
+                }
+    
+    It creates a tenant option without a value:
+        command: >
+            c8y tenantoptions update --category measurement.series.latestvalue --key c8y_Power.V --dry --dryFormat json |
+            c8y util show --select body -c=false --output json
+        exit-code: 0
+        stdout:
+            exactly: |
+                {
+                  "body": {}
+                }

--- a/tools/schema/extensionCommands.json
+++ b/tools/schema/extensionCommands.json
@@ -288,6 +288,7 @@
                 "softwareversionName",
                 "source",
                 "string",
+                "stringAny",
                 "string[]",
                 "stringcsv[]",
                 "stringStatic",


### PR DESCRIPTION
Align to Cumulocity REST API spec where the `value` is not a required parameter for the following commands:

* `c8y tenantoptions create`
* `c8y tenantoptions update`

The above command include the following changes:

* Allow users to specify an empty string via the `--value` flag
* Allow users to create an option without using the `--value` flag (e.g. it is no longer required)

**Examples**

```sh
# Create an option
c8y tenantoptions create --category "measurement.series.latestvalue" \
    --key "c8y_Temperature.*" --value "" --dry

# Update an option
c8y tenantoptions update --category "measurement.series.latestvalue" \
    --key "c8y_Temperature.*" --value "" --dry
```