### PR TITLE
fix(ui plugins create): only include plugins owned by current tenant during named lookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.20.3
+	github.com/reubenmiller/go-c8y v0.20.4
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.20.3 h1:p+RZMeBqUA1qdPdhPaaMR7EEgWNXrN4CUfqehKpX0fw=
-github.com/reubenmiller/go-c8y v0.20.3/go.mod h1:UmSCgL79kUoGuYGCuAhDsXVB4LZtYBAQckxRNQG9mzs=
+github.com/reubenmiller/go-c8y v0.20.4 h1:ZI3fIPVk49xEDLqFJ3fVn+2TmxsW8zVjzgoj5vAu5zA=
+github.com/reubenmiller/go-c8y v0.20.4/go.mod h1:UmSCgL79kUoGuYGCuAhDsXVB4LZtYBAQckxRNQG9mzs=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=


### PR DESCRIPTION
Fix a bug where the "smart" `c8y ui plugins create` command would check if the given plugin already exists or not, however when run against the `management` tenant, if subtenants already had a plugin with the same name, it would result in the incorrect plugin being found.

Now the ui plugin named lookup (only during the `c8y ui plugins create` command) will only look for plugins owned by the current tenant.

**Note** The bug was fixed in the underlying go-c8y library in https://github.com/reubenmiller/go-c8y/pull/73