### PR TITLE
fix(powershell): set-c8ymode was calling non existent source function

### DIFF
--- a/pkg/cmd/cli/profile/scripts/plugin.ps1
+++ b/pkg/cmd/cli/profile/scripts/plugin.ps1
@@ -95,7 +95,7 @@ Enable dev mode (enables POST, PUT and DELETE commands)
         [parameter(ValueFromRemainingArguments=$true)]
         $Options
     )
-    c8y settings update --shell auto mode $Mode $Options | source
+    c8y settings update --shell auto mode $Mode $Options | Out-String | Invoke-Expression
     Write-Host "Enabled "$Mode" mode (temporarily)" -ForegroundColor Green
 }
 

--- a/tools/shell/c8y.plugin.ps1
+++ b/tools/shell/c8y.plugin.ps1
@@ -93,8 +93,6 @@ Enable dev mode (enables POST, PUT and DELETE commands)
         [parameter(ValueFromRemainingArguments=$true)]
         $Options
     )
-    c8y settings update --shell auto mode $Mode $Options | source
+    c8y settings update --shell auto mode $Mode $Options | Out-String | Invoke-Expression
     Write-Host "Enabled "$Mode" mode (temporarily)" -ForegroundColor Green
 }
-
-# Function source { $input | Out-String | Invoke-Expression }


### PR DESCRIPTION
In powershell, calling the `set-c8ymode` function would result in an error due to the usage of the non-existent `source` function.

The usage of `source` has been replaced with `| Out-String | Invoke-Expression`