### PR TITLE
feat(software install): add softwareType field by looking up the software

### DIFF
--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -382,7 +382,14 @@
           "type": "string",
           "required": false,
           "property": "c8y_SoftwareUpdate.0.url",
-          "description": "Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository"
+          "description": "Software url. Leave blank to automatically set it if a matching software/version is found in the c8y software repository"
+        },
+        {
+          "name": "softwareType",
+          "type": "string",
+          "required": false,
+          "property": "c8y_SoftwareUpdate.0.softwareType",
+          "description": "Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository"
         },
         {
           "name": "description",

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -294,8 +294,13 @@ commands:
         type: 'string'
         required: false
         property: c8y_SoftwareUpdate.0.url
-        description: Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository
+        description: Software url. Leave blank to automatically set it if a matching software/version is found in the c8y software repository
 
+      - name: softwareType
+        type: string
+        required: false
+        property: c8y_SoftwareUpdate.0.softwareType
+        description: Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository
 
       - name: description
         type: string

--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -710,7 +710,7 @@ func WithSoftwareByNameFirstMatch(factory *cmdutil.Factory, args []string, opts 
 }
 
 // WithSoftwareVersionData adds software information (name, version and url)
-func WithSoftwareVersionData(factory *cmdutil.Factory, flagSoftware, flagVersion, flagURL string, args []string, opts ...string) flags.GetOption {
+func WithSoftwareVersionData(factory *cmdutil.Factory, flagSoftware, flagVersion, flagURL string, flagSoftwareType string, args []string, opts ...string) flags.GetOption {
 	return func(cmd *cobra.Command, inputIterators *flags.RequestInputIterators) (string, interface{}, error) {
 		client, err := factory.Client()
 		if err != nil {
@@ -731,9 +731,32 @@ func WithSoftwareVersionData(factory *cmdutil.Factory, flagSoftware, flagVersion
 			url = v[0]
 		}
 
+		softwareType := ""
+		if v, err := flags.GetFlagStringValues(cmd, flagSoftwareType); err == nil && len(v) > 0 {
+			softwareType = v[0]
+		}
+
+		if softwareType == "" && software != "" {
+			// Set software type by looking up the software (if found)
+			matchingSoftware, _, err := client.Software.GetSoftwareByName(c8y.WithDisabledDryRunContext(context.Background()), software, c8y.NewPaginationOptions(5))
+			if err != nil {
+				return "", "", err
+			}
+
+			if len(matchingSoftware.ManagedObjects) > 0 {
+				if v := matchingSoftware.Items[0].Get("softwareType"); v.Exists() {
+					softwareType = v.String()
+				}
+			}
+		}
+
 		_, dst, _ := flags.UnpackGetterOptions("", opts...)
 
 		output := map[string]string{}
+
+		if softwareType != "" {
+			output["softwareType"] = softwareType
+		}
 
 		// If version is empty, then pass the values as is
 		if version == "" || (software != "" && version != "" && url != "") {

--- a/pkg/cmd/software/versions/install/install.auto.go
+++ b/pkg/cmd/software/versions/install/install.auto.go
@@ -54,7 +54,8 @@ Install a software package version with an explicit url
 	cmd.Flags().StringSlice("device", []string{""}, "Device or agent where the software should be installed (accepts pipeline)")
 	cmd.Flags().String("software", "", "Software name (required)")
 	cmd.Flags().String("version", "", "Software version id or name")
-	cmd.Flags().String("url", "", "Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository")
+	cmd.Flags().String("url", "", "Software url. Leave blank to automatically set it if a matching software/version is found in the c8y software repository")
+	cmd.Flags().String("softwareType", "", "Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository")
 	cmd.Flags().String("description", "Install software package", "Operation description")
 	cmd.Flags().String("action", "install", "Software action")
 
@@ -156,8 +157,9 @@ func (n *InstallCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("software", "c8y_SoftwareUpdate.0.name"),
 		flags.WithStringValue("version", "c8y_SoftwareUpdate.0.version"),
 		flags.WithStringValue("url", "c8y_SoftwareUpdate.0.url"),
+		flags.WithStringValue("softwareType", "c8y_SoftwareUpdate.0.softwareType"),
 		flags.WithStringValue("description", "description"),
-		c8yfetcher.WithSoftwareVersionData(n.factory, "software", "version", "url", args, "", "c8y_SoftwareUpdate.0"),
+		c8yfetcher.WithSoftwareVersionData(n.factory, "software", "version", "url", "softwareType", args, "", "c8y_SoftwareUpdate.0"),
 		flags.WithStringValue("action", "c8y_SoftwareUpdate.0.action"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),

--- a/pkg/cmdparser/cmdparser.go
+++ b/pkg/cmdparser/cmdparser.go
@@ -451,7 +451,7 @@ func GetOption(cmd *CmdOptions, p *models.Parameter, factory *cmdutil.Factory, a
 		opts = append(opts, c8yfetcher.WithSoftwareByNameFirstMatch(factory, args, p.Name, targetProp, p.Format))
 
 	case "softwareDetails":
-		opts = append(opts, c8yfetcher.WithSoftwareVersionData(factory, p.GetDependentProperty(0, "software"), p.Name, p.GetDependentProperty(1, "url"), args, "", targetProp, p.Format))
+		opts = append(opts, c8yfetcher.WithSoftwareVersionData(factory, p.GetDependentProperty(0, "software"), p.Name, p.GetDependentProperty(1, "url"), p.GetDependentProperty(2, "softwareType"), args, "", targetProp, p.Format))
 
 	case "configurationDetails":
 		opts = append(opts, c8yfetcher.WithConfigurationFileData(factory, p.Name, p.GetDependentProperty(0, "configurationType"), p.GetDependentProperty(1, "url"), args, "", targetProp, p.Format))

--- a/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
+++ b/scripts/build-cli/New-C8yApiGoGetValueFromFlag.ps1
@@ -140,7 +140,7 @@
         "software[]" = "c8yfetcher.WithSoftwareByNameFirstMatch(n.factory, args, `"${prop}`", `"${queryParam}`"$FormatValue),"
 
         "softwareDetails" = @(
-            "c8yfetcher.WithSoftwareVersionData(n.factory, `"software`", `"version`", `"url`", args, `"`", `"${queryParam}`"$FormatValue),"
+            "c8yfetcher.WithSoftwareVersionData(n.factory, `"software`", `"version`", `"url`", `"softwareType`", args, `"`", `"${queryParam}`"$FormatValue),"
         ) -join "`n"
 
         "configurationDetails" = @(

--- a/tests/manual/software/install/software_versions_install.yaml
+++ b/tests/manual/software/install/software_versions_install.yaml
@@ -10,7 +10,7 @@ config:
 tests:
   It creates an operation to update software without a version:
     command: |
-      c8y software versions install --device 1 --software "myapp" --description "Installing software" |
+      c8y software versions install --device 1 --software "userapp1" --description "Installing software" |
         c8y util show --select method,pathEncoded,body --compact=false
     exit-code: 0
     stdout:
@@ -20,7 +20,7 @@ tests:
             "c8y_SoftwareUpdate": [
               {
                 "action": "install",
-                "name": "myapp",
+                "name": "userapp1",
                 "url": "",
                 "version": ""
               }
@@ -36,7 +36,7 @@ tests:
     command: |
       c8y software versions install \
         --device 1 \
-        --software "myapp" \
+        --software "userapp1" \
         --description "Installing software" \
         --url "https://test.com/binary/package.zip" |
         c8y util show --select method,pathEncoded,body --compact=false
@@ -48,7 +48,7 @@ tests:
             "c8y_SoftwareUpdate": [
               {
                 "action": "install",
-                "name": "myapp",
+                "name": "userapp1",
                 "url": "https://test.com/binary/package.zip",
                 "version": ""
               }
@@ -77,6 +77,7 @@ tests:
               {
                 "action": "install",
                 "name": "my-app",
+                "softwareType": "linux-package",
                 "url": "https://example.com/debian/my-app-1.2.3.deb",
                 "version": "1.2.3"
               }
@@ -106,6 +107,38 @@ tests:
               {
                 "action": "install",
                 "name": "my-app",
+                "softwareType": "linux-package",
+                "url": "https://test.com/binary/package.zip",
+                "version": "1.2.3"
+              }
+            ],
+            "description": "Installing software",
+            "deviceId": "1"
+          },
+          "method": "POST",
+          "pathEncoded": "/devicecontrol/operations"
+        }
+
+  It creates an operation to update software with a version but a custom softwareType:
+    command: |
+      c8y software versions install \
+        --device 1 \
+        --software "my-app" \
+        --version "1.2.3" \
+        --softwareType otherType \
+        --description "Installing software" \
+        --url "https://test.com/binary/package.zip" |
+        c8y util show --select method,pathEncoded,body --compact=false
+    exit-code: 0
+    stdout:
+      exactly: |
+        {
+          "body": {
+            "c8y_SoftwareUpdate": [
+              {
+                "action": "install",
+                "name": "my-app",
+                "softwareType": "otherType",
                 "url": "https://test.com/binary/package.zip",
                 "version": "1.2.3"
               }

--- a/tests/scripts/setup.sh
+++ b/tests/scripts/setup.sh
@@ -44,7 +44,7 @@ setup () {
     create_firmware_version "iot-linux" "1.0.0" "https://example.com"
     create_firmware_patch_version "iot-linux" "1.0.1" "https://example.com/patch1"
 
-    create_software "my-app"
+    create_software "my-app" "linux-package"
     create_software_version "my-app" "1.2.3" "https://example.com/debian/my-app-1.2.3.deb"
 
     create_device_profile "profile01"
@@ -203,8 +203,11 @@ create_configuration () {
 
 create_software () {
     local name="$1"
-    c8y software get -n --id "$name" --silentStatusCodes 404 ||
+    local software_type="$2"
+    {
+        c8y software get -n --id "$name" --silentStatusCodes 404 ||
         c8y software create -n --name "$name"
+    } | c8y software update --softwareType "$software_type"
 }
 
 create_software_version () {

--- a/tools/PSc8y/Public/Install-SoftwareVersion.ps1
+++ b/tools/PSc8y/Public/Install-SoftwareVersion.ps1
@@ -38,10 +38,15 @@ Get a software package
         [object[]]
         $Version,
 
-        # Software url. Leave blank to automatically set it if a matching firmware/version is found in the c8y firmware repository
+        # Software url. Leave blank to automatically set it if a matching software/version is found in the c8y software repository
         [Parameter()]
         [string]
         $Url,
+
+        # Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository
+        [Parameter()]
+        [string]
+        $SoftwareType,
 
         # Operation description
         [Parameter()]


### PR DESCRIPTION
`c8y software versions install` now sets the `softwareType` property of the operation if the user provides the software item reference via `--software <name|id>`.

Previously, name, url, and version were added, by softwareType was not. This has been resolved now.

User's can also over the value by specifying a static value using the `--softwareType <value>` flag.

**Example**

```sh
c8y software versions install --softwareType hello \
        --device "portenta-x8-1f0e4a09dabc16ac" \
        --action install \
        --software tedge \
        --version "ghcr.io/thin-edge/tedge-container-bundle:20241201.0920" --dry
```

Outgoing request Body:

```json
{
  "c8y_SoftwareUpdate": [
    {
      "action": "install",
      "name": "tedge",
      "softwareType": "container",
      "url": "",
      "version": "ghcr.io/thin-edge/tedge-container-bundle:20241201.0920"
    }
  ],
  "description": "Install software package",
  "deviceId": "4541877894"
}
```