### PR TITLE
fix(users update): remove example that no longer works due to security changes in Cumulocity

### DIFF
--- a/api/spec/json/users.json
+++ b/api/spec/json/users.json
@@ -416,11 +416,6 @@
           {
             "description": "Update a user",
             "command": "c8y users update --id \"myuser\" --firstName \"Simon\""
-          },
-          {
-            "description": "Update the email field in each user to match the id (if the id includes the @ sign)",
-            "command": "c8y users list --filter \"id like *@*\" | c8y users update --template \"{email: input.value.id}\"\n",
-            "skipTest": true
           }
         ]
       },

--- a/api/spec/yaml/users.yaml
+++ b/api/spec/yaml/users.yaml
@@ -308,11 +308,6 @@ commands:
         - description: Update a user
           command: c8y users update --id "myuser" --firstName "Simon"
 
-        - description: Update the email field in each user to match the id (if the id includes the @ sign)
-          command: |
-            c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"
-          skipTest: true
-
     pathParameters:
       - name: id
         type: user[]

--- a/pkg/cmd/users/update/update.auto.go
+++ b/pkg/cmd/users/update/update.auto.go
@@ -36,9 +36,6 @@ func NewUpdateCmd(f *cmdutil.Factory) *UpdateCmd {
 		Example: heredoc.Doc(`
 $ c8y users update --id "myuser" --firstName "Simon"
 Update a user
-
-$ c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"
-Update the email field in each user to match the id (if the id includes the @ sign)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.UpdateModeEnabled()

--- a/tests/auto/users/tests/users_update.yaml
+++ b/tests/auto/users/tests/users_update.yaml
@@ -7,11 +7,3 @@ tests:
                 body.firstName: Simon
                 method: PUT
                 path: /user/$C8Y_TENANT/users/myuser
-    users_update_Update the email field in each user to match the id (if the id includes the @ sign):
-        command: '$TEST_SHELL -c ''c8y users list --filter "id like *@*" | c8y users update --template "{email: input.value.id}"'''
-        exit-code: 0
-        skip: true
-        stdout:
-            json:
-                method: PUT
-                path: /user/$C8Y_TENANT/users/{id}


### PR DESCRIPTION
Removing an example in the `c8y users update` command which is no longer valid as Cumulocity does not allow updating other user's email address.

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/413