### PR TITLE
feat(remoteaccess): support easier ssh port-forwarding for users

### DIFF
--- a/pkg/cmd/remoteaccess/connect/run/run.manual.go
+++ b/pkg/cmd/remoteaccess/connect/run/run.manual.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -189,6 +190,7 @@ func (n *CmdRun) RunE(cmd *cobra.Command, args []string) error {
 		}
 
 		runCmd := exec.CommandContext(context.Background(), run, runArgs...)
+		runCmd.Env = append(runCmd.Env, os.Environ()...)
 
 		// Add target and port to the environment variables so it can be easily accessed from more
 		// complex scripts

--- a/pkg/cmd/remoteaccess/connect/run/run.manual.go
+++ b/pkg/cmd/remoteaccess/connect/run/run.manual.go
@@ -67,6 +67,9 @@ func NewCmdRun(f *cmdutil.Factory) *CmdRun {
 		Example: heredoc.Doc(`
 			$ c8y remoteaccess connect run --device 12345 -- ssh -p %p root@%h
 			Start an interactive SSH session on the device with a given ssh user
+
+			$ c8y remoteaccess connect run --device rpi5-abcdef01 --configuration passthrough -- ssh -p %p -L 1885:127.0.0.1:1883 -o ServerAliveInterval=120 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1
+			Start an SSH session to setup port-forwarding to map the remote's 127.0.0.1:1883 port to your machine's 1885 port
 		`),
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -66,6 +66,12 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1883:127.0.0.1:1883
 			Start an interactive SSH session and configure port-forwarding by mapping the remote's 127.0.0.1:1883 to your machine's port 1883
 
+			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1883
+			Start an interactive SSH session and configure port-forwarding: 127.0.0.11883 (remote) => 1883 (local)
+
+			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1884:1883
+			Start an interactive SSH session and configure port-forwarding: 127.0.0.11883 (remote) => 1884 (local)
+
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -- systemctl status
 			Use a non-interactive session to execute a single command and print the result
 
@@ -80,7 +86,7 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 	cmd.Flags().StringVar(&ccmd.listen, "listen", "127.0.0.1:0", "Listener address. unix:///run/example.sock")
 	cmd.Flags().StringVar(&ccmd.user, "user", "", "Default ssh user")
 	cmd.Flags().StringVar(&ccmd.configuration, "configuration", "", "Remote Access Configuration")
-	cmd.Flags().StringVarP(&ccmd.portForwarding, "port-forwarding", "L", "", "SSH Port-Forwarding option in the format [bind_address:]port:host:hostport. The value is passed to the ssh -L option, so read the ssh man page for more info")
+	cmd.Flags().StringVarP(&ccmd.portForwarding, "port-forwarding", "L", "", "SSH Port-Forwarding option in the format [bind_address:]port:host:hostport. It also accepts a custom short form, <local>[:<remote>]. The value is passed to the ssh -L option, so read the ssh man page for more info")
 
 	completion.WithOptions(
 		cmd,
@@ -98,6 +104,20 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 	return ccmd
 }
 
+func (n *CmdSSH) GetPortForwarding() string {
+	// convenience functions to mirror docker port mapping options
+	portMapping := n.portForwarding
+	portForwardingParts := strings.Split(portMapping, ":")
+	switch len(portForwardingParts) {
+	case 1:
+		// -L 1883 => -L 1883:127.0.0.1:1883
+		portMapping = fmt.Sprintf("%s:127.0.0.1:%s", portForwardingParts[0], portForwardingParts[0])
+	case 2:
+		// -L 1884:1883 => -L 1884:127.0.0.1:1883
+		portMapping = fmt.Sprintf("%s:127.0.0.1:%s", portForwardingParts[0], portForwardingParts[1])
+	}
+	return portMapping
+}
 func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 	client, err := n.factory.Client()
 	if err != nil {
@@ -190,8 +210,9 @@ func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 		}
 		sshArgs = append(sshArgs, "-p", port, sshTarget)
 
-		if n.portForwarding != "" {
-			sshArgs = append(sshArgs, "-L", n.portForwarding)
+		portForwarding := n.GetPortForwarding()
+		if portForwarding != "" {
+			sshArgs = append(sshArgs, "-L", portForwarding)
 		}
 
 		dashIdx := cmd.ArgsLenAtDash()
@@ -207,8 +228,8 @@ func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 		log.Infof("Executing command: ssh %s\n", strings.Join(sshArgs, " "))
 
 		cs := n.factory.IOStreams.ColorScheme()
-		if n.portForwarding != "" {
-			fmt.Fprintln(n.factory.IOStreams.ErrOut, cs.Green(fmt.Sprintf("Starting interactive ssh session with %s (%s) with port-forwarding %s\n", device, strings.TrimRight(client.BaseURL.String(), "/"), n.portForwarding)))
+		if portForwarding != "" {
+			fmt.Fprintln(n.factory.IOStreams.ErrOut, cs.Green(fmt.Sprintf("Starting interactive ssh session with %s (%s) with port-forwarding %s\n", device, strings.TrimRight(client.BaseURL.String(), "/"), portForwarding)))
 		} else {
 			fmt.Fprintln(n.factory.IOStreams.ErrOut, cs.Green(fmt.Sprintf("Starting interactive ssh session with %s (%s)\n", device, strings.TrimRight(client.BaseURL.String(), "/"))))
 		}

--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -24,10 +24,11 @@ import (
 )
 
 type CmdSSH struct {
-	device        []string
-	listen        string
-	user          string
-	configuration string
+	device         []string
+	listen         string
+	user           string
+	configuration  string
+	portForwarding string
 
 	*subcommand.SubCommand
 
@@ -62,6 +63,9 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 			$ c8y remoteaccess connect ssh --device 12345 --user admin
 			Start an interactive SSH session on the device with a given ssh user
 
+			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1883:127.0.0.1:1883
+			Start an interactive SSH session and configure port-forwarding by mapping the remote's 127.0.0.1:1883 to your machine's port 1883
+
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -- systemctl status
 			Use a non-interactive session to execute a single command and print the result
 
@@ -76,6 +80,7 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 	cmd.Flags().StringVar(&ccmd.listen, "listen", "127.0.0.1:0", "Listener address. unix:///run/example.sock")
 	cmd.Flags().StringVar(&ccmd.user, "user", "", "Default ssh user")
 	cmd.Flags().StringVar(&ccmd.configuration, "configuration", "", "Remote Access Configuration")
+	cmd.Flags().StringVarP(&ccmd.portForwarding, "port-forwarding", "L", "", "SSH Port-Forwarding option in the format [bind_address:]port:host:hostport. The value is passed to the ssh -L option, so read the ssh man page for more info")
 
 	completion.WithOptions(
 		cmd,
@@ -185,6 +190,10 @@ func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 		}
 		sshArgs = append(sshArgs, "-p", port, sshTarget)
 
+		if n.portForwarding != "" {
+			sshArgs = append(sshArgs, "-L", n.portForwarding)
+		}
+
 		dashIdx := cmd.ArgsLenAtDash()
 		if dashIdx > -1 {
 			sshArgs = append(sshArgs, "--")
@@ -198,7 +207,11 @@ func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 		log.Infof("Executing command: ssh %s\n", strings.Join(sshArgs, " "))
 
 		cs := n.factory.IOStreams.ColorScheme()
-		fmt.Fprintln(n.factory.IOStreams.ErrOut, cs.Green(fmt.Sprintf("Starting interactive ssh session with %s (%s)\n", device, strings.TrimRight(client.BaseURL.String(), "/"))))
+		if n.portForwarding != "" {
+			fmt.Fprintln(n.factory.IOStreams.ErrOut, cs.Green(fmt.Sprintf("Starting interactive ssh session with %s (%s) with port-forwarding %s\n", device, strings.TrimRight(client.BaseURL.String(), "/"), n.portForwarding)))
+		} else {
+			fmt.Fprintln(n.factory.IOStreams.ErrOut, cs.Green(fmt.Sprintf("Starting interactive ssh session with %s (%s)\n", device, strings.TrimRight(client.BaseURL.String(), "/"))))
+		}
 
 		start := time.Now()
 		sshErr := sshCmd.Run()

--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -64,13 +64,13 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 			Start an interactive SSH session on the device with a given ssh user
 
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1883:127.0.0.1:1883
-			Start an interactive SSH session and configure port-forwarding by mapping the remote's 127.0.0.1:1883 to your machine's port 1883
+			Start an interactive SSH session and configure port-forward by mapping the remote's 127.0.0.1:1883 to your machine's port 1883
 
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1883
-			Start an interactive SSH session and configure port-forwarding: 127.0.0.11883 (remote) => 1883 (local)
+			Start an interactive SSH session and configure port-forward: 127.0.0.11883 (remote) => 1883 (local)
 
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1884:1883
-			Start an interactive SSH session and configure port-forwarding: 127.0.0.11883 (remote) => 1884 (local)
+			Start an interactive SSH session and configure port-forward: 127.0.0.11883 (remote) => 1884 (local)
 
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -- systemctl status
 			Use a non-interactive session to execute a single command and print the result
@@ -86,7 +86,7 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 	cmd.Flags().StringVar(&ccmd.listen, "listen", "127.0.0.1:0", "Listener address. unix:///run/example.sock")
 	cmd.Flags().StringVar(&ccmd.user, "user", "", "Default ssh user")
 	cmd.Flags().StringVar(&ccmd.configuration, "configuration", "", "Remote Access Configuration")
-	cmd.Flags().StringVarP(&ccmd.portForwarding, "port-forwarding", "L", "", "SSH Port-Forwarding option in the format [bind_address:]port:host:hostport. It also accepts a custom short form, <local>[:<remote>]. The value is passed to the ssh -L option, so read the ssh man page for more info")
+	cmd.Flags().StringVarP(&ccmd.portForwarding, "port-forward", "L", "", "SSH Port-Forwarding option in the format [bind_address:]port:host:hostport. It also accepts a custom short form, <local>[:<remote>]. The value is passed to the ssh -L option, so read the ssh man page for more info")
 
 	completion.WithOptions(
 		cmd,

--- a/pkg/cmd/remoteaccess/server/server.manual.go
+++ b/pkg/cmd/remoteaccess/server/server.manual.go
@@ -39,25 +39,25 @@ func NewCmdServer(f *cmdutil.Factory) *CmdServer {
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Start a local proxy server",
-		Long: `
-		Start a local proxy server
+		Long: heredoc.Doc(`
+			Start a local proxy server
 
-		You can add use the remote access local proxy within your ssh config file, to use it to
-		connect to your device with ssh without having to manually launch the proxy yourself!
+			You can add use the remote access local proxy within your ssh config file, to use it to
+			connect to your device with ssh without having to manually launch the proxy yourself!
 
-		To do this add the following configuration to your device.
+			To do this add the following configuration to your device.
 
-		---
-		Host <device>
-			User <device_username>
-			PreferredAuthentications publickey
-			IdentityFile <identify_file>
-			ServerAliveInterval 120
-			StrictHostKeyChecking no
-			UserKnownHostsFile /dev/null
-			ProxyCommand c8y remoteaccess server --device %n --listen -
-		---
-		`,
+			---
+			Host <device>
+				User <device_username>
+				PreferredAuthentications publickey
+				IdentityFile <identify_file>
+				ServerAliveInterval 120
+				StrictHostKeyChecking no
+				UserKnownHostsFile /dev/null
+				ProxyCommand c8y remoteaccess server --device %n --listen -
+			---
+		`),
 		Example: heredoc.Doc(`
 			$ c8y remoteaccess server --device 12345
 			Start a local proxy server on a random local port


### PR DESCRIPTION
Minor improvements to the `c8y remoteaccess` command to make it easier for users to start ssh port-forwarding (in various ways).

* `c8y remoteaccess connect ssh` -  New `-L <[bind_address:]port:host:hostport>` flag which is used to pass to the [ssh -L](https://linux.die.net/man/1/ssh) port-forwarding flag. But it also supports a short-form, `-L <port>` or `-L <local_port>:<remote_port>`

* `c8y remoteaccess connect run` - Inherits the parent's environment variables so it behaves the same as being run manually by the user in the shell

**Examples**

```sh
# Example 1: Setup ssh port forwarding, 127.0.0.1:1883 (remote) to 1883 (local)
c8y remoteaccess connect ssh --device 12345 --user admin -L 1883:127.0.0.1:1883

# Example 2: Setup ssh port forwarding, 127.0.0.1:1883 (remote) to 1883 (local)
c8y remoteaccess connect ssh --device 12345 --user admin -L 1883

# Example 3: Setup ssh port forwarding, 127.0.0.1:1883 (remote) to 1884 (local)
c8y remoteaccess connect ssh --device 12345 --user admin -L 1884:1883

# Example 4: Setup ssh port forwarding using custom ssh command call
c8y remoteaccess connect run --device rpi5-abcdef01 --configuration passthrough -- ssh -p %p -L 1885:127.0.0.1:1883 -o ServerAliveInterval=120 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1
```