### PR TITLE
docs: fix create measurement via template example

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/templates.md
+++ b/docs/go-c8y-cli/docs/concepts/templates.md
@@ -54,7 +54,7 @@ The template can then be used from the command line using the `template` paramet
 <CodeExample>
 
 ```bash
-c8y measurements create --device 1234 --template ./example.jsonnet --dry
+c8y measurements create --device 1234 --type iot_weather_sensor1 --template ./example.jsonnet --dry
 ```
 
 </CodeExample>


### PR DESCRIPTION
Add missing `--type` flag to the example which creates a measurement using a jsonnet template (as the template does not include the required `type` property).

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/421