### PR TITLE
fix: propagate fetcher errors back to the user

### DIFF
--- a/pkg/c8yfetcher/c8yfetcher.go
+++ b/pkg/c8yfetcher/c8yfetcher.go
@@ -130,8 +130,10 @@ func lookupEntity(fetch EntityFetcher, values []string, getID bool, format strin
 						Data: resultSet,
 					})
 				}
+			} else {
+				// Propagate errors back to the caller
+				return entities, err
 			}
-			// TODO: Handle error
 		} else {
 			entities = append(entities, entityReference{
 				ID: applyFormatter(id, format),
@@ -150,8 +152,10 @@ func lookupEntity(fetch EntityFetcher, values []string, getID bool, format strin
 					Data: resultSet,
 				})
 			}
+		} else {
+			// Propagate errors back to the caller
+			return entities, err
 		}
-		// TODO: Handle error
 	}
 
 	return entities, nil

--- a/pkg/c8yfetcher/childAdditionFetcher.go
+++ b/pkg/c8yfetcher/childAdditionFetcher.go
@@ -2,6 +2,7 @@ package c8yfetcher
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 )
@@ -41,9 +42,13 @@ func (f *ChildAdditionFetcher) getByID(id string) ([]fetcherResultSet, error) {
 }
 
 func (f *ChildAdditionFetcher) getByName(name string) ([]fetcherResultSet, error) {
+	var err error
 	query := "name eq '" + name + "'"
 	if f.Query != nil {
-		query = f.Query(name)
+		query, err = f.Query(name)
+		if err != nil {
+			return nil, NewQueryBuildErr(err)
+		}
 	}
 	mcol, _, err := f.client.Inventory.GetChildAdditions(
 		c8y.WithDisabledDryRunContext(context.Background()),

--- a/pkg/c8yfetcher/configurationFetcher.go
+++ b/pkg/c8yfetcher/configurationFetcher.go
@@ -16,8 +16,8 @@ func NewConfigurationFetcher(factory *cmdutil.Factory) *ConfigurationFetcher {
 			CumulocityFetcher: &CumulocityFetcher{
 				factory: factory,
 			},
-			Query: func(s string) string {
-				return fmt.Sprintf("(type eq 'c8y_ConfigurationDump') and name eq '%s'", s)
+			Query: func(s string) (string, error) {
+				return fmt.Sprintf("(type eq 'c8y_ConfigurationDump') and name eq '%s'", s), nil
 			},
 		},
 	}

--- a/pkg/c8yfetcher/deviceServiceFetcher.go
+++ b/pkg/c8yfetcher/deviceServiceFetcher.go
@@ -18,11 +18,11 @@ func NewDeviceServiceFetcher(factory *cmdutil.Factory, device string) *DeviceSer
 			CumulocityFetcher: &CumulocityFetcher{
 				factory: factory,
 			},
-			Query: func(s string) string {
+			Query: func(s string) (string, error) {
 
 				client, err := factory.Client()
 				if err != nil {
-					return ""
+					return "", err
 				}
 
 				if !IsID(device) {
@@ -30,15 +30,18 @@ func NewDeviceServiceFetcher(factory *cmdutil.Factory, device string) *DeviceSer
 					moDevice, _, err := client.Inventory.GetDevicesByName(c8y.WithDisabledDryRunContext(context.Background()), device, &c8y.PaginationOptions{
 						PageSize: 5,
 					})
-					if err == nil && moDevice != nil && len(moDevice.ManagedObjects) > 0 {
+					if err != nil {
+						return "", NewQueryBuildErr(err)
+					}
+					if moDevice != nil && len(moDevice.ManagedObjects) > 0 {
 						device = moDevice.ManagedObjects[0].ID
 					}
 				}
 
 				if IsID(device) {
-					return fmt.Sprintf("(type eq 'c8y_Service') and name eq '%s' and (bygroupid(%s))", s, device)
+					return fmt.Sprintf("(type eq 'c8y_Service') and name eq '%s' and (bygroupid(%s))", s, device), nil
 				}
-				return fmt.Sprintf("(type eq 'c8y_Service') and name eq '%s'", s)
+				return fmt.Sprintf("(type eq 'c8y_Service') and name eq '%s'", s), nil
 			},
 		},
 	}

--- a/pkg/c8yfetcher/firmwareFetcher.go
+++ b/pkg/c8yfetcher/firmwareFetcher.go
@@ -16,8 +16,8 @@ func NewFirmwareFetcher(factory *cmdutil.Factory) *FirmwareFetcher {
 			CumulocityFetcher: &CumulocityFetcher{
 				factory: factory,
 			},
-			Query: func(s string) string {
-				return fmt.Sprintf("(type eq 'c8y_Firmware') and name eq '%s'", s)
+			Query: func(s string) (string, error) {
+				return fmt.Sprintf("(type eq 'c8y_Firmware') and name eq '%s'", s), nil
 			},
 		},
 	}

--- a/pkg/c8yfetcher/firmwareVersionFetcher.go
+++ b/pkg/c8yfetcher/firmwareVersionFetcher.go
@@ -18,18 +18,25 @@ func NewFirmwareVersionFetcher(factory *cmdutil.Factory, firmware string, includ
 			CumulocityFetcher: &CumulocityFetcher{
 				factory: factory,
 			},
-			Query: func(s string) string {
+			Query: func(s string) (string, error) {
 				client, err := factory.Client()
 				if err != nil {
-					return ""
+					return "", err
 				}
-				var firmwareID string
+
+				// Use default value of a non-existent id so that the query does not return anything
+				// Use a default (non-existent) managed object to ensure the inventory
+				// query is still valid when the firmware is not found (for whatever reason)
+				firmwareID := "0"
 				if IsID(firmware) {
 					firmwareID = firmware
 				} else {
 					// Lookup firmware by name
 					res, _, err := client.Firmware.GetFirmwareByName(c8y.WithDisabledDryRunContext(context.Background()), firmware, c8y.NewPaginationOptions(5))
-					if err == nil && len(res.ManagedObjects) > 0 {
+					if err != nil {
+						return "", NewQueryBuildErr(err)
+					}
+					if len(res.ManagedObjects) > 0 {
 						firmwareID = res.ManagedObjects[0].ID
 					}
 				}
@@ -39,7 +46,7 @@ func NewFirmwareVersionFetcher(factory *cmdutil.Factory, firmware string, includ
 					patchFilter = "not(" + patchFilter + ")"
 				}
 
-				return fmt.Sprintf("(type eq 'c8y_FirmwareBinary') and %s and c8y_Firmware.version eq '%s' and (bygroupid(%s))", patchFilter, s, firmwareID)
+				return fmt.Sprintf("(type eq 'c8y_FirmwareBinary') and %s and c8y_Firmware.version eq '%s' and (bygroupid(%s))", patchFilter, s, firmwareID), nil
 			},
 		},
 	}

--- a/pkg/c8yfetcher/managedObjectFetcher.go
+++ b/pkg/c8yfetcher/managedObjectFetcher.go
@@ -2,12 +2,17 @@ package c8yfetcher
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 )
 
-type QueryFilter func(string) string
+func NewQueryBuildErr(err error) error {
+	return errors.Wrap(err, "Fetcher could not build a query")
+}
+
+type QueryFilter func(string) (string, error)
 
 type ManagedObjectFetcher struct {
 	Query QueryFilter
@@ -43,9 +48,13 @@ func (f *ManagedObjectFetcher) getByID(id string) ([]fetcherResultSet, error) {
 }
 
 func (f *ManagedObjectFetcher) getByName(name string) ([]fetcherResultSet, error) {
+	var err error
 	query := "name eq '" + name + "'"
 	if f.Query != nil {
-		query = f.Query(name)
+		query, err = f.Query(name)
+		if err != nil {
+			return nil, errors.Wrap(err, "Fetcher could not build a valid query")
+		}
 	}
 	mcol, _, err := f.Client().Inventory.GetManagedObjects(
 		c8y.WithDisabledDryRunContext(context.Background()),

--- a/pkg/c8yfetcher/softwareFetcher.go
+++ b/pkg/c8yfetcher/softwareFetcher.go
@@ -16,8 +16,8 @@ func NewSoftwareFetcher(factory *cmdutil.Factory) *SoftwareFetcher {
 			CumulocityFetcher: &CumulocityFetcher{
 				factory: factory,
 			},
-			Query: func(s string) string {
-				return fmt.Sprintf("(type eq 'c8y_Software') and name eq '%s'", s)
+			Query: func(s string) (string, error) {
+				return fmt.Sprintf("(type eq 'c8y_Software') and name eq '%s'", s), nil
 			},
 		},
 	}

--- a/pkg/c8yfetcher/softwareVersionFetcher.go
+++ b/pkg/c8yfetcher/softwareVersionFetcher.go
@@ -18,11 +18,11 @@ func NewSoftwareVersionFetcher(factory *cmdutil.Factory, software string) *Softw
 			CumulocityFetcher: &CumulocityFetcher{
 				factory: factory,
 			},
-			Query: func(s string) string {
+			Query: func(s string) (string, error) {
 				// Check
 				client, err := factory.Client()
 				if err != nil {
-					return ""
+					return "", err
 				}
 
 				if !IsID(software) {
@@ -30,15 +30,18 @@ func NewSoftwareVersionFetcher(factory *cmdutil.Factory, software string) *Softw
 					moSoftware, _, err := client.Software.GetSoftwareByName(c8y.WithDisabledDryRunContext(context.Background()), software, &c8y.PaginationOptions{
 						PageSize: 5,
 					})
-					if err == nil && moSoftware != nil && len(moSoftware.ManagedObjects) > 0 {
+					if err != nil {
+						return "", NewQueryBuildErr(err)
+					}
+					if moSoftware != nil && len(moSoftware.ManagedObjects) > 0 {
 						software = moSoftware.ManagedObjects[0].ID
 					}
 				}
 
 				if IsID(software) {
-					return fmt.Sprintf("(type eq 'c8y_SoftwareBinary') and not(has(c8y_Patch)) and c8y_Software.version eq '%s' and (bygroupid(%s))", s, software)
+					return fmt.Sprintf("(type eq 'c8y_SoftwareBinary') and not(has(c8y_Patch)) and c8y_Software.version eq '%s' and (bygroupid(%s))", s, software), nil
 				}
-				return fmt.Sprintf("(type eq 'c8y_SoftwareBinary') and not(has(c8y_Patch)) and c8y_Software.version eq '%s'", s)
+				return fmt.Sprintf("(type eq 'c8y_SoftwareBinary') and not(has(c8y_Patch)) and c8y_Software.version eq '%s'", s), nil
 			},
 		},
 	}

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -1060,10 +1060,8 @@ func (b *MapBuilder) MarshalJSONObject() (body []byte, err error) {
 		Logger.Debugf("body iterator. path=%s, value=%s", it.Path, value)
 
 		if itErr != nil {
-			if itErr == io.EOF {
-				err = itErr
-				return
-			}
+			err = itErr
+			return
 		} else {
 			switch extInput := input.(type) {
 			case []byte:


### PR DESCRIPTION
Ensure the any errors encountered by the fetcher are returned instead of being silently ignored.

Previously any fetcher errors were being ignored so it was difficult for users to debug.

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/424