### PR TITLE
feat(users): add shouldResetPassword flag to user create and update

### DIFF
--- a/api/spec/json/users.json
+++ b/api/spec/json/users.json
@@ -146,12 +146,12 @@
       "examples": {
         "powershell": [
           {
-            "description": "Create a user",
+            "description": "Create a user and force user to change their password when logging in",
             "beforeEach": [
               "$Username = \"testuser_\" + [guid]::NewGuid().Guid.Substring(1,10)",
               "$NewPassword = New-RandomPassword"
             ],
-            "command": "New-user -Username \"$Username\" -Email \"testuser@no-reply.dummy.com\" -Password \"$NewPassword\"",
+            "command": "New-user -Username \"$Username\" -Email \"testuser@no-reply.dummy.com\" -Password \"$NewPassword\" -ShouldResetPassword",
             "afterEach": [
               "Get-UserByName -Name \"$Username\" | Remove-User"
             ]
@@ -159,8 +159,8 @@
         ],
         "go": [
           {
-            "description": "Create a user",
-            "command": "c8y users create --userName \"testuser1\" --email \"testuser@no-reply.dummy.com\" --password \"a0)8k2kld9lm!\""
+            "description": "Create a user and force user to change their password when logging in",
+            "command": "c8y users create --userName \"testuser1\" --email \"testuser@no-reply.dummy.com\" --password 'a0)8k2kld9lm' --shouldResetPassword"
           },
           {
             "description": "Create a user using a template",
@@ -220,6 +220,12 @@
           "type": "string",
           "required": false,
           "description": "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed"
+        },
+        {
+          "name": "shouldResetPassword",
+          "type": "boolean",
+          "required": false,
+          "description": "User must reset password on next login"
         },
         {
           "name": "sendPasswordResetEmail",
@@ -471,6 +477,12 @@
           "type": "string",
           "required": false,
           "description": "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed"
+        },
+        {
+          "name": "shouldResetPassword",
+          "type": "boolean",
+          "required": false,
+          "description": "User must reset password on next login"
         },
         {
           "name": "sendPasswordResetEmail",

--- a/api/spec/yaml/users.yaml
+++ b/api/spec/yaml/users.yaml
@@ -110,16 +110,16 @@ commands:
         powershell: New-User
     examples:
       powershell:
-        - description: Create a user
+        - description: Create a user and force user to change their password when logging in
           beforeEach:
             - $Username = "testuser_" + [guid]::NewGuid().Guid.Substring(1,10)
             - $NewPassword = New-RandomPassword
-          command: New-user -Username "$Username" -Email "testuser@no-reply.dummy.com" -Password "$NewPassword"
+          command: New-user -Username "$Username" -Email "testuser@no-reply.dummy.com" -Password "$NewPassword" -ShouldResetPassword
           afterEach:
             - Get-UserByName -Name "$Username" | Remove-User
       go:
-        - description: Create a user
-          command: c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password "a0)8k2kld9lm!"
+        - description: Create a user and force user to change their password when logging in
+          command: c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password 'a0)8k2kld9lm' --shouldResetPassword
 
         - description: Create a user using a template
           command: |
@@ -168,6 +168,11 @@ commands:
         type: string
         required: false
         description: 'User password. Min: 6, max: 32 characters. Only Latin1 chars allowed'
+
+      - name: shouldResetPassword
+        type: boolean
+        required: false
+        description: User must reset password on next login
 
       # TODO: Only set value if it has changed!
       - name: sendPasswordResetEmail
@@ -352,6 +357,11 @@ commands:
         type: string
         required: false
         description: 'User password. Min: 6, max: 32 characters. Only Latin1 chars allowed'
+
+      - name: shouldResetPassword
+        type: boolean
+        required: false
+        description: User must reset password on next login
 
       # TODO: Only set value if it has changed!
       - name: sendPasswordResetEmail

--- a/pkg/cmd/users/create/create.auto.go
+++ b/pkg/cmd/users/create/create.auto.go
@@ -33,8 +33,8 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 		Short: "Create user",
 		Long:  `Create a new user so that they can access the tenant`,
 		Example: heredoc.Doc(`
-$ c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password "a0)8k2kld9lm!"
-Create a user
+$ c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password 'a0)8k2kld9lm' --shouldResetPassword
+Create a user and force user to change their password when logging in
 
 $ c8y users create --template "{email: 'test@me.com', userName: $.email, firstName: 'Peter'}" --sendPasswordResetEmail
 Create a user using a template
@@ -55,6 +55,7 @@ Create a user using a template
 	cmd.Flags().String("email", "", "User email address")
 	cmd.Flags().Bool("enabled", false, "User activation status (true/false)")
 	cmd.Flags().String("password", "", "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed")
+	cmd.Flags().Bool("shouldResetPassword", false, "User must reset password on next login")
 	cmd.Flags().Bool("sendPasswordResetEmail", false, "Send password reset email to the user instead of setting a password")
 	cmd.Flags().String("customProperties", "", "Custom properties to be added to the user")
 
@@ -157,6 +158,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("email", "email"),
 		flags.WithBoolValue("enabled", "enabled", ""),
 		flags.WithStringValue("password", "password"),
+		flags.WithBoolValue("shouldResetPassword", "shouldResetPassword", ""),
 		flags.WithBoolValue("sendPasswordResetEmail", "sendPasswordResetEmail", ""),
 		flags.WithDataValue("customProperties", "customProperties"),
 		cmdutil.WithTemplateValue(n.factory),

--- a/pkg/cmd/users/update/update.auto.go
+++ b/pkg/cmd/users/update/update.auto.go
@@ -53,6 +53,7 @@ Update a user
 	cmd.Flags().String("email", "", "User email address")
 	cmd.Flags().Bool("enabled", false, "User activation status (true/false)")
 	cmd.Flags().String("password", "", "User password. Min: 6, max: 32 characters. Only Latin1 chars allowed")
+	cmd.Flags().Bool("shouldResetPassword", false, "User must reset password on next login")
 	cmd.Flags().Bool("sendPasswordResetEmail", false, "Send password reset email to the user instead of setting a password")
 	cmd.Flags().String("customProperties", "", "Custom properties to be added to the user")
 
@@ -154,6 +155,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithStringValue("email", "email"),
 		flags.WithBoolValue("enabled", "enabled", ""),
 		flags.WithStringValue("password", "password"),
+		flags.WithBoolValue("shouldResetPassword", "shouldResetPassword", ""),
 		flags.WithBoolValue("sendPasswordResetEmail", "sendPasswordResetEmail", ""),
 		flags.WithDataValue("customProperties", "customProperties"),
 		cmdutil.WithTemplateValue(n.factory),

--- a/tests/auto/users/tests/users_create.yaml
+++ b/tests/auto/users/tests/users_create.yaml
@@ -1,11 +1,12 @@
 tests:
-    users_create_Create a user:
-        command: c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password "a0)8k2kld9lm!"
+    users_create_Create a user and force user to change their password when logging in:
+        command: c8y users create --userName "testuser1" --email "testuser@no-reply.dummy.com" --password 'a0)8k2kld9lm' --shouldResetPassword
         exit-code: 0
         stdout:
             json:
                 body.email: testuser@no-reply.dummy.com
-                body.password: a0)8k2kld9lm!
+                body.password: a0)8k2kld9lm
+                body.shouldResetPassword: "true"
                 body.userName: testuser1
                 method: POST
                 path: /user/$C8Y_TENANT/users

--- a/tools/PSc8y/Public/New-User.ps1
+++ b/tools/PSc8y/Public/New-User.ps1
@@ -11,9 +11,9 @@ Create a new user so that they can access the tenant
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/users_create
 
 .EXAMPLE
-PS> New-user -Username "$Username" -Email "testuser@no-reply.dummy.com" -Password "$NewPassword"
+PS> New-user -Username "$Username" -Email "testuser@no-reply.dummy.com" -Password "$NewPassword" -ShouldResetPassword
 
-Create a user
+Create a user and force user to change their password when logging in
 
 
 #>
@@ -57,6 +57,11 @@ Create a user
         [Parameter()]
         [string]
         $Password,
+
+        # User must reset password on next login
+        [Parameter()]
+        [switch]
+        $ShouldResetPassword,
 
         # Send password reset email to the user instead of setting a password
         [Parameter()]

--- a/tools/PSc8y/Public/Update-User.ps1
+++ b/tools/PSc8y/Public/Update-User.ps1
@@ -59,6 +59,11 @@ Update a user
         [string]
         $Password,
 
+        # User must reset password on next login
+        [Parameter()]
+        [switch]
+        $ShouldResetPassword,
+
         # Send password reset email to the user instead of setting a password
         [Parameter()]
         [ValidateSet('true','false')]

--- a/tools/PSc8y/Tests/New-User.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/New-User.auto.Tests.ps1
@@ -7,8 +7,8 @@ Describe -Name "New-User" {
 
     }
 
-    It "Create a user" {
-        $Response = PSc8y\New-user -Username "$Username" -Email "testuser@no-reply.dummy.com" -Password "$NewPassword"
+    It "Create a user and force user to change their password when logging in" {
+        $Response = PSc8y\New-user -Username "$Username" -Email "testuser@no-reply.dummy.com" -Password "$NewPassword" -ShouldResetPassword
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
New flag (`--shouldResetPassword`) to force a user to change their password on next login.

**Examples**

```sh
# Create a new user with a temp password, and force them to change it when logging in
c8y users create --userName myuser --email "myuser@cumulocity.com" --shouldResetPassword --password "<one_time_password>"

# force existing user to reset their password on next login
c8y users update --id myuser --shouldResetPassword
```