### PR TITLE
fix: remoteaccess connect ssh handling of empty port-forwarding options

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -193,7 +193,7 @@ tasks:
       - goreleaser build --clean --snapshot --single-target --id {{.OS_NAME}} {{.CLI_ARGS}}
       - rm -f .bin/c8y
       - mkdir -p .bin
-      - cp dist/{{.OS_NAME}}_{{OS}}_{{.ARCH_NAME}}/bin/c8y .bin/c8y
+      - cp dist/{{.OS_NAME}}_{{OS}}_{{.ARCH_NAME}}*/bin/c8y .bin/c8y
 
   generate:
     desc: Generate the cli code

--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -107,6 +107,11 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 func (n *CmdSSH) GetPortForwarding() string {
 	// convenience functions to mirror docker port mapping options
 	portMapping := n.portForwarding
+
+	if portMapping == "" {
+		return portMapping
+	}
+
 	portForwardingParts := strings.Split(portMapping, ":")
 	switch len(portForwardingParts) {
 	case 1:


### PR DESCRIPTION
Fixing a bug where the remoteaccess port-forwarding option was not ignore empty values (which is the default) and it was resulting in an invalid ssh command.

This resulted in the following command failing as shown below:

```sh
$ c8y remoteaccess connect ssh --device rpi5-abcdef --user pi

2025-01-29T09:27:02.994+0100	INFO	Executing command: ssh -o ServerAliveInterval=120 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 59380 root@127.0.0.1 -L :127.0.0.1:

Starting interactive ssh session with 5733465816 (https://myiot.example.cumulocity.com) with port-forwarding :127.0.0.1:

Bad local forwarding specification ':127.0.0.1:'
Duration: 26m
```