### PR TITLE
docs: fix the reference to the build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-c8y-cli
 
-![build](https://github.com/reubenmiller/go-c8y-cli/workflows/build/badge.svg)
+[![build](https://github.com/reubenmiller/go-c8y-cli/actions/workflows/main.yml/badge.svg?branch=v2)](https://github.com/reubenmiller/go-c8y-cli/actions/workflows/main.yml)
 
 <p align="center">
     <img width="1000" src="demo.svg">


### PR DESCRIPTION
Only show the build status from the default branch `v2`.