### PR TITLE
feat(deviceregistration): support security tokens, group assignment and templates

### DIFF
--- a/api/spec/json/deviceCredentials.json
+++ b/api/spec/json/deviceCredentials.json
@@ -101,12 +101,28 @@
             "afterEach": [
               "Remove-DeviceRequest -Id \"ASDF098SD1J10912UD92JDLCNCU8\""
             ]
+          },
+          {
+            "description": "Register a new device",
+            "command": "Register-Device -Id \"ASDF098SD1J10912UD92JDLCNCU8\" -Group \"My Group\"",
+            "skipTest": true
           }
         ],
         "go": [
           {
             "description": "Register a new device",
             "command": "c8y deviceregistration register --id \"ASDF098SD1J10912UD92JDLCNCU8\""
+          },
+          {
+            "description": "Register a new device and assign to a group",
+            "command": "c8y deviceregistration register --id \"ASDF098SD1J10912UD92JDLCNCU8\" --group \"My Group\"",
+            "assertStdOut": {
+              "json": {
+                "path": "/devicecontrol/newDeviceRequests",
+                "body.id": "ASDF098SD1J10912UD92JDLCNCU8",
+                "body.groupId": "r/^\\d+$"
+              }
+            }
           }
         ]
       },
@@ -117,6 +133,22 @@
           "required": true,
           "pipeline": true,
           "description": "Device identifier. Max: 1000 characters. E.g. IMEI"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "description": "Type of the device"
+        },
+        {
+          "name": "group",
+          "property": "groupId",
+          "type": "devicegroup[]",
+          "description": "Group to which the device will be assigned"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties"
         }
       ]
     },
@@ -144,12 +176,21 @@
             "afterEach": [
               "Remove-DeviceRequest -Id $DeviceRequest.id"
             ]
+          },
+          {
+            "description": "Approve a new device request and provide a security token",
+            "skipTest": true,
+            "command": "Approve-DeviceRequest -Id $DeviceRequest.id -SecurityToken \"abcdef123456\""
           }
         ],
         "go": [
           {
             "description": "Approve a new device request",
             "command": "c8y deviceregistration approve --id \"1234010101s01ldk208\""
+          },
+          {
+            "description": "Approve a new device request and provide a security token",
+            "command": "c8y deviceregistration approve --id \"1234010101s01ldk208\" --securityToken \"abcdef123456\""
           }
         ]
       },
@@ -172,6 +213,16 @@
           "validationSet": [
             "ACCEPTED"
           ]
+        },
+        {
+          "name": "securityToken",
+          "type": "string",
+          "description": "When accepting a device request, the security token is verified against the token submitted by the device when requesting credentials"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties"
         }
       ],
       "bodyTemplates": [
@@ -228,6 +279,7 @@
       "descriptionLong": "Device credentials can be enquired by devices that do not have credentials for accessing a tenant yet. Since the device does not have credentials yet, a set of fixed credentials is used for this API. The credentials can be obtained by contacting support. Do not use your tenant credentials with this API.",
       "path": "devicecontrol/deviceCredentials",
       "accept": "application/vnd.com.nsn.cumulocity.deviceCredentials+json",
+      "semanticMethod": "GET",
       "alias": {
         "go": "getCredentials",
         "powershell": "Request-DeviceCredentials"
@@ -257,6 +309,11 @@
           "required": true,
           "pipeline": true,
           "description": "Device identifier. Max: 1000 characters. E.g. IMEI"
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties"
         }
       ]
     }

--- a/api/spec/yaml/deviceCredentials.yaml
+++ b/api/spec/yaml/deviceCredentials.yaml
@@ -78,15 +78,40 @@ commands:
           afterEach:
             - Remove-DeviceRequest -Id "ASDF098SD1J10912UD92JDLCNCU8"
 
+        - description: Register a new device
+          command: Register-Device -Id "ASDF098SD1J10912UD92JDLCNCU8" -Group "My Group"
+          skipTest: true
+
       go:
         - description: Register a new device
           command: c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8"
+        
+        - description: Register a new device and assign to a group
+          command: c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8" --group "My Group"
+          assertStdOut:
+            json:
+              path: /devicecontrol/newDeviceRequests
+              body.id: ASDF098SD1J10912UD92JDLCNCU8
+              body.groupId: r/^\d+$
     body:
       - name: id
         type: id[]
         required: true
         pipeline: true
         description: 'Device identifier. Max: 1000 characters. E.g. IMEI'
+
+      - name: type
+        type: string
+        description: Type of the device
+
+      - name: group
+        property: groupId
+        type: devicegroup[]
+        description: Group to which the device will be assigned
+
+      - name: data
+        type: json
+        description: Additional properties
 
   - name: approveNewDeviceRequest
     method: PUT
@@ -107,10 +132,18 @@ commands:
           command: Approve-DeviceRequest -Id $DeviceRequest.id
           afterEach:
             - Remove-DeviceRequest -Id $DeviceRequest.id
+        
+        - description: Approve a new device request and provide a security token
+          skipTest: true    # todo: requests usage of the device bootstrap user
+          command: Approve-DeviceRequest -Id $DeviceRequest.id -SecurityToken "abcdef123456"
 
       go:
         - description: Approve a new device request
           command: c8y deviceregistration approve --id "1234010101s01ldk208"
+
+        - description: Approve a new device request and provide a security token
+          command: c8y deviceregistration approve --id "1234010101s01ldk208" --securityToken "abcdef123456"
+
     pathParameters:
       - name: id
         type: devicerequest[]
@@ -124,6 +157,14 @@ commands:
         description: 'Status of registration'
         default: ""
         validationSet: [ACCEPTED]
+
+      - name: securityToken
+        type: string
+        description: When accepting a device request, the security token is verified against the token submitted by the device when requesting credentials
+
+      - name: data
+        type: json
+        description: Additional properties
     bodyTemplates:
       - type: jsonnet
         applyLast: false
@@ -163,6 +204,7 @@ commands:
     descriptionLong: 'Device credentials can be enquired by devices that do not have credentials for accessing a tenant yet. Since the device does not have credentials yet, a set of fixed credentials is used for this API. The credentials can be obtained by contacting support. Do not use your tenant credentials with this API.'
     path: devicecontrol/deviceCredentials
     accept: application/vnd.com.nsn.cumulocity.deviceCredentials+json
+    semanticMethod: GET
     alias:
         go: getCredentials
         powershell: Request-DeviceCredentials
@@ -183,3 +225,7 @@ commands:
         required: true
         pipeline: true
         description: 'Device identifier. Max: 1000 characters. E.g. IMEI'
+
+      - name: data
+        type: json
+        description: Additional properties

--- a/pkg/cmd/deviceregistration/approve/approve.auto.go
+++ b/pkg/cmd/deviceregistration/approve/approve.auto.go
@@ -36,6 +36,9 @@ func NewApproveCmd(f *cmdutil.Factory) *ApproveCmd {
 		Example: heredoc.Doc(`
 $ c8y deviceregistration approve --id "1234010101s01ldk208"
 Approve a new device request
+
+$ c8y deviceregistration approve --id "1234010101s01ldk208" --securityToken "abcdef123456"
+Approve a new device request and provide a security token
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.UpdateModeEnabled()
@@ -47,6 +50,7 @@ Approve a new device request
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device identifier (required) (accepts pipeline)")
 	cmd.Flags().String("status", "", "Status of registration")
+	cmd.Flags().String("securityToken", "", "When accepting a device request, the security token is verified against the token submitted by the device when requesting credentials")
 
 	completion.WithOptions(
 		cmd,
@@ -57,7 +61,8 @@ Approve a new device request
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true),
 	)
 
@@ -138,6 +143,7 @@ func (n *ApproveCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("status", "status"),
+		flags.WithStringValue("securityToken", "securityToken"),
 		flags.WithDefaultTemplateString(`
 {status: 'ACCEPTED'}`),
 		cmdutil.WithTemplateValue(n.factory),

--- a/pkg/cmd/deviceregistration/getcredentials/getCredentials.auto.go
+++ b/pkg/cmd/deviceregistration/getcredentials/getCredentials.auto.go
@@ -38,7 +38,7 @@ $ c8y deviceregistration getCredentials --id "device-AD76-matrixer"
 Request credentials for a new device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return nil
 		},
 		RunE: ccmd.RunE,
 	}
@@ -55,8 +55,11 @@ Request credentials for a new device
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true),
+
+		flags.WithSemanticMethod("GET"),
 	)
 
 	// Required flags

--- a/pkg/cmd/deviceregistration/register/register.auto.go
+++ b/pkg/cmd/deviceregistration/register/register.auto.go
@@ -36,6 +36,9 @@ func NewRegisterCmd(f *cmdutil.Factory) *RegisterCmd {
 		Example: heredoc.Doc(`
 $ c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8"
 Register a new device
+
+$ c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8" --group "My Group"
+Register a new device and assign to a group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled()
@@ -46,16 +49,21 @@ Register a new device
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("id", []string{""}, "Device identifier. Max: 1000 characters. E.g. IMEI (required) (accepts pipeline)")
+	cmd.Flags().String("type", "", "Type of the device")
+	cmd.Flags().StringSlice("group", []string{""}, "Group to which the device will be assigned")
 
 	completion.WithOptions(
 		cmd,
+		completion.WithDeviceGroup("group", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithPipelineAliases("group", "source.id", "managedObject.id", "id"),
 	)
 
 	// Required flags
@@ -135,6 +143,8 @@ func (n *RegisterCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithDataFlagValue(),
 		c8yfetcher.WithIDSlice(args, "id", "id"),
+		flags.WithStringValue("type", "type"),
+		c8yfetcher.WithDeviceGroupByNameFirstMatch(n.factory, args, "group", "groupId"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
 	)

--- a/tests/auto/devicecredentials/tests/deviceregistration_approve.yaml
+++ b/tests/auto/devicecredentials/tests/deviceregistration_approve.yaml
@@ -6,3 +6,11 @@ tests:
             json:
                 method: PUT
                 path: /devicecontrol/newDeviceRequests/1234010101s01ldk208
+    deviceregistration_approve_Approve a new device request and provide a security token:
+        command: c8y deviceregistration approve --id "1234010101s01ldk208" --securityToken "abcdef123456"
+        exit-code: 0
+        stdout:
+            json:
+                body.securityToken: abcdef123456
+                method: PUT
+                path: /devicecontrol/newDeviceRequests/1234010101s01ldk208

--- a/tests/auto/devicecredentials/tests/deviceregistration_register.yaml
+++ b/tests/auto/devicecredentials/tests/deviceregistration_register.yaml
@@ -7,3 +7,12 @@ tests:
                 body.id: ASDF098SD1J10912UD92JDLCNCU8
                 method: POST
                 path: /devicecontrol/newDeviceRequests
+    deviceregistration_register_Register a new device and assign to a group:
+        command: c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8" --group "My Group"
+        exit-code: 0
+        stdout:
+            json:
+                body.groupId: r/^\d+$
+                body.id: ASDF098SD1J10912UD92JDLCNCU8
+                method: POST
+                path: /devicecontrol/newDeviceRequests

--- a/tools/PSc8y/Public/Approve-DeviceRequest.ps1
+++ b/tools/PSc8y/Public/Approve-DeviceRequest.ps1
@@ -15,6 +15,11 @@ PS> Approve-DeviceRequest -Id $DeviceRequest.id
 
 Approve a new device request
 
+.EXAMPLE
+PS> Approve-DeviceRequest -Id $DeviceRequest.id -SecurityToken "abcdef123456"
+
+Approve a new device request and provide a security token
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,
@@ -33,7 +38,12 @@ Approve a new device request
         [Parameter()]
         [ValidateSet('ACCEPTED')]
         [string]
-        $Status
+        $Status,
+
+        # When accepting a device request, the security token is verified against the token submitted by the device when requesting credentials
+        [Parameter()]
+        [string]
+        $SecurityToken
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Update", "Template"

--- a/tools/PSc8y/Public/Register-Device.ps1
+++ b/tools/PSc8y/Public/Register-Device.ps1
@@ -15,6 +15,11 @@ PS> Register-Device -Id "ASDF098SD1J10912UD92JDLCNCU8"
 
 Register a new device
 
+.EXAMPLE
+PS> Register-Device -Id "ASDF098SD1J10912UD92JDLCNCU8" -Group "My Group"
+
+Register a new device
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,
@@ -27,7 +32,17 @@ Register a new device
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Type of the device
+        [Parameter()]
+        [string]
+        $Type,
+
+        # Group to which the device will be assigned
+        [Parameter()]
+        [object[]]
+        $Group
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Create", "Template"

--- a/tools/PSc8y/Tests/Approve-DeviceRequest.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Approve-DeviceRequest.auto.Tests.ps1
@@ -13,6 +13,12 @@ Describe -Name "Approve-DeviceRequest" {
         $Response | Should -Not -BeNullOrEmpty
     }
 
+    It -Skip "Approve a new device request and provide a security token" {
+        $Response = PSc8y\Approve-DeviceRequest -Id $DeviceRequest.id -SecurityToken "abcdef123456"
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
 
     AfterEach {
         Remove-DeviceRequest -Id $DeviceRequest.id

--- a/tools/PSc8y/Tests/Register-Device.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Register-Device.auto.Tests.ps1
@@ -5,8 +5,14 @@ Describe -Name "Register-Device" {
 
     }
 
-    It "Register a new device" {
+    It -Skip "Register a new device" {
         $Response = PSc8y\Register-Device -Id "ASDF098SD1J10912UD92JDLCNCU8"
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It -Skip "Register a new device" {
+        $Response = PSc8y\Register-Device -Id "ASDF098SD1J10912UD92JDLCNCU8" -Group "My Group"
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
Improvements/updates to the `c8y deviceregistration` commands

* `register` - Add `--type` and `--group` flags. The `group` flag can be used to assign a device to an existing group.
* `approve` - Add support for `--securityToken` flag and `--template` and `--data` flags
* `getCredentials` - No longer prompts for confirmation as it is more similar to a `GET` command (eventhough it is technically doing a `POST` under the hood)

**Examples**

```sh
# Register a device and assign it to a group
c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8" --group "Germany"

# Approve a device request with matching securityToken
c8y deviceregistration approve --id "1234010101s01ldk208" --securityToken "abcdef123456"
```

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/430