### PR TITLE
fix(data): add user hint to use template flag when unsupported json array is detected

### DIFF
--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -974,7 +974,12 @@ func WithDataValueAdvanced(stripCumulocityKeys bool, raw bool, opts ...string) G
 
 		// Merge multiple data objects together
 		for _, value := range values {
-			err = jsonUtilities.ParseJSON(resolveContents(value), data)
+			v := resolveContents(value)
+			// data flag does not yet support arrays
+			if jsonUtilities.IsValidJSON([]byte(v)) && jsonUtilities.IsJSONArray([]byte(v)) {
+				return dst, "", fmt.Errorf("invalid data type (array) provided on the '%s' flag. Currently only key/value or json objects are supported. Hint: Try using the 'template' flag instead", src)
+			}
+			err = jsonUtilities.ParseJSON(v, data)
 			if err != nil {
 				return dst, "", fmt.Errorf("json error: %s parameter does not contain valid json or shorthand json. %w", src, err)
 			}


### PR DESCRIPTION
Since the `--data` flag currently does not support providing json arrays, provide a useful hint to users that they can just use the `--template` flag instead.

Below shows the error/hint shown to users.

```sh
$ c8y inventory create --data '["one"]' --dry

2025-02-16T19:58:58.857+0100    ERROR   commandError: invalid data type (array) provided on the 'data' flag. Currently only key/value or json objects are supported. Hint: Try using the 'template' flag instead
```

The above command can then be simply rewritten by replace `--data` with `--template`:

```sh
c8y inventory create --template '["one"]' --dry
```

Related to https://github.com/reubenmiller/go-c8y-cli/issues/432
