### PR TITLE
fix: suppress warning message when displaying help

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -194,7 +195,9 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 			if cmdErr != nil {
 				logg, logErr := f.Logger()
 				if logg != nil && logErr == nil {
-					logg.Warnf("Check existing session failed. %s", cmdErr)
+					if !errors.Is(cmderrors.ErrHelp, cmdErr) {
+						logg.Warnf("Check existing session failed. %s", cmdErr)
+					}
 				}
 			}
 			return cmdErr


### PR DESCRIPTION
Suppress a warning which was accidentally displayed when showing help related text output (e.g. `--help` or `--examples`)

Below shows an example of the warning which has now been removed.

```sh
$ c8y devices list --examples

2025-02-16T22:07:34.559+0100	WARN	Check existing session failed. help text: this is not an error
```