### PR TITLE
fix(ui plugin): rename --tags to --tag

### DIFF
--- a/api/spec/json/uiPluginsVersions.json
+++ b/api/spec/json/uiPluginsVersions.json
@@ -189,10 +189,21 @@
           "name": "tags",
           "property": "tags",
           "type": "string[]",
+          "deprecatedAt": "2025-02-17",
+          "deprecated": true,
+          "deprecationNotice": "please use 'tag' instead",
           "options": {
             "formData": "applicationVersion"
           },
-          "required": true,
+          "description": "List of tags associated to the version"
+        },
+        {
+          "name": "tag",
+          "property": "tags",
+          "type": "string[]",
+          "options": {
+            "formData": "applicationVersion"
+          },
           "description": "List of tags associated to the version"
         },
         {
@@ -200,6 +211,9 @@
           "type": "json_custom",
           "description": "data"
         }
+      ],
+      "bodyRequiredKeys": [
+        "tags"
       ]
     },
     {
@@ -290,14 +304,14 @@
         "powershell": [
           {
             "description": "Replace tags assigned to a version of a plugin",
-            "command": "Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tags tag1,latest",
+            "command": "Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tag tag1,latest",
             "skipTest": true
           }
         ],
         "go": [
           {
             "description": "Replace tags assigned to a version of a plugin",
-            "command": "c8y ui plugins versions update --plugin 1234 --version 1.0 --tags tag1,latest",
+            "command": "c8y ui plugins versions update --plugin 1234 --version 1.0 --tag tag1,latest",
             "assertStdOut": {
               "json": {
                 "path": "/application/applications/1234/versions/1.0",
@@ -333,6 +347,15 @@
           "name": "tags",
           "property": "tags",
           "type": "string[]",
+          "deprecatedAt": "2025-02-17",
+          "deprecated": true,
+          "deprecationNotice": "please use 'tag' instead",
+          "description": "Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions"
+        },
+        {
+          "name": "tag",
+          "property": "tags",
+          "type": "string[]",
           "description": "Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions"
         },
         {
@@ -340,6 +363,9 @@
           "type": "json",
           "description": "Custom data"
         }
+      ],
+      "bodyRequiredKeys": [
+        "tags"
       ]
     }
   ]

--- a/api/spec/schema.json
+++ b/api/spec/schema.json
@@ -157,6 +157,16 @@
       "title": "Is Hidden",
       "description": "The parameter should be hidden from docs and completions but is still parsed. This is used to deprecate a flag without breaking existing scripts"
     },
+    "deprecatedParameter": {
+      "type": "boolean",
+      "title": "Is Deprecated",
+      "description": "The parameter should be hidden from docs and completions but is still parsed. This is used to deprecate a flag without breaking existing scripts"
+    },
+    "deprecationNoticeParameter": {
+      "type": "string",
+      "title": "Deprecation notice",
+      "description": "Add information that will be presented to the user"
+    },
     "defaultValue": {
       "type": "string",
       "title": "Default value",
@@ -587,6 +597,12 @@
                 "hidden": {
                   "$ref": "#/definitions/hiddenParameter"
                 },
+                "deprecated": {
+                  "$ref": "#/definitions/deprecatedParameter"
+                },
+                "deprecationNotice": {
+                  "$ref": "#/definitions/deprecationNoticeParameter"
+                },
                 "position": {
                   "$ref": "#/definitions/argumentPosition"
                 },
@@ -640,6 +656,12 @@
                 },
                 "hidden": {
                   "$ref": "#/definitions/hiddenParameter"
+                },
+                "deprecated": {
+                  "$ref": "#/definitions/deprecatedParameter"
+                },
+                "deprecationNotice": {
+                  "$ref": "#/definitions/deprecationNoticeParameter"
                 },
                 "position": {
                   "$ref": "#/definitions/argumentPosition"
@@ -769,6 +791,12 @@
                 },
                 "hidden": {
                   "$ref": "#/definitions/hiddenParameter"
+                },
+                "deprecated": {
+                  "$ref": "#/definitions/deprecatedParameter"
+                },
+                "deprecationNotice": {
+                  "$ref": "#/definitions/deprecationNoticeParameter"
                 },
                 "default": {
                   "$ref": "#/definitions/defaultValue"

--- a/api/spec/yaml/uiPluginsVersions.yaml
+++ b/api/spec/yaml/uiPluginsVersions.yaml
@@ -142,14 +142,27 @@ commands:
       - name: tags
         property: tags
         type: string[]
+        # Renamed from tags to tag to be more consistent
+        deprecatedAt: "2025-02-17"
+        deprecated: true
+        deprecationNotice: please use 'tag' instead
         options:
           formData: applicationVersion
-        required: true
+        description: List of tags associated to the version
+
+      - name: tag
+        property: tags
+        type: string[]
+        options:
+          formData: applicationVersion
         description: List of tags associated to the version
 
       - name: data
         type: json_custom
         description: data
+
+    bodyRequiredKeys:
+      - tags
 
   - name: delete
     description: Delete a specific version of a plugin
@@ -215,12 +228,12 @@ commands:
     examples:
       powershell:
         - description: Replace tags assigned to a version of a plugin
-          command: Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tags tag1,latest
+          command: Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tag tag1,latest
           skipTest: true
 
       go:
         - description: Replace tags assigned to a version of a plugin
-          command: c8y ui plugins versions update --plugin 1234 --version 1.0 --tags tag1,latest
+          command: c8y ui plugins versions update --plugin 1234 --version 1.0 --tag tag1,latest
           assertStdOut:
             json:
               path: /application/applications/1234/versions/1.0
@@ -246,8 +259,20 @@ commands:
       - name: tags
         property: tags
         type: string[]
+        # Renamed from tags to tag to be more consistent
+        deprecatedAt: "2025-02-17"
+        deprecated: true
+        deprecationNotice: please use 'tag' instead
+        description: Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions
+
+      - name: tag
+        property: tags
+        type: string[]
         description: Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions
 
       - name: data
         type: json
         description: Custom data
+
+    bodyRequiredKeys:
+      - tags

--- a/docs/go-c8y-cli/docs/examples/ui_plugins.md
+++ b/docs/go-c8y-cli/docs/examples/ui_plugins.md
@@ -14,7 +14,7 @@ The `c8y ui plugins create` command is a "smart" command which will perform all 
 <CodeExample transform="false">
 
 ```bash
-c8y ui plugins create --file ./my_plugin.zip --tags latest
+c8y ui plugins create --file ./my_plugin.zip --tag latest
 ```
 
 </CodeExample>
@@ -24,7 +24,7 @@ Alternatively, you can install a plugin directly from a URL (provided the URL do
 <CodeExample transform="false">
 
 ```bash
-c8y ui plugins create --file "https://github.com/thin-edge/tedge-container-plugin/releases/download/1.2.3/tedge-container-plugin-ui_1.0.2.zip" --tags latest
+c8y ui plugins create --file "https://github.com/thin-edge/tedge-container-plugin/releases/download/1.2.3/tedge-container-plugin-ui_1.0.2.zip" --tag latest
 ```
 
 </CodeExample>
@@ -36,7 +36,7 @@ For example, you can provide a manual plugin name and version using:
 <CodeExample transform="false">
 
 ```bash
-c8y ui plugins create --file ./my_plugin.zip --name custom_name --version 1.0.0 --tags latest
+c8y ui plugins create --file ./my_plugin.zip --name custom_name --version 1.0.0 --tag latest
 ```
 
 </CodeExample>
@@ -72,7 +72,7 @@ For example the `latest` and `other` tags
 <CodeExample transform="false">
 
 ```bash
-c8y ui plugins versions update --plugin myplugin --version "1.0.0" --tags latest,other
+c8y ui plugins versions update --plugin myplugin --version "1.0.0" --tag latest,other
 ```
 
 </CodeExample>

--- a/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
@@ -68,6 +68,8 @@ Delete measurement collection for a device
 
 	// Required flags
 
+	flags.MarkDeprecated(cmd, "fragmentType", "")
+
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
 	return ccmd

--- a/pkg/cmd/measurements/list/list.auto.go
+++ b/pkg/cmd/measurements/list/list.auto.go
@@ -79,6 +79,8 @@ Get a list of measurements
 
 	// Required flags
 
+	flags.MarkDeprecated(cmd, "fragmentType", "")
+
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
 	return ccmd

--- a/pkg/cmd/ui/plugins/create/create.manual.go
+++ b/pkg/cmd/ui/plugins/create/create.manual.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -83,6 +84,7 @@ func NewCmdCreate(f *cmdutil.Factory) *CmdCreate {
 	cmd.Flags().StringVar(&ccmd.contextPath, "contextPath", "", "contextPath of the hosted application. Required when application type is HOSTED")
 	cmd.Flags().StringVar(&ccmd.resourceURL, "resourcesUrl", "", "URL to application base directory hosted on an external server. Required when application type is HOSTED")
 	cmd.Flags().StringSliceVar(&ccmd.tags, "tags", []string{}, "Tags. Include 'latest' to change the activeVersionId of the application")
+	cmd.Flags().StringSliceVar(&ccmd.tags, "tag", []string{}, "Tags. Include 'latest' to change the activeVersionId of the application")
 
 	completion.WithOptions(
 		cmd,
@@ -94,6 +96,7 @@ func NewCmdCreate(f *cmdutil.Factory) *CmdCreate {
 		flags.WithProcessingMode(),
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
+		flags.MarkRenamed("tags", "tag"),
 	)
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("file")
@@ -114,8 +117,9 @@ func (n *CmdCreate) getApplicationDetails(client *c8y.Client, log *logger.Logger
 	}
 
 	// Check if it is really a plugin!
-	if app.ManifestFile.Package != "plugin" {
-		return nil, fmt.Errorf("invalid file. The given file is not a UI plugin (e.g. the manifest.package != 'plugin'). file=%s", n.file)
+	allowedTypes := []string{"plugin", "blueprint"}
+	if !slices.Contains(allowedTypes, strings.ToLower(app.ManifestFile.Package)) {
+		return nil, fmt.Errorf("invalid file. The given file is not a UI plugin or blueprint (e.g. the manifest.package is not one of [%v]). file=%s", allowedTypes, n.file)
 	}
 
 	// Set application name using the following preferences (first match wins)

--- a/pkg/cmd/ui/plugins/versions/create/create.auto.go
+++ b/pkg/cmd/ui/plugins/versions/create/create.auto.go
@@ -48,7 +48,8 @@ Create a new version for a plugin
 	cmd.Flags().String("plugin", "", "Plugin (accepts pipeline)")
 	cmd.Flags().String("file", "", "The ZIP file to be uploaded")
 	cmd.Flags().String("version", "", "Plugin version (required)")
-	cmd.Flags().StringSlice("tags", []string{""}, "List of tags associated to the version (required)")
+	cmd.Flags().StringSlice("tags", []string{""}, "List of tags associated to the version")
+	cmd.Flags().StringSlice("tag", []string{""}, "List of tags associated to the version")
 	cmd.Flags().String("data", "", "data")
 
 	completion.WithOptions(
@@ -68,7 +69,8 @@ Create a new version for a plugin
 
 	// Required flags
 	_ = cmd.MarkFlagRequired("version")
-	_ = cmd.MarkFlagRequired("tags")
+
+	flags.MarkDeprecated(cmd, "tags", "please use 'tag' instead")
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
@@ -137,6 +139,8 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 			Append(flags.WithStringValue("version", "version")).
 			Append(flags.WithFormDataProperty("applicationVersion")).
 			Append(flags.WithStringSliceValues("tags", "tags", "")).
+			Append(flags.WithFormDataProperty("applicationVersion")).
+			Append(flags.WithStringSliceValues("tag", "tags", "")).
 			Append(flags.WithDataValue("data", "data")).
 			Append(cmdutil.WithTemplateValue(n.factory)).
 			Append(flags.WithTemplateVariablesValue()).
@@ -152,6 +156,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		cmd,
 		body,
 		inputIterators,
+		flags.WithRequiredProperties("tags"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/ui/plugins/versions/update/update.auto.go
+++ b/pkg/cmd/ui/plugins/versions/update/update.auto.go
@@ -34,7 +34,7 @@ func NewUpdateCmd(f *cmdutil.Factory) *UpdateCmd {
 		Short: "Replace tags related to a plugin version",
 		Long:  `Replaces the tags of a given plugin version in your tenant`,
 		Example: heredoc.Doc(`
-$ c8y ui plugins versions update --plugin 1234 --version 1.0 --tags tag1,latest
+$ c8y ui plugins versions update --plugin 1234 --version 1.0 --tag tag1,latest
 Replace tags assigned to a version of a plugin
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -48,6 +48,7 @@ Replace tags assigned to a version of a plugin
 	cmd.Flags().String("plugin", "", "Plugin (accepts pipeline)")
 	cmd.Flags().String("version", "", "Version")
 	cmd.Flags().StringSlice("tags", []string{""}, "Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions")
+	cmd.Flags().StringSlice("tag", []string{""}, "Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions")
 
 	completion.WithOptions(
 		cmd,
@@ -68,6 +69,8 @@ Replace tags assigned to a version of a plugin
 	)
 
 	// Required flags
+
+	flags.MarkDeprecated(cmd, "tags", "please use 'tag' instead")
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
@@ -145,8 +148,10 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithDataFlagValue(),
 		flags.WithStringSliceValues("tags", "tags", ""),
+		flags.WithStringSliceValues("tag", "tags", ""),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
+		flags.WithRequiredProperties("tags"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/flags/rename.go
+++ b/pkg/flags/rename.go
@@ -1,0 +1,21 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func MarkRenamed(previous, current string) Option {
+	return func(cmd *cobra.Command) *cobra.Command {
+		cmd.Flags().MarkDeprecated(previous, fmt.Sprintf("please use --%s instead", current))
+		return cmd
+	}
+}
+
+func MarkDeprecated(cmd *cobra.Command, name string, notice string) {
+	if notice == "" {
+		notice = "please remove it"
+	}
+	_ = cmd.Flags().MarkDeprecated(name, notice)
+}

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -232,6 +232,8 @@
             Default = $iArg.default
             Required = $iArg.required
             Hidden = $iArg.hidden
+            Deprecated = $iArg.deprecated
+            DeprecationNotice = $iArg.deprecationNotice
             Pipeline = $iArg.pipeline
         }
         $CurrentArg = Get-C8yGoArgs @ArgParams
@@ -663,6 +665,7 @@ $($Examples -join "`n`n")
     // Required flags
     $($CommandArgs.Required -join "`n	")
     $($CommandArgs.Hidden -join "`n	")
+    $($CommandArgs.Deprecated -join "`n	")
 
     ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
@@ -894,6 +897,10 @@ Function Get-C8yGoArgs {
         [string] $Required,
 
         [string] $Hidden,
+
+        [string] $Deprecated,
+
+        [string] $DeprecationNotice,
 
         [string] $OptionName,
 
@@ -1439,6 +1446,10 @@ Function Get-C8yGoArgs {
 
     if ($Hidden -match "true|yes" -and $Pipeline -notmatch "true") {
         $Entry | Add-Member -MemberType NoteProperty -Name "Hidden" -Value "_ = cmd.Flags().MarkHidden(`"${Name}`")"
+    }
+
+    if ($Deprecated -match "true|yes") {
+        $Entry | Add-Member -MemberType NoteProperty -Name "Deprecated" -Value "flags.MarkDeprecated(cmd, `"${Name}`", `"${DeprecationNotice}`")"
     }
 
     $Entry.Name = $Name

--- a/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
+++ b/scripts/build-powershell/New-C8yApiPowershellCommand.ps1
@@ -189,6 +189,10 @@
             Required = $iArg.required
             ReadFromPipeline = $ReadFromPipeline
         }
+        if ($iArg.deprecated) {
+            Write-Warning "Skipping deprecated argument: $($item.Name)"
+            continue
+        }
         $item = New-C8yPowershellArguments @ArgParams
 
         if ($item.ignore) {

--- a/tests/auto/uipluginsversions/tests/ui/plugins/versions_update.yaml
+++ b/tests/auto/uipluginsversions/tests/ui/plugins/versions_update.yaml
@@ -1,6 +1,6 @@
 tests:
     ui/plugins/versions_update_Replace tags assigned to a version of a plugin:
-        command: c8y ui plugins versions update --plugin 1234 --version 1.0 --tags tag1,latest
+        command: c8y ui plugins versions update --plugin 1234 --version 1.0 --tag tag1,latest
         exit-code: 0
         stdout:
             json:

--- a/tests/manual/ui/applications/plugins/crud.sh
+++ b/tests/manual/ui/applications/plugins/crud.sh
@@ -57,7 +57,7 @@ c8y applications create --name "$NAME" --type HOSTED --template "{key: $.name + 
 #
 # Create a custom dummy with two versions
 #
-c8y ui plugins create --name "$PLUGIN_NAME" --file "$PLUGIN_VERSION1_URL" --version "1.0.1" --tags latest
+c8y ui plugins create --name "$PLUGIN_NAME" --file "$PLUGIN_VERSION1_URL" --version "1.0.1" --tag latest
 c8y ui plugins create --name "$PLUGIN_NAME" --file "$PLUGIN_VERSION2_URL" --version "1.0.2"
 
 
@@ -128,7 +128,7 @@ c8y ui applications plugins update --application "$NAME" --plugin "$PLUGIN_NAME"
 assert_application_remotes_contains "$NAME" "$SHARED_PLUGIN_CONTEXT_PATH@*" "$PLUGIN_NAME@1.0.1"
 
 echo "Marking $PLUGIN_NAME 1.0.2 as the latest version"
-echo "$PLUGIN_NAME" | c8y ui plugins versions update --tags "latest" --version "1.0.2"
+echo "$PLUGIN_NAME" | c8y ui plugins versions update --tag "latest" --version "1.0.2"
 
 echo "Updating all plugins"
 c8y ui applications plugins update --application "$NAME" --all

--- a/tests/manual/ui/plugins/crud.sh
+++ b/tests/manual/ui/plugins/crud.sh
@@ -40,7 +40,7 @@ c8y ui plugins create --file "$VERSION1_URL" --name "$NAME"
 echo "Creating plugin from file"
 PLUGIN_FILE="${TEMP_DIR}/${NAME}.zip" 
 wget -O "$PLUGIN_FILE" "$VERSION2_URL"
-c8y ui plugins create --file "$PLUGIN_FILE" --tags latest -v
+c8y ui plugins create --file "$PLUGIN_FILE" --tag latest -v
 
 echo "List plugins"
 [ -n "$(c8y ui plugins list)" ]
@@ -58,7 +58,7 @@ echo "List versions"
 [ "$(c8y ui plugins versions list --plugin "$NAME" | wc -l | xargs)" = "2" ]
 
 echo "Update version tags"
-c8y ui plugins versions update --plugin "$NAME" --version "1.0.1" --tags latest,v1-info
+c8y ui plugins versions update --plugin "$NAME" --version "1.0.1" --tag latest,v1-info
 [ "$(c8y ui plugins versions get --plugin "$NAME" --tag v1-info --select version -o csv)" = "1.0.1" ]
 [ "$(c8y ui plugins versions get --plugin "$NAME" --tag latest --select version -o csv)" = "1.0.1" ]
 

--- a/tools/PSc8y/Public/Get-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Get-MeasurementCollection.ps1
@@ -53,11 +53,6 @@ Get measurements from a device (using pipeline)
         [string]
         $ValueFragmentSeries,
 
-        # Fragment name from measurement (deprecated).
-        [Parameter()]
-        [string]
-        $FragmentType,
-
         # Start date or date and time of measurement occurrence.
         [Parameter()]
         [string]

--- a/tools/PSc8y/Public/New-UIPluginVersion.ps1
+++ b/tools/PSc8y/Public/New-UIPluginVersion.ps1
@@ -38,10 +38,10 @@ Create a new version for a plugin
         [string]
         $Version,
 
-        # List of tags associated to the version (required)
-        [Parameter(Mandatory = $true)]
+        # List of tags associated to the version
+        [Parameter()]
         [string[]]
-        $Tags
+        $Tag
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Create", "Template"

--- a/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
@@ -33,11 +33,6 @@ Delete measurement collection for a device
         [string]
         $Type,
 
-        # Fragment name from measurement (deprecated).
-        [Parameter()]
-        [string]
-        $FragmentType,
-
         # Start date or date and time of measurement occurrence.
         [Parameter()]
         [string]

--- a/tools/PSc8y/Public/Update-UIPluginVersion.ps1
+++ b/tools/PSc8y/Public/Update-UIPluginVersion.ps1
@@ -11,7 +11,7 @@ Replaces the tags of a given plugin version in your tenant
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/ui_plugins_versions_update
 
 .EXAMPLE
-PS> Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tags tag1,latest
+PS> Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tag tag1,latest
 
 Replace tags assigned to a version of a plugin
 
@@ -36,7 +36,7 @@ Replace tags assigned to a version of a plugin
         # Tag assigned to the version. Version tags must be unique across all versions and version fields of plugin versions
         [Parameter()]
         [string[]]
-        $Tags
+        $Tag
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Update", "Template"

--- a/tools/PSc8y/Tests/Update-UIPluginVersion.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Update-UIPluginVersion.auto.Tests.ps1
@@ -6,7 +6,7 @@ Describe -Name "Update-UIPluginVersion" {
     }
 
     It -Skip "Replace tags assigned to a version of a plugin" {
-        $Response = PSc8y\Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tags tag1,latest
+        $Response = PSc8y\Update-UIPluginVersion -Plugin 1234 -Version 1.0 -Tag tag1,latest
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
Add consistency between the ui plugins commands by renaming `--tags` to `--tag`. Keep backwards compatibility by marking `--tags` as deprecated.

The examples in the commands have also been updated to match accordingly.