### PR TITLE
docs: fix device group assign/unassign examples

### DIFF
--- a/docs/go-c8y-cli/docs/examples/devicegroups.md
+++ b/docs/go-c8y-cli/docs/examples/devicegroups.md
@@ -10,7 +10,7 @@ import CodeExample from '@site/src/components/CodeExample';
 
 ```bash
 c8y inventory find --query "agentVersion eq '1.*' and not(bygroupid(123456))" --includeAll |
-    c8y devicegroups assignDevice --group 123456 --workers 2 --progress
+    c8y devicegroups children assign --childType asset --id 123456 --workers 2 --progress
 ```
 
 </CodeExample>
@@ -64,7 +64,7 @@ UNIQUE_ID_4
 
     ```bash
     cat list.ids.csv |
-        c8y devicegroups assignDevice --group 1234 --workers 2 --progress --silentStatusCodes 409
+        c8y devicegroups children assign --childType asset --id 1234 --workers 2 --progress --silentStatusCodes 409
     ```
 
     </CodeExample>
@@ -101,7 +101,7 @@ group=$( c8y devicegroups create --name "my_custom_group" --output csv --select 
 
 # Assign the failed operations
 c8y operations list --bulkOperationId 8 --status FAILED --includeAll |
-    c8y devicegroups assignDevice --group $group --workers 2 --progress --silentStatusCodes 409
+    c8y devicegroups children assign --id $group --workers 2 --progress --silentStatusCodes 409
 ```
 
 ```powershell
@@ -110,7 +110,7 @@ $group = c8y devicegroups create --name "my_custom_group" --output csv --select 
 
 # Assign the failed operations
 c8y operations list --bulkOperationId 8 --status FAILED --includeAll |
-    c8y devicegroups assignDevice --group $group --workers 2 --progress --silentStatusCodes 409
+    c8y devicegroups children assign --id $group --workers 2 --progress --silentStatusCodes 409
 ```
 
 </CodeExample>
@@ -124,7 +124,7 @@ The Cumulocity inventory query language supports a the `bygroupid(x)` operator w
 
 ```bash
 c8y inventory find --query "agentVersion eq '1.*' and bygroupid(123456)" --includeAll |
-    c8y devicegroups unassignDevice --group 123456 --workers 2 --progress
+    c8y devicegroups children unassign --childType asset --id 123456 --workers 2 --progress
 ```
 
 </CodeExample>

--- a/docs/go-c8y-cli/docs/examples/inventory.md
+++ b/docs/go-c8y-cli/docs/examples/inventory.md
@@ -14,15 +14,15 @@ import CodeExample from '@site/src/components/CodeExample';
 <CodeExample>
 
 ```bash
-$Group = c8y devicegroups create --name "AU_Group" -o csv --select id
+group=$(c8y devicegroups create --name "AU_Group" -o csv --select id)
 c8y devices create --name "myDevice01" |
-    c8y devicegroups assignDevice --group $Group
+    c8y devicegroups children assign --childType asset --id "$group"
 ```
 
 ```powershell
 $Group = c8y devicegroups create --name "AU_Group" | fromjson
 c8y devices create --name "myDevice01" |
-    c8y devicegroups assignDevice --group $Group.id
+    c8y devicegroups children assign --childType asset --id $Group.id
 ```
 
 </CodeExample>

--- a/docs/go-c8y-cli/src/components/CodeBlock.jsx
+++ b/docs/go-c8y-cli/src/components/CodeBlock.jsx
@@ -65,9 +65,12 @@ const c8yCommands = {
 
     'c8y devicegroups create': 'New-DeviceGroup',
     'c8y devicegroups list': 'Get-DeviceGroupCollection',
+    'c8y devicegroups listAssets': 'Get-DeviceGroupChildAssetCollection',
+    'c8y devicegroups children assign': 'Add-DeviceGroupChild',
+    'c8y devicegroups children unassign': 'Remove-DeviceGroupChild',
+    // Deprecated
     'c8y devicegroups assignDevice': 'Add-DeviceToGroup',
     'c8y devicegroups unassignDevice': 'Remove-DeviceFromGroup',
-    'c8y devicegroups listAssets': 'Get-DeviceGroupChildAssetCollection',
     
     'c8y applications create': 'New-Application',
     'c8y applications createHostedApplication': 'New-HostedApplication',


### PR DESCRIPTION
Fix a few mistakes in the device group assign/unassign in the docs:

The mistakes were:

* Incorrect shell example which used the powershell code for variable assignment
* Usage of deprecated group assignment commands