### PR TITLE
docs: fix go-c8y-cli native powershell examples which used variable assignments

### DIFF
--- a/docs/go-c8y-cli/docs/examples/devicegroups.md
+++ b/docs/go-c8y-cli/docs/examples/devicegroups.md
@@ -113,6 +113,15 @@ c8y operations list --bulkOperationId 8 --status FAILED --includeAll |
     c8y devicegroups children assign --id $group --workers 2 --progress --silentStatusCodes 409
 ```
 
+```powershell
+# Create a new group
+$group = c8y devicegroups create --name "my_custom_group" --output csv --select id
+
+# Assign the failed operations
+c8y operations list --bulkOperationId 8 --status FAILED --includeAll |
+    c8y devicegroups children assign --id $group --workers 2 --progress --silentStatusCodes 409
+```
+
 </CodeExample>
 
 ### Unassign devices from a group which match a custom inventory query

--- a/docs/go-c8y-cli/docs/examples/inventory.md
+++ b/docs/go-c8y-cli/docs/examples/inventory.md
@@ -25,6 +25,12 @@ c8y devices create --name "myDevice01" |
     c8y devicegroups children assign --childType asset --id $Group.id
 ```
 
+```powershell
+$Group = c8y devicegroups create --name "AU_Group" | fromjson
+c8y devices create --name "myDevice01" |
+    c8y devicegroups children assign --childType asset --id $Group.id
+```
+
 </CodeExample>
 
 ## Update


### PR DESCRIPTION
Fixed errors in the code auto generation for the native go-c8y-cli examples under powershell which used variable assignments. The error was that they still used the bash style variable assignments instead of powershell.