### PR TITLE
fix: don't ignore a flag's target property when using custom pipeline mapping

### DIFF
--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -191,8 +191,8 @@ func WithRuntimePipelineProperty() Option {
 		}
 		cmd.Annotations[AnnotationValueFromPipeline] = name
 
-		aliases := []string{name}
-
+		// Note: User given aliases should take precedence (as they're specifying it)
+		aliases := []string{}
 		if alias != "" {
 			for _, a := range strings.Split(alias, ",") {
 				a = strings.TrimLeft(a, ".")
@@ -201,14 +201,23 @@ func WithRuntimePipelineProperty() Option {
 				}
 			}
 		}
+		aliases = append(aliases, name)
 
 		if aliasValue, ok := cmd.Annotations[AnnotationValuePipelineAlias+"."+name]; ok {
 			aliases = append(aliases, strings.Split(aliasValue, ",")...)
 		}
 
+		// Check for existing pipe options
+		targetProperty := name
+		if existingPipeLineOptions, err := GetPipeOptionsFromAnnotation(cmd); err == nil {
+			if existingPipeLineOptions.Name == name {
+				targetProperty = existingPipeLineOptions.Property
+			}
+		}
+
 		options := &PipelineOptions{
 			Name:     name,
-			Property: name,
+			Property: targetProperty,
 			Aliases:  aliases,
 			Required: true,
 			IsID:     true,

--- a/tests/manual/common/pipe/pipe_mapping.yaml
+++ b/tests/manual/common/pipe/pipe_mapping.yaml
@@ -108,3 +108,15 @@ tests:
       json:
         method: GET
         path: /inventory/managedObjects/12345/childDevices
+
+  It does not override body target when using custom pipe mapping:
+    command: |
+        c8y template execute --template "{custom:{id:12345}}" |
+          c8y alarms create --device -.custom.id --type example --text foo --severity MAJOR --dry --dryFormat json
+    exit-code: 0
+    stdout:
+      json:
+        body.source.id: "12345"
+        body.type: example
+        body.text: foo
+        body.severity: MAJOR


### PR DESCRIPTION
A flag's original target property is now preserved even when the user is using custom piped argument mapping.

Previously the flag's property was being ignored and the flag name was being used as the target instead.

**Example**

```sh
c8y template execute --template "{custom:{id:12345}}" \
| c8y alarms create --device -.custom.id --type example --text foo --severity MAJOR --dry --dryFormat json
```

*Before*

The following error occurs because the `--device` flag's value (read from the pipeline) as been written to `body.device` instead of `source.id`.

```sh
2025-02-27T15:26:40.106+0100	ERROR	commandError: Body is missing required properties: source.id
2025-02-27T15:26:40.108+0100	ERROR	commandError: Missing required parameter. input
```

*After*

```json
{
  "body": {
    "severity": "MAJOR",
    "source": {
      "id": "12345"
    },
    "text": "foo",
    "time": "2025-02-27T15:25:48.795+01:00",
    "type": "example"
  }
}
```