### PR TITLE
fix(microservice): add pipeline alias for the microservice id flag

### DIFF
--- a/api/spec/json/microservices.json
+++ b/api/spec/json/microservices.json
@@ -218,7 +218,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
       ]
     },
@@ -273,7 +277,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
       ]
     },
@@ -320,7 +328,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
       ],
       "body": [
@@ -399,7 +411,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
       ],
       "body": [
@@ -458,7 +474,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
       ]
     },
@@ -518,9 +538,15 @@
           "type": "microservice",
           "property": "application.id",
           "pipeline": true,
-          "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
+      ],
+      "bodyRequiredKeys": [
+        "application.id"
       ]
     },
     {
@@ -569,7 +595,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         },
         {
           "name": "tenant",
@@ -635,7 +665,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         }
       ]
     },
@@ -674,7 +708,11 @@
           "type": "microservice",
           "pipeline": true,
           "required": true,
-          "description": "Microservice id"
+          "description": "Microservice id",
+          "pipelineAliases": [
+            "application.id",
+            "id"
+          ]
         },
         {
           "name": "instance",

--- a/api/spec/json/microservices.json
+++ b/api/spec/json/microservices.json
@@ -543,6 +543,11 @@
             "application.id",
             "id"
           ]
+        },
+        {
+          "name": "data",
+          "type": "json",
+          "description": "Additional properties of the inventory."
         }
       ],
       "bodyRequiredKeys": [

--- a/api/spec/yaml/microservices.yaml
+++ b/api/spec/yaml/microservices.yaml
@@ -400,6 +400,11 @@ commands:
         pipelineAliases:
           - application.id
           - id
+
+      - name: data
+        type: json
+        description: Additional properties of the inventory.
+
     bodyRequiredKeys:
       - application.id
 

--- a/api/spec/yaml/microservices.yaml
+++ b/api/spec/yaml/microservices.yaml
@@ -163,6 +163,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
 
   - name: deleteMicroservice
     description: Delete microservice
@@ -201,6 +204,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
 
   - name: updateMicroservice
     description: Update microservice details
@@ -233,6 +239,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
 
     body:
       - name: data
@@ -298,6 +307,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
     body:
       - name: file
         type: file
@@ -340,6 +352,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
 
   - name: enableMicroservice
     description: subscribe to microservice
@@ -381,8 +396,12 @@ commands:
         type: microservice
         property: application.id
         pipeline: true
-        required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
+    bodyRequiredKeys:
+      - application.id
 
   - name: disableMicroservice
     description: unsubscribe microservice
@@ -418,6 +437,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
 
       - name: tenant
         type: tenant
@@ -467,6 +489,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
 
   - name: getLog
     # Currently a bug when parsing the output
@@ -496,6 +521,9 @@ commands:
         pipeline: true
         required: true
         description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
       
       - name: instance
         type: microserviceinstance

--- a/pkg/cmd/microservices/createbinary/createBinary.auto.go
+++ b/pkg/cmd/microservices/createbinary/createBinary.auto.go
@@ -66,7 +66,7 @@ Upload microservice binary
 		cmd,
 		flags.WithProcessingMode(),
 
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 	)
 

--- a/pkg/cmd/microservices/delete/delete.auto.go
+++ b/pkg/cmd/microservices/delete/delete.auto.go
@@ -59,7 +59,7 @@ Delete a microservice by name
 		cmd,
 		flags.WithProcessingMode(),
 
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 	)
 

--- a/pkg/cmd/microservices/disable/disable.auto.go
+++ b/pkg/cmd/microservices/disable/disable.auto.go
@@ -62,7 +62,7 @@ Disable (unsubscribe) to a microservice
 		cmd,
 		flags.WithProcessingMode(),
 
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 		flags.WithPipelineAliases("tenant", "tenant", "owner.tenant.id"),
 	)

--- a/pkg/cmd/microservices/enable/enable.auto.go
+++ b/pkg/cmd/microservices/enable/enable.auto.go
@@ -61,7 +61,8 @@ Enable (subscribe) to a microservice by name
 	flags.WithOptions(
 		cmd,
 		flags.WithProcessingMode(),
-
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "application.id", false, "application.id", "id"),
 		flags.WithPipelineAliases("tenant", "tenant", "owner.tenant.id"),
 		flags.WithPipelineAliases("id", "id"),

--- a/pkg/cmd/microservices/enable/enable.auto.go
+++ b/pkg/cmd/microservices/enable/enable.auto.go
@@ -50,7 +50,7 @@ Enable (subscribe) to a microservice by name
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("tenant", "", "Tenant id")
-	cmd.Flags().String("id", "", "Microservice id (required) (accepts pipeline)")
+	cmd.Flags().String("id", "", "Microservice id (accepts pipeline)")
 
 	completion.WithOptions(
 		cmd,
@@ -62,7 +62,7 @@ Enable (subscribe) to a microservice by name
 		cmd,
 		flags.WithProcessingMode(),
 
-		flags.WithExtendedPipelineSupport("id", "application.id", true),
+		flags.WithExtendedPipelineSupport("id", "application.id", false, "application.id", "id"),
 		flags.WithPipelineAliases("tenant", "tenant", "owner.tenant.id"),
 		flags.WithPipelineAliases("id", "id"),
 	)
@@ -146,6 +146,7 @@ func (n *EnableCmd) RunE(cmd *cobra.Command, args []string) error {
 		c8yfetcher.WithMicroserviceByNameFirstMatch(n.factory, args, "id", "application.id"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
+		flags.WithRequiredProperties("application.id"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/microservices/get/get.auto.go
+++ b/pkg/cmd/microservices/get/get.auto.go
@@ -56,7 +56,7 @@ Get an application
 	flags.WithOptions(
 		cmd,
 
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 	)
 

--- a/pkg/cmd/microservices/getbootstrapuser/getBootstrapUser.auto.go
+++ b/pkg/cmd/microservices/getbootstrapuser/getBootstrapUser.auto.go
@@ -61,7 +61,7 @@ Get application bootstrap user by app name
 	flags.WithOptions(
 		cmd,
 
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 	)
 

--- a/pkg/cmd/microservices/getstatus/getStatus.auto.go
+++ b/pkg/cmd/microservices/getstatus/getStatus.auto.go
@@ -60,7 +60,7 @@ Get microservice status (using pipeline)
 	flags.WithOptions(
 		cmd,
 
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 
 		flags.WithCollectionProperty("managedObjects"),

--- a/pkg/cmd/microservices/update/update.auto.go
+++ b/pkg/cmd/microservices/update/update.auto.go
@@ -63,7 +63,7 @@ Update microservice availability to MARKET
 		flags.WithProcessingMode(),
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
-		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithExtendedPipelineSupport("id", "id", true, "application.id", "id"),
 		flags.WithPipelineAliases("id", "id"),
 	)
 

--- a/tests/manual/microservices/microservices.yaml
+++ b/tests/manual/microservices/microservices.yaml
@@ -84,3 +84,19 @@ tests:
           name: loader-dev
           requiredRoles.0: ROLE_INVENTORY_READ
           requiredRoles.1: ROLE_INVENTORY_ADMIN
+
+    Pipe an application via application.id:
+      command: |
+        c8y template execute --template '{application:{id:1111}}' |
+        c8y microservices enable --dry --dryFormat json
+      stdout:
+        json:
+          body.application.id: 1111
+
+    Pipe an application via id:
+      command: |
+        c8y template execute --template '{id:2222}' |
+        c8y microservices enable --dry --dryFormat json
+      stdout:
+        json:
+          body.application.id: 2222

--- a/tests/manual/microservices/microservices.yaml
+++ b/tests/manual/microservices/microservices.yaml
@@ -91,7 +91,7 @@ tests:
         c8y microservices enable --dry --dryFormat json
       stdout:
         json:
-          body.application.id: 1111
+          body.application.id: "1111"
 
     Pipe an application via id:
       command: |
@@ -99,4 +99,27 @@ tests:
         c8y microservices enable --dry --dryFormat json
       stdout:
         json:
-          body.application.id: 2222
+          body.application.id: "2222"
+
+    Enable microservice by explicit id:
+      command: |
+        c8y microservices enable --id 3333 --dry --dryFormat json
+      stdout:
+        json:
+          body.application.id: "3333"
+
+    Enable microservice via template:
+      command: |
+        c8y template execute --template '{other:4444}' |
+        c8y microservices enable --template "{application:{id:input.value.other}}" --dry --dryFormat json
+      stdout:
+        json:
+          body.application.id: "4444"
+    
+    Enable microservice via custom piped values:
+      command: |
+        c8y template execute --template '{other:5555}' |
+        c8y microservices enable --id -.other --dry --dryFormat json
+      stdout:
+        json:
+          body.application.id: "5555"

--- a/tools/PSc8y/Public/Enable-Microservice.ps1
+++ b/tools/PSc8y/Public/Enable-Microservice.ps1
@@ -23,9 +23,8 @@ Enable (subscribe) to a microservice
     [Alias()]
     [OutputType([object])]
     Param(
-        # Microservice id (required)
-        [Parameter(Mandatory = $true,
-                   ValueFromPipeline=$true,
+        # Microservice id
+        [Parameter(ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
         $Id,


### PR DESCRIPTION
Improve the pipeline support for the `c8y microservice` command by allowing users to pipe in an application.

**Example**

```sh
c8y microservices list --pageSize 1 --owner $C8Y_TENANT | c8y microservices enable --dry
```

In addition, the `c8y microservices enable` command also supports the `--data` and `--template` flags.

**Example**

```sh
c8y microservices list --pageSize 1 --owner $C8Y_TENANT \
| c8y microservices enable --template '{application:{id: input.value.id}}' --dry
```

