### PR TITLE
feat: print response's body on errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.21.4
+	github.com/reubenmiller/go-c8y v0.22.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sethvargo/go-password v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.21.4 h1:91DCstniA0QVAb/XEv+oNCWIDny43UmdLHmciIqwcSw=
-github.com/reubenmiller/go-c8y v0.21.4/go.mod h1:EkcyYBezlbxSa4ybWGkPUQA/I+uPv4sLJxWTa/DiELc=
+github.com/reubenmiller/go-c8y v0.22.0 h1:gNMFoFneMD8nmDe7cux5lxJP1C4XckmMqcqy/5B3g18=
+github.com/reubenmiller/go-c8y v0.22.0/go.mod h1:EkcyYBezlbxSa4ybWGkPUQA/I+uPv4sLJxWTa/DiELc=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cmderrors/cmderrors.go
+++ b/pkg/cmderrors/cmderrors.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/tidwall/pretty"
 )
 
 const (
@@ -70,12 +72,14 @@ type CommandError struct {
 	ErrorType       string `json:"errorType,omitempty"`
 	Message         string `json:"message,omitempty"`
 	silent          bool
-	StatusCode      int                `json:"statusCode,omitempty"`
-	ExitCode        ExitCode           `json:"exitCode,omitempty"`
-	URL             string             `json:"url,omitempty"`
-	CumulocityError *c8y.ErrorResponse `json:"c8yResponse,omitempty"`
-	Err             error              `json:"error,omitempty"`
-	Processed       bool               `json:"-"`
+	StatusCode      int                  `json:"statusCode,omitempty"`
+	ExitCode        ExitCode             `json:"exitCode,omitempty"`
+	URL             string               `json:"url,omitempty"`
+	CumulocityError json.RawMessage      `json:"c8yResponse,omitempty"`
+	Err             error                `json:"error,omitempty"`
+	Processed       bool                 `json:"-"`
+	WithRawMessage  bool                 `json:"-"`
+	IO              *iostreams.IOStreams `json:"-"`
 }
 
 func (c CommandError) Unwrap() error {
@@ -100,6 +104,26 @@ func (c CommandError) Error() string {
 	if details != "" {
 		message.WriteString(" " + details)
 	}
+
+	// Print raw response as microservices add additional information in the response
+	if c.WithRawMessage && len(c.CumulocityError) > 0 && c.IO != nil {
+		message.WriteString(c.IO.ColorScheme().Red("\n\nError Response\n\n"))
+		if json.Valid(c.CumulocityError) {
+			b := pretty.PrettyOptions(c.CumulocityError, &pretty.Options{
+				SortKeys: true,
+				Width:    80,
+				Prefix:   "",
+				Indent:   "  ",
+			})
+			if c.IO.ColorEnabled() {
+				b = pretty.Color(b, pretty.TerminalStyle)
+			}
+			message.Write(b)
+		} else {
+			message.Write(c.CumulocityError)
+		}
+	}
+
 	return message.String()
 }
 
@@ -220,14 +244,16 @@ var httpStatusCodeToExitCode = map[int]ExitCode{
 }
 
 // NewServerError creates a server error from a Cumulocity response
-func NewServerError(r *c8y.Response, err error) CommandError {
+func NewServerError(r *c8y.Response, err error, iostream *iostreams.IOStreams, withRawMessage bool) CommandError {
 	cmdError := CommandError{
-		Message:    err.Error(),
-		ErrorType:  ErrTypeServer,
-		silent:     false,
-		ExitCode:   ExitUnknownError,
-		StatusCode: 0,
-		Err:        err,
+		Message:        err.Error(),
+		ErrorType:      ErrTypeServer,
+		silent:         false,
+		ExitCode:       ExitUnknownError,
+		StatusCode:     0,
+		Err:            err,
+		WithRawMessage: withRawMessage,
+		IO:             iostream,
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) {
@@ -237,7 +263,14 @@ func NewServerError(r *c8y.Response, err error) CommandError {
 	}
 
 	if v, ok := err.(*c8y.ErrorResponse); ok {
-		cmdError.CumulocityError = v
+		if v.Response != nil {
+			if json.Valid(v.Response.Body()) {
+				cmdError.CumulocityError = json.RawMessage(v.Response.Body())
+			} else if b, jsonErr := json.Marshal(v.Response.Body()); jsonErr == nil {
+				// handle non json response
+				cmdError.CumulocityError = json.RawMessage(b)
+			}
+		}
 		cmdError.Message = v.Message
 	}
 

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -1016,7 +1016,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 		if userErr, ok := respError.(cmderrors.CommandError); ok {
 			return unfilteredSize, userErr
 		}
-		return unfilteredSize, cmderrors.NewServerError(resp, respError)
+		return unfilteredSize, cmderrors.NewServerError(resp, respError, r.IO, !r.Config.WithError())
 	}
 	return unfilteredSize, nil
 }


### PR DESCRIPTION
Print the full response's body on server errors to enable for easier debugging for users.

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/446