### PR TITLE
fix(notifications2): use subscriber value from token if not set by user

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
-	github.com/reubenmiller/go-c8y v0.24.0
+	github.com/reubenmiller/go-c8y v0.25.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sethvargo/go-password v0.3.1
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
 github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.24.0 h1:QwBL0U7bQZqFt0lJEFoIE+5baBf2bC6/ei0xUg5LYEs=
-github.com/reubenmiller/go-c8y v0.24.0/go.mod h1:p5s782qdWYULGARfuiaTJScLbChyLYO8G6GInui9/tU=
+github.com/reubenmiller/go-c8y v0.25.0 h1:zsgijatjoJ8NMIb7mQTR1Ro/rOazCj7Ye9Tjyee8olU=
+github.com/reubenmiller/go-c8y v0.25.0/go.mod h1:p5s782qdWYULGARfuiaTJScLbChyLYO8G6GInui9/tU=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
+++ b/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
@@ -66,7 +66,7 @@ func NewSubscribeCmd(f *cmdutil.Factory) *SubscribeCmd {
 
 	cmd.Flags().StringVar(&ccmd.Subscription, "name", "", "The subscription name. Each subscription is identified by a unique name within a specific context")
 	cmd.Flags().StringVar(&ccmd.Token, "token", "", "Token for the subscription. If not provided, then a token will be created")
-	cmd.Flags().StringVar(&ccmd.Subscriber, "subscriber", "goc8ycli", "The subscriber name which the client wishes to be identified with. Defaults to goc8ycli")
+	cmd.Flags().StringVar(&ccmd.Subscriber, "subscriber", "", "The subscriber name which the client wishes to be identified with. Defaults to goc8ycli")
 	cmd.Flags().StringVar(&ccmd.Consumer, "consumer", "", "Consumer name. Required for shared subscriptions")
 	cmd.Flags().StringSliceVar(&ccmd.ActionTypes, "actionTypes", []string{}, "Only listen for specific action types, CREATE, UPDATE or DELETE (client side filtering)")
 	cmd.Flags().String("duration", "", "Subscription duration")
@@ -111,9 +111,10 @@ func (n *SubscribeCmd) RunE(cmd *cobra.Command, args []string) error {
 		Consumer: n.Consumer,
 		Token:    n.Token,
 		Options: c8y.Notification2TokenOptions{
-			Subscriber:       n.Subscriber,
-			Subscription:     n.Subscription,
-			ExpiresInMinutes: n.ExpiresInMinutes,
+			Subscriber:        n.Subscriber,
+			Subscription:      n.Subscription,
+			ExpiresInMinutes:  n.ExpiresInMinutes,
+			DefaultSubscriber: "goc8ycli",
 		},
 		ConnectionOptions: notification2.ConnectionOptions{
 			PingInterval: 60 * time.Second,

--- a/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
+++ b/pkg/cmd/notification2/subscriptions/subscribe/subscribe.manual.go
@@ -66,7 +66,7 @@ func NewSubscribeCmd(f *cmdutil.Factory) *SubscribeCmd {
 
 	cmd.Flags().StringVar(&ccmd.Subscription, "name", "", "The subscription name. Each subscription is identified by a unique name within a specific context")
 	cmd.Flags().StringVar(&ccmd.Token, "token", "", "Token for the subscription. If not provided, then a token will be created")
-	cmd.Flags().StringVar(&ccmd.Subscriber, "subscriber", "", "The subscriber name which the client wishes to be identified with. Defaults to goc8ycli")
+	cmd.Flags().StringVar(&ccmd.Subscriber, "subscriber", "", "The subscriber name which the client wishes to be identified with. Defaults to token subject if not empty otherwise 'goc8ycli'")
 	cmd.Flags().StringVar(&ccmd.Consumer, "consumer", "", "Consumer name. Required for shared subscriptions")
 	cmd.Flags().StringSliceVar(&ccmd.ActionTypes, "actionTypes", []string{}, "Only listen for specific action types, CREATE, UPDATE or DELETE (client side filtering)")
 	cmd.Flags().String("duration", "", "Subscription duration")


### PR DESCRIPTION
If the user does not povide an explicit subscriber value, then read the subscriber from the given token (via the "sub" claim in the jwt). And if that is not set then only use the default value of "goc8ycli" (as before).

Resolves #454