### PR TITLE
feat(session): don't print token will expire soon message when token has already expired

### DIFF
--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -177,7 +177,10 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 			expiresSoon, expiresAt := ShouldRenewToken(tok, shouldBeValidFor)
 
 			if expiresAt != nil {
-				if expiresSoon {
+				if time.Now().After(*expiresAt) {
+					log.Infof("Token has expired. tokenExpiresAt=%s", expiresAt.Format(time.RFC3339))
+					client.SetToken("")
+				} else if expiresSoon {
 					log.Warnf("Ignoring existing token as it will expire soon. minimumValidFor=%s, tokenExpiresAt=%s", shouldBeValidFor, expiresAt.Format(time.RFC3339))
 					client.SetToken("")
 				} else {


### PR DESCRIPTION
Improve the logging around the token expiration so that if the token has already expired, then a warning will not be printed (as this is an expected operation when a token is no longer valid).

**Before**

Previously, the following message is printed to the user if the token has expired.

```
2025-03-17T09:21:13.671+0100    WARN    Ignoring existing token as it will expire soon. minimumValidFor=8h0m0s, tokenExpiresAt=2025-03-14T13:21:04+01:00
```

**After**

The "Ignoring existing token as it will expire soon" message will only be displayed if the token is still valid AND it will expire "soon".