### PR TITLE
docs: use alternative template replacement tokens

### DIFF
--- a/docs/go-c8y-cli/docs/cli/c8y/remoteaccess/c8y_remoteaccess_server.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/remoteaccess/c8y_remoteaccess_server.md
@@ -14,10 +14,10 @@ connect to your device with ssh without having to manually launch the proxy your
 To do this add the following configuration to your device.
 
 ---
-Host <device>
-	User <device_username>
+Host {{device}}
+	User {{device_username}}
 	PreferredAuthentications publickey
-	IdentityFile <identify_file>
+	IdentityFile {{identify_file}}
 	ServerAliveInterval 120
 	StrictHostKeyChecking no
 	UserKnownHostsFile /dev/null

--- a/pkg/cmd/remoteaccess/server/server.manual.go
+++ b/pkg/cmd/remoteaccess/server/server.manual.go
@@ -49,10 +49,10 @@ func NewCmdServer(f *cmdutil.Factory) *CmdServer {
 			To do this add the following configuration to your device.
 
 			---
-			Host <device>
-				User <device_username>
+			Host {{device}}
+				User {{device_username}}
 				PreferredAuthentications publickey
-				IdentityFile <identify_file>
+				IdentityFile {{identify_file}}
 				ServerAliveInterval 120
 				StrictHostKeyChecking no
 				UserKnownHostsFile /dev/null


### PR DESCRIPTION
Fix doc build issue due to using html like tags in the example ssh config.