### PR TITLE
fix: respect c8y host/url scheme provided by the user

### DIFF
--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -233,10 +233,12 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		n.onSave(handler.C8Yclient)
 	}
 
+	// include scheme so the user is aware if they are using http or https
+	formatURL := strings.TrimSuffix(c8y.FormatBaseURL(handler.C8Yclient.BaseURL.String()), "/")
 	session := &c8ysession.CumulocitySession{
 		Path:       cfg.GetSessionFile(),
 		SessionUri: "file://" + cfg.GetSessionFile(),
-		Host:       handler.C8Yclient.BaseURL.Host,
+		Host:       formatURL,
 		Password:   handler.C8Yclient.Password,
 		Token:      handler.C8Yclient.Token,
 		Tenant:     cfg.GetTenant(),


### PR DESCRIPTION
Respect the url scheme (e.g. `http` or `https`) provided by the user, but still default to https if non is provided.

This use-case is especially useful for developers, but also people using the thin-edge.io local c8y proxy.

To activate this feature, you just need to specify the url using the `http://` prefix when setting the Cumulocity host url. You can edit your existing session by simply editing the session file and adding the desired prefix.

**Example: Creating a session to talk to the local thin-edge.io local c8y proxy**

```sh
c8y sessions create --host http://localhost:8001/c8y
```

Then when activating the session, you will now see the full URL which is used (including the URL scheme).

```sh
$ set-session localhost
✓ Session is now active
---------------------  Cumulocity Session  ---------------------

    source: file:///Users/reubenmiller/.cumulocity/localhost-reuben.miller@example.com.json


host         : http://localhost:8001/c8y
tenant       : t493319102
version      : 2025.66.0
username     : reuben.miller@example.com
```