### PR TITLE
feat(currenttenant): add support for withParent

### DIFF
--- a/api/spec/json/currentTenant.json
+++ b/api/spec/json/currentTenant.json
@@ -22,15 +22,30 @@
           {
             "description": "Get the current tenant (based on your current credentials)",
             "command": "Get-CurrentTenant"
+          },
+          {
+            "description": "Get the current tenant including the parent tenant (based on your current credentials)",
+            "command": "Get-CurrentTenant -WithParent"
           }
         ],
         "go": [
           {
             "description": "Get the current tenant (based on your current credentials)",
             "command": "c8y currenttenant get"
+          },
+          {
+            "description": "Get the current tenant including the parent tenant (based on your current credentials)",
+            "command": "c8y currenttenant get --withParent"
           }
         ]
-      }
+      },
+      "queryParameters": [
+        {
+          "name": "withParent",
+          "type": "boolean",
+          "description": "When set to true, the returned result will contain the parent of the current tenant"
+        }
+      ]
     },
     {
       "name": "listApplications",

--- a/api/spec/yaml/currentTenant.yaml
+++ b/api/spec/yaml/currentTenant.yaml
@@ -21,9 +21,19 @@ commands:
         powershell:
           - description: Get the current tenant (based on your current credentials)
             command: Get-CurrentTenant
+          - description: Get the current tenant including the parent tenant (based on your current credentials)
+            command: Get-CurrentTenant -WithParent
+
         go:
           - description: Get the current tenant (based on your current credentials)
             command: c8y currenttenant get
+
+          - description: Get the current tenant including the parent tenant (based on your current credentials)
+            command: c8y currenttenant get --withParent
+    queryParameters:
+      - name: withParent
+        type: boolean
+        description: When set to true, the returned result will contain the parent of the current tenant
   
   - name: listApplications
     description: List applications in current tenant

--- a/currenttenant.json
+++ b/currenttenant.json
@@ -1,0 +1,1143 @@
+{
+  "allowCreateTenants": true,
+  "applications": {
+    "references": [
+      {
+        "application": {
+          "activeVersionId": "41964980",
+          "availability": "MARKET",
+          "contextPath": "opcua-mgmt-service",
+          "id": "30",
+          "key": "opcua-mgmt-service",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "opcua-mgmt-service",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_DEVICE_CONTROL_READ",
+            "ROLE_DEVICE_CONTROL_ADMIN",
+            "ROLE_IDENTITY_READ",
+            "ROLE_IDENTITY_ADMIN",
+            "ROLE_ALARM_ADMIN"
+          ],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/30",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/30"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "timeseries-migration",
+          "id": "88096",
+          "key": "timeseries-migration",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "timeseries-migration",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_OPTION_MANAGEMENT_READ",
+            "ROLE_OPTION_MANAGEMENT_ADMIN",
+            "ROLE_TENANT_MANAGEMENT_ADMIN"
+          ],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/88096",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/88096"
+      },
+      {
+        "application": {
+          "activeVersionId": "40329736",
+          "availability": "MARKET",
+          "contextPath": "dtm",
+          "id": "298838",
+          "key": "dtm",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "dtm",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_INVENTORY_READ"
+          ],
+          "roles": [
+            "ROLE_DIGITAL_TWIN_READ",
+            "ROLE_DIGITAL_TWIN_CREATE",
+            "ROLE_DIGITAL_TWIN_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/298838",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/298838"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "description": "Microservice that allows tenant management to get access to this tenant.",
+          "id": "72",
+          "key": "subtenant-mgmt-288965a1",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "subtenant-mgmt-288965a1",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_MEASUREMENT_READ",
+            "ROLE_EVENT_READ",
+            "ROLE_ALARM_READ",
+            "ROLE_DEVICE_CONTROL_READ",
+            "ROLE_USER_MANAGEMENT_READ",
+            "ROLE_USER_MANAGEMENT_ADMIN",
+            "ROLE_DEVICE_CONTROL_ADMIN",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_OPTION_MANAGEMENT_READ",
+            "ROLE_OPTION_MANAGEMENT_ADMIN",
+            "ROLE_IDENTITY_READ",
+            "ROLE_IDENTITY_ADMIN",
+            "ROLE_RETENTION_RULE_READ",
+            "ROLE_RETENTION_RULE_ADMIN",
+            "ROLE_APPLICATION_MANAGEMENT_READ",
+            "ROLE_ALARM_ADMIN",
+            "ROLE_CEP_MANAGEMENT_ADMIN",
+            "ROLE_APPLICATION_MANAGEMENT_ADMIN"
+          ],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/72",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/72"
+      },
+      {
+        "application": {
+          "activeVersionId": "3142195630",
+          "availability": "MARKET",
+          "config": {
+            "remotes": {}
+          },
+          "contextPath": "cockpit",
+          "id": "9",
+          "key": "cockpit-application-key",
+          "manifest": {
+            "author": "Cumulocity GmbH",
+            "breadcrumbs": false,
+            "contentSecurityPolicy": "base-uri 'none'; default-src 'self' 'unsafe-inline' http: https: ws: wss:; connect-src 'self' http: https: ws: wss: data:;  script-src 'self' *.bugherd.com *.twitter.com *.twimg.com *.aptrinsic.com 'unsafe-inline' 'unsafe-eval' data:; style-src * 'unsafe-inline' blob:; img-src * data: blob:; font-src * data:; frame-src *; worker-src 'self' blob:;",
+            "contextHelp": true,
+            "description": "The Cockpit application provides you with options to manage and monitor Internet of Things (IoT) assets and data from a business perspective.",
+            "dynamicOptionsUrl": true,
+            "exports": [
+              {
+                "description": "KPI widget",
+                "module": "kpiWidgetProviders",
+                "name": "Widgets: KPI widget",
+                "path": "@c8y/ngx-components/widgets/definitions/kpi",
+                "scope": "self"
+              },
+              {
+                "description": "Alarm list widget",
+                "module": "alarmListWidgetProviders",
+                "name": "Widgets: Alarm list",
+                "path": "@c8y/ngx-components/widgets/definitions/alarms/alarm-list",
+                "scope": "self"
+              },
+              {
+                "description": "All critical alarms widget",
+                "module": "criticalAlarmsWidgetProviders",
+                "name": "Widgets: All critical alarms",
+                "path": "@c8y/ngx-components/widgets/definitions/alarms/all-critical-alarms",
+                "scope": "self"
+              },
+              {
+                "description": "Recent alarms widget",
+                "module": "recentAlarmsWidgetProviders",
+                "name": "Widgets: Recent alarms",
+                "path": "@c8y/ngx-components/widgets/definitions/alarms/recent-alarms",
+                "scope": "self"
+              },
+              {
+                "description": "Applications widget",
+                "module": "applicationsWidgetProviders",
+                "name": "Widgets: Applications",
+                "path": "@c8y/ngx-components/widgets/definitions/applications",
+                "scope": "self"
+              },
+              {
+                "description": "Legacy welcome to Cockpit widget",
+                "module": "legacyCockpitWelcomeWidgetProviders",
+                "name": "Widgets: Legacy welcome to Cockpit",
+                "path": "@c8y/ngx-components/widgets/definitions/cockpit-legacy-welcome",
+                "scope": "self"
+              },
+              {
+                "description": "Welcome to Cockpit widget",
+                "module": "cockpitWelcomeWidgetProviders",
+                "name": "Widgets: Welcome to Cockpit",
+                "path": "@c8y/ngx-components/widgets/definitions/cockpit-welcome",
+                "scope": "self"
+              },
+              {
+                "description": "Message sending widget",
+                "module": "deviceControlMessageWidgetProviders",
+                "name": "Widgets: Message sending",
+                "path": "@c8y/ngx-components/widgets/definitions/device-control-message",
+                "scope": "self"
+              },
+              {
+                "description": "Help and service widget",
+                "module": "helpAndServiceWidgetProviders",
+                "name": "Widgets: Help and service",
+                "path": "@c8y/ngx-components/widgets/definitions/help-and-service",
+                "scope": "self"
+              },
+              {
+                "description": "Image widget",
+                "module": "imageWidgetProviders",
+                "name": "Widgets: Image",
+                "path": "@c8y/ngx-components/widgets/definitions/image",
+                "scope": "self"
+              },
+              {
+                "description": "Info gauge widget",
+                "module": "infoGaugeWidgetProviders",
+                "name": "Widgets: Info gauge",
+                "path": "@c8y/ngx-components/widgets/definitions/info-gauge",
+                "scope": "self"
+              },
+              {
+                "description": "Map widget",
+                "module": "mapWidgetProviders",
+                "name": "Widgets: Map",
+                "path": "@c8y/ngx-components/widgets/definitions/map",
+                "scope": "self"
+              },
+              {
+                "description": "Markdown widget",
+                "module": "markdownWidgetProviders",
+                "name": "Widgets: Markdown",
+                "path": "@c8y/ngx-components/widgets/definitions/markdown",
+                "scope": "self"
+              },
+              {
+                "description": "Rotation widget",
+                "module": "threeDRotationWidgetProviders",
+                "name": "Widgets: Rotation",
+                "path": "@c8y/ngx-components/widgets/definitions/three-d-rotation",
+                "scope": "self"
+              },
+              {
+                "description": "Silo widget",
+                "module": "siloWidgetProviders",
+                "name": "Widgets: Silo",
+                "path": "@c8y/ngx-components/widgets/definitions/silo",
+                "scope": "self"
+              },
+              {
+                "description": "Linear Gauge widget",
+                "module": "linearGaugeWidgetProviders",
+                "name": "Widgets: Linear Gauge",
+                "path": "@c8y/ngx-components/widgets/definitions/linear-gauge",
+                "scope": "self"
+              },
+              {
+                "description": "Data points graph widget",
+                "module": "datapointGraphWidgetproviders",
+                "name": "Widgets: Data points graph",
+                "path": "@c8y/ngx-components/widgets/definitions/datapoints-graph",
+                "scope": "self-optional"
+              },
+              {
+                "description": "Data Points Table widget",
+                "module": "dataPointsTableWidgetProviders",
+                "name": "Widgets: Data Points Table",
+                "path": "@c8y/ngx-components/widgets/definitions/datapoints-table",
+                "scope": "self"
+              },
+              {
+                "description": "Reports list and navigator items reports",
+                "module": "ReportDashboardModule",
+                "name": "Reports",
+                "path": "@c8y/ngx-components/report-dashboard",
+                "scope": "self"
+              },
+              {
+                "description": "Alarms functionality in cockpit application.",
+                "module": "CockpitAlarmsModule",
+                "name": "Cockpit alarms",
+                "path": "@c8y/ngx-components/alarms/cockpit",
+                "scope": "self"
+              },
+              {
+                "description": "Dialogs to connect smartphone to platform.",
+                "module": "SensorPhoneModule",
+                "name": "Sensor phone",
+                "path": "@c8y/ngx-components/sensor-phone",
+                "scope": "self"
+              },
+              {
+                "description": "View listing children of devices.",
+                "module": "ChildDevicesModule",
+                "name": "Child devices",
+                "path": "@c8y/ngx-components/child-devices",
+                "scope": "self"
+              },
+              {
+                "description": "\"Groups\" navigation entry, allowing to navigate through asset hierarchy.",
+                "module": "AssetsNavigatorModule",
+                "name": "Assets navigator",
+                "path": "@c8y/ngx-components/assets-navigator",
+                "scope": "self"
+              },
+              {
+                "description": "Allows to define certain features of data points.",
+                "module": "DatapointLibraryModule",
+                "name": "Data point library",
+                "path": "@c8y/ngx-components/datapoint-library",
+                "scope": "self"
+              },
+              {
+                "description": "Allows to bookmark views.",
+                "module": "BookmarksModule",
+                "name": "Bookmarks",
+                "path": "@c8y/ngx-components/bookmarks",
+                "scope": "self"
+              },
+              {
+                "description": "View the location of devices and assets.",
+                "module": "LocationTabModule",
+                "name": "Location",
+                "path": "@c8y/ngx-components/location",
+                "scope": "self"
+              },
+              {
+                "description": "Assign a location to devices and assets that currently do not have any location.",
+                "module": "AddLocationModule",
+                "name": "Add location",
+                "path": "@c8y/ngx-components/location",
+                "scope": "self-optional"
+              },
+              {
+                "description": "Allows to search for assets.",
+                "module": "SearchModule",
+                "name": "Search",
+                "path": "@c8y/ngx-components/search",
+                "scope": "self"
+              },
+              {
+                "description": "Enables visualization of data points",
+                "module": "DatapointExplorerModule",
+                "name": "Data point explorer",
+                "path": "@c8y/ngx-components/datapoint-explorer",
+                "scope": "self-optional"
+              }
+            ],
+            "globalTitle": "Cumulocity",
+            "rightDrawer": true,
+            "sensorAppOneLink": "http://onelink.to/pca6qe",
+            "sensorPhone": true,
+            "tabsHorizontal": true,
+            "upgrade": true,
+            "version": "1021.55.1",
+            "webSdkVersion": "1021.55.1"
+          },
+          "name": "cockpit",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "resourcesUrl": "",
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/9",
+          "type": "HOSTED"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/9"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "feature-cep-custom-rules",
+          "id": "8",
+          "key": "c8y-feature-cep-custom-rules",
+          "manifest": {
+            "noAppSwitcher": true
+          },
+          "name": "feature-cep-custom-rules",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/8",
+          "type": "HOSTED"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/8"
+      },
+      {
+        "application": {
+          "activeVersionId": "9142114743",
+          "availability": "MARKET",
+          "contextPath": "digital-twin-manager",
+          "id": "28",
+          "key": "digital-twin-manager-application-key",
+          "manifest": {
+            "contentSecurityPolicy": "base-uri 'none'; default-src 'self' 'unsafe-inline' http: https: ws: wss:; connect-src 'self' http: https: ws: wss:; script-src 'self' open.mapquestapi.com *.twitter.com *.twimg.com *.aptrinsic.com 'unsafe-inline' 'unsafe-eval' data:; style-src * 'unsafe-inline' blob:; img-src * data:; font-src * data:; frame-src *; worker-src 'self' blob:;",
+            "contextHelp": true,
+            "description": "This application helps manage assets around your physical connected devices in Cumulocity IoT by digitally representing their hierarchy. It structures devices logically, mirroring real-world hierarchies to enhance visualization in a digital environment.",
+            "docs": {
+              "links": []
+            },
+            "docsBaseUrl": "https://cumulocity.com",
+            "dynamicOptionsUrl": true,
+            "exports": [],
+            "globalTitle": "",
+            "icon": {
+              "class": "c8y-icon c8y-icon-enterprise"
+            },
+            "languages": {},
+            "remotes": {
+              "dtm-plugins": [
+                "AddAssetModule",
+                "SubAssetsModule"
+              ]
+            },
+            "rightDrawer": true,
+            "tabsHorizontal": true,
+            "version": "1021.1.2",
+            "webSdkVersion": "1021.36.0"
+          },
+          "name": "digital-twin-manager",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "resourcesUrl": "/",
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/28",
+          "type": "HOSTED"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/28"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "lwm2m-agent",
+          "extensions": [
+            {
+              "description": "The LWM2M Agent allows customers to connect devices via OMA Lightweight M2M",
+              "name": "LWM2M",
+              "type": "extensibleDeviceRegistration"
+            },
+            {
+              "description": "The LWM2M Agent allows customers to connect devices via OMA Lightweight M2M",
+              "name": "LWM2M",
+              "type": "extensibleBulkDeviceRegistration"
+            }
+          ],
+          "id": "14",
+          "key": "lwm2m-agent-application-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "lwm2m-agent",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_OPTION_MANAGEMENT_ADMIN",
+            "ROLE_OPTION_MANAGEMENT_READ",
+            "ROLE_ALARM_READ",
+            "ROLE_ALARM_ADMIN",
+            "ROLE_DEVICE_CONTROL_READ",
+            "ROLE_DEVICE_CONTROL_ADMIN",
+            "ROLE_EVENT_READ",
+            "ROLE_EVENT_ADMIN",
+            "ROLE_IDENTITY_READ",
+            "ROLE_IDENTITY_ADMIN",
+            "ROLE_MEASUREMENT_READ",
+            "ROLE_MEASUREMENT_ADMIN",
+            "ROLE_TENANT_MANAGEMENT_READ",
+            "ROLE_APPLICATION_MANAGEMENT_READ",
+            "ROLE_NOTIFICATION_2_ADMIN"
+          ],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/14",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/14"
+      },
+      {
+        "application": {
+          "activeVersionId": "42195785",
+          "availability": "MARKET",
+          "contextPath": "cep",
+          "id": "24",
+          "key": "apama-ctrl-smartrulesmt",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "apama-ctrl-smartrulesmt",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_AUDIT_ADMIN",
+            "ROLE_AUDIT_READ",
+            "ROLE_BULK_OPERATION_ADMIN",
+            "ROLE_BULK_OPERATION_READ",
+            "ROLE_APPLICATION_MANAGEMENT_READ",
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_INVENTORY_CREATE",
+            "ROLE_MEASUREMENT_READ",
+            "ROLE_MEASUREMENT_ADMIN",
+            "ROLE_EVENT_READ",
+            "ROLE_EVENT_ADMIN",
+            "ROLE_ALARM_READ",
+            "ROLE_ALARM_ADMIN",
+            "ROLE_DEVICE_CONTROL_READ",
+            "ROLE_DEVICE_CONTROL_ADMIN",
+            "ROLE_IDENTITY_READ",
+            "ROLE_IDENTITY_ADMIN",
+            "ROLE_CEP_MANAGEMENT_READ",
+            "ROLE_CEP_MANAGEMENT_ADMIN",
+            "ROLE_OPTION_MANAGEMENT_READ",
+            "ROLE_TENANT_MANAGEMENT_READ",
+            "ROLE_SMS_ADMIN",
+            "ROLE_USER_MANAGEMENT_READ",
+            "ROLE_USER_MANAGEMENT_OWN_READ",
+            "ROLE_NOTIFICATION_2_ADMIN"
+          ],
+          "roles": [
+            "ROLE_SMARTRULE_READ",
+            "ROLE_SMARTRULE_ADMIN",
+            "ROLE_ANALYTICSBUILDER_READ",
+            "ROLE_EPLAPPS_READ"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/24",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/24"
+      },
+      {
+        "application": {
+          "activeVersionId": "42060661",
+          "availability": "MARKET",
+          "contextPath": "device-simulator",
+          "id": "143",
+          "key": "device-simulator-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "device-simulator",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_INVENTORY_CREATE",
+            "ROLE_MEASUREMENT_READ",
+            "ROLE_MEASUREMENT_ADMIN",
+            "ROLE_EVENT_READ",
+            "ROLE_EVENT_ADMIN",
+            "ROLE_ALARM_READ",
+            "ROLE_ALARM_ADMIN",
+            "ROLE_IDENTITY_READ",
+            "ROLE_IDENTITY_ADMIN"
+          ],
+          "roles": [
+            "ROLE_SIMULATOR_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/143",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/143"
+      },
+      {
+        "application": {
+          "activeVersionId": "42114810",
+          "availability": "MARKET",
+          "contextPath": "smartrule",
+          "id": "144",
+          "key": "smartrule-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "smartrule",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_CREATE",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_CEP_MANAGEMENT_READ",
+            "ROLE_CEP_MANAGEMENT_ADMIN"
+          ],
+          "roles": [
+            "ROLE_SMARTRULE_READ",
+            "ROLE_SMARTRULE_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/144",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/144"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "technician",
+          "id": "99174",
+          "key": "technician-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "technician",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/t9679",
+            "tenant": {
+              "id": "t9679"
+            }
+          },
+          "requiredRoles": [],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/99174",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/99174"
+      },
+      {
+        "application": {
+          "activeVersionId": "3684679",
+          "availability": "MARKET",
+          "contextPath": "messaging",
+          "id": "157",
+          "key": "sms-gateway-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "sms-gateway",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_IDENTITY_READ",
+            "ROLE_IDENTITY_ADMIN",
+            "ROLE_MEASUREMENT_ADMIN",
+            "ROLE_EVENT_ADMIN",
+            "ROLE_EVENT_READ",
+            "ROLE_TENANT_MANAGEMENT_READ",
+            "ROLE_OPTION_MANAGEMENT_READ",
+            "ROLE_OPTION_MANAGEMENT_ADMIN",
+            "ROLE_APPLICATION_MANAGEMENT_READ",
+            "ROLE_SMS_ADMIN",
+            "ROLE_AUDIT_ADMIN"
+          ],
+          "roles": [
+            "ROLE_SMS_READ",
+            "ROLE_SMS_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/157",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/157"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "dummyapp-02",
+          "id": "147955",
+          "key": "dummyapp-02",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "dummyapp-02",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/t9679",
+            "tenant": {
+              "id": "t9679"
+            }
+          },
+          "requiredRoles": [],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/147955",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/147955"
+      },
+      {
+        "application": {
+          "activeVersionId": "42114993",
+          "availability": "MARKET",
+          "contextPath": "reporting",
+          "id": "137",
+          "key": "report-agent-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "report-agent",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ",
+            "ROLE_TENANT_MANAGEMENT_READ",
+            "ROLE_MEASUREMENT_READ",
+            "ROLE_ALARM_READ",
+            "ROLE_ALARM_ADMIN",
+            "ROLE_EVENT_READ"
+          ],
+          "roles": [
+            "ROLE_SCHEDULE_REPORT_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/137",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/137"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "balancer",
+          "id": "147954",
+          "key": "balancer",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "balancer",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/t9679",
+            "tenant": {
+              "id": "t9679"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_ALARM_READ",
+            "ROLE_ALARM_ADMIN"
+          ],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/147954",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/147954"
+      },
+      {
+        "application": {
+          "activeVersionId": "41965054",
+          "availability": "MARKET",
+          "contextPath": "advanced-software-mgmt",
+          "id": "18",
+          "key": "advanced-software-mgmt",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "advanced-software-mgmt",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_INVENTORY_READ",
+            "ROLE_INVENTORY_CREATE"
+          ],
+          "roles": [
+            "ROLE_ADVANCED_SOFTWARE_READ",
+            "ROLE_ADVANCED_SOFTWARE_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/18",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/18"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "feature-microservice-hosting",
+          "id": "4",
+          "key": "c8y-feature-microservice-hosting",
+          "manifest": {
+            "noAppSwitcher": true
+          },
+          "name": "feature-microservice-hosting",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/4",
+          "type": "HOSTED"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/4"
+      },
+      {
+        "application": {
+          "activeVersionId": "2142195628",
+          "availability": "MARKET",
+          "config": {},
+          "contextPath": "administration",
+          "id": "3",
+          "key": "administration-application-key",
+          "manifest": {
+            "author": "Cumulocity GmbH",
+            "contentSecurityPolicy": "base-uri 'none'; default-src 'self' 'unsafe-inline' http: https: ws: wss:; connect-src 'self' http: https: ws: wss:;  script-src 'self' *.bugherd.com *.twitter.com *.twimg.com *.aptrinsic.com  'unsafe-inline' 'unsafe-eval' data:; style-src * 'unsafe-inline' blob:; media-src 'self' blob:; img-src * data: blob:; font-src * data:; frame-src *; worker-src 'self' blob:;",
+            "contextHelp": true,
+            "description": "The Administration application enables account administrators to manage their users, roles, tenants, applications and business rules and lets them configure a number of settings for their account.",
+            "dynamicOptionsUrl": true,
+            "exports": [
+              {
+                "description": "Allows to make basic changes to the tenants branding.",
+                "module": "BaseBrandingModule",
+                "name": "Branding base editor",
+                "path": "@c8y/ngx-components/branding/base-branding",
+                "scope": "self"
+              },
+              {
+                "description": "Allows editing the dark theme variables.",
+                "module": "DarkThemeModule",
+                "name": "Branding dark theme editor",
+                "path": "@c8y/ngx-components/branding/dark-theme",
+                "scope": "self"
+              },
+              {
+                "description": "Allows to add and edit a custom style sheet to the branding.",
+                "module": "ExtraCssBrandingEditorModule",
+                "name": "Branding custom CSS editor",
+                "path": "@c8y/ngx-components/branding/extra-css-branding-editor",
+                "scope": "self"
+              },
+              {
+                "description": "Allows to edit the plain JSON of the branding.",
+                "module": "PlainBrandingEditorModule",
+                "name": "Branding JSON editor",
+                "path": "@c8y/ngx-components/branding/plain-branding-editor",
+                "scope": "self"
+              },
+              {
+                "description": "Allows to edit translations.",
+                "module": "tranlationEditorProviders",
+                "name": "Translation editor",
+                "path": "@c8y/ngx-components/translation-editor",
+                "scope": "self"
+              }
+            ],
+            "globalTitle": "Cumulocity",
+            "remotes": {
+              "c8y-timeseries-migration-plugin@1021-stable": [
+                "TimeseriesModule"
+              ]
+            },
+            "rightDrawer": true,
+            "tabsHorizontal": true,
+            "upgrade": true,
+            "version": "1021.55.1",
+            "webSdkVersion": "1021.55.1"
+          },
+          "name": "administration",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "resourcesUrl": "",
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/3",
+          "type": "HOSTED"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/3"
+      },
+      {
+        "application": {
+          "availability": "MARKET",
+          "contextPath": "downloader",
+          "id": "200233",
+          "key": "downloader-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "downloader",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/t9679",
+            "tenant": {
+              "id": "t9679"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_READ"
+          ],
+          "roles": [],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/200233",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/200233"
+      },
+      {
+        "application": {
+          "activeVersionId": "2242195632",
+          "availability": "MARKET",
+          "config": {
+            "excludedRemotes": {
+              "devicemanagement": [
+                "LWM2Module"
+              ]
+            }
+          },
+          "contextPath": "devicemanagement",
+          "id": "1",
+          "key": "devicemanagement-application-key",
+          "manifest": {
+            "author": "Cumulocity GmbH",
+            "breadcrumbs": false,
+            "contentSecurityPolicy": "base-uri 'none'; default-src 'self' 'unsafe-inline' http: https: ws: wss:; connect-src 'self' http: https: ws: wss:;  script-src 'self' *.bugherd.com *.twitter.com *.twimg.com *.aptrinsic.com 'unsafe-inline' 'unsafe-eval' data:; style-src * 'unsafe-inline' blob:; img-src * data: blob:; font-src * data:; frame-src *; worker-src 'self' blob:;",
+            "contextHelp": true,
+            "description": "The Device Management application provides functionalities for managing and monitoring devices and enables you to control and troubleshoot devices remotely.",
+            "dynamicOptionsUrl": true,
+            "exports": [
+              {
+                "description": "Replace device plugin for enabling the action of replacing a physical device with another one.",
+                "module": "ReplaceDeviceModule",
+                "name": "Replace device plugin",
+                "path": "@c8y/ngx-components/replace-device",
+                "scope": "self"
+              },
+              {
+                "description": "The Services plugin provides a device tab that lists all services running on a device with their status, name, type and date of the last update.",
+                "module": "ServicesModule",
+                "name": "Services plugin",
+                "path": "@c8y/ngx-components/services",
+                "scope": "self"
+              },
+              {
+                "description": "Self scoped LWM2M plugin. Serves Post-operations, configuration and more...",
+                "module": "LWM2Module",
+                "name": "LWM2M plugin",
+                "path": "@c8y/ngx-components/protocol-lwm2m",
+                "scope": "self"
+              },
+              {
+                "description": "Allows to configure remote access on devices and to initiate the remote access connections.",
+                "module": "remoteAccessConfigurationListProviders",
+                "name": "Remote access: Configuration list",
+                "path": "@c8y/ngx-components/remote-access/configurations",
+                "scope": "self"
+              },
+              {
+                "description": "Adds VNC protocol support to the remote access feature.",
+                "module": "remoteAccessVNCProviders",
+                "name": "Remote access: VNC protocol support",
+                "path": "@c8y/ngx-components/remote-access/vnc",
+                "scope": "self"
+              },
+              {
+                "description": "Adds SSH protocol support to the remote access feature.",
+                "module": "remoteAccessSSHProviders",
+                "name": "Remote access: SSH protocol support",
+                "path": "@c8y/ngx-components/remote-access/ssh",
+                "scope": "self"
+              },
+              {
+                "description": "Adds Telnet protocol support to the remote access feature.",
+                "module": "remoteAccessTelnetProviders",
+                "name": "Remote access: Telnet protocol support",
+                "path": "@c8y/ngx-components/remote-access/telnet",
+                "scope": "self"
+              },
+              {
+                "description": "Adds passthrough support to the remote access feature.",
+                "module": "remoteAccessPassthroughProviders",
+                "name": "Remote access: Passthrough protocol support",
+                "path": "@c8y/ngx-components/remote-access/passthrough",
+                "scope": "self"
+              }
+            ],
+            "globalTitle": "Cumulocity",
+            "remotes": {
+              "c8y-asm-ui@latest": [
+                "AdvancedSoftwareModule"
+              ],
+              "lwm2m-ui-plugin@1021-stable": [
+                "Lwm2mModuleWrapper"
+              ]
+            },
+            "rightDrawer": true,
+            "upgrade": true,
+            "version": "1021.55.1",
+            "webSdkVersion": "1021.55.1"
+          },
+          "name": "devicemanagement",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "resourcesUrl": "",
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/1",
+          "type": "HOSTED"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/1"
+      },
+      {
+        "application": {
+          "activeVersionId": "41851689",
+          "availability": "MARKET",
+          "contextPath": "remoteaccess",
+          "id": "140",
+          "key": "cloud-remote-access-key",
+          "manifest": {
+            "billingMode": "RESOURCES",
+            "noAppSwitcher": true,
+            "requiredRoles": [],
+            "roles": [],
+            "settingsCategory": null
+          },
+          "name": "cloud-remote-access",
+          "owner": {
+            "self": "https://t9679.latest.stage.c8y.io/tenant/tenants/management",
+            "tenant": {
+              "id": "management"
+            }
+          },
+          "requiredRoles": [
+            "ROLE_INVENTORY_ADMIN",
+            "ROLE_INVENTORY_READ",
+            "ROLE_DEVICE_CONTROL_ADMIN",
+            "ROLE_DEVICE_CONTROL_READ",
+            "ROLE_OPTION_MANAGEMENT_READ",
+            "ROLE_OPTION_MANAGEMENT_ADMIN",
+            "ROLE_ALARM_ADMIN"
+          ],
+          "roles": [
+            "ROLE_REMOTE_ACCESS_ADMIN"
+          ],
+          "self": "https://t9679.latest.stage.c8y.io/application/applications/140",
+          "type": "MICROSERVICE"
+        },
+        "self": "http://t9679.latest.stage.c8y.io/application/applications/140"
+      }
+    ],
+    "self": "http://t9679.latest.stage.c8y.io/tenant/tenants/t9679/applications"
+  },
+  "customProperties": {
+    "authenticationProviders": []
+  },
+  "domainName": "iot.latest.stage.c8y.io",
+  "name": "t9679",
+  "parent": "management",
+  "self": "https://t9679.latest.stage.c8y.io/currentTenant"
+}

--- a/examples/views/default/tenant.json
+++ b/examples/views/default/tenant.json
@@ -23,7 +23,8 @@
             "columns": [
                 "name",
                 "domainName",
-                "allowCreateTenants"
+                "allowCreateTenants",
+                "parent"
             ]
         }
     ]

--- a/pkg/cmd/currenttenant/get/get.auto.go
+++ b/pkg/cmd/currenttenant/get/get.auto.go
@@ -36,6 +36,9 @@ func NewGetCmd(f *cmdutil.Factory) *GetCmd {
 		Example: heredoc.Doc(`
 $ c8y currenttenant get
 Get the current tenant (based on your current credentials)
+
+$ c8y currenttenant get --withParent
+Get the current tenant including the parent tenant (based on your current credentials)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil
@@ -44,6 +47,8 @@ Get the current tenant (based on your current credentials)
 	}
 
 	cmd.SilenceUsage = true
+
+	cmd.Flags().Bool("withParent", false, "When set to true, the returned result will contain the parent of the current tenant")
 
 	completion.WithOptions(
 		cmd,
@@ -89,6 +94,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("withParent", "withParent", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tests/auto/currenttenant/tests/currenttenant_get.yaml
+++ b/tests/auto/currenttenant/tests/currenttenant_get.yaml
@@ -6,3 +6,12 @@ tests:
             json:
                 method: GET
                 path: /tenant/currentTenant
+    currenttenant_get_Get the current tenant including the parent tenant (based on your current credentials):
+        command: c8y currenttenant get --withParent
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /tenant/currentTenant
+            contains:
+                - withParent=true

--- a/tools/PSc8y/Public/Get-CurrentTenant.ps1
+++ b/tools/PSc8y/Public/Get-CurrentTenant.ps1
@@ -15,6 +15,11 @@ PS> Get-CurrentTenant
 
 Get the current tenant (based on your current credentials)
 
+.EXAMPLE
+PS> Get-CurrentTenant -WithParent
+
+Get the current tenant including the parent tenant (based on your current credentials)
+
 
 #>
     [cmdletbinding(PositionalBinding=$true,
@@ -22,7 +27,10 @@ Get the current tenant (based on your current credentials)
     [Alias()]
     [OutputType([object])]
     Param(
-
+        # When set to true, the returned result will contain the parent of the current tenant
+        [Parameter()]
+        [switch]
+        $WithParent
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Tests/Get-CurrentTenant.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Get-CurrentTenant.auto.Tests.ps1
@@ -11,6 +11,12 @@ Describe -Name "Get-CurrentTenant" {
         $Response | Should -Not -BeNullOrEmpty
     }
 
+    It "Get the current tenant including the parent tenant (based on your current credentials)" {
+        $Response = PSc8y\Get-CurrentTenant -WithParent
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
 
     AfterEach {
 


### PR DESCRIPTION
Allow users to get the current tenant with the parent tenant name.

```
c8y currenttenant get --withParent 
| name       | domainName                   | allowCreateTenants | parent          |
|------------|------------------------------|--------------------|-----------------|
| t1234      | example.cumulocity.com       | true               | management      |
```