### PR TITLE
feat(tenants): add support for tenant list filters

### DIFF
--- a/api/spec/json/tenants.json
+++ b/api/spec/json/tenants.json
@@ -33,7 +33,25 @@
             "command": "c8y tenants list"
           }
         ]
-      }
+      },
+      "queryParameters": [
+        {
+          "name": "name",
+          "property": "company",
+          "type": "string",
+          "description": "Company name associated with the Cumulocity tenant"
+        },
+        {
+          "name": "domain",
+          "type": "string",
+          "description": "Domain name of the Cumulocity tenant"
+        },
+        {
+          "name": "parent",
+          "type": "tenant",
+          "description": "Identifier of the Cumulocity tenant's parent"
+        }
+      ]
     },
     {
       "name": "newTenant",

--- a/api/spec/yaml/tenants.yaml
+++ b/api/spec/yaml/tenants.yaml
@@ -27,6 +27,19 @@ commands:
         go:
           - description: Get a list of tenants
             command: c8y tenants list
+    queryParameters:
+      - name: name
+        property: company
+        type: string
+        description: Company name associated with the Cumulocity tenant
+
+      - name: domain  
+        type: string
+        description: Domain name of the Cumulocity tenant
+
+      - name: parent
+        type: tenant
+        description: Identifier of the Cumulocity tenant's parent
 
   - name: newTenant
     description: Create tenant

--- a/pkg/cmd/tenants/list/list.auto.go
+++ b/pkg/cmd/tenants/list/list.auto.go
@@ -45,14 +45,20 @@ Get a list of tenants
 
 	cmd.SilenceUsage = true
 
+	cmd.Flags().String("name", "", "Company name associated with the Cumulocity tenant")
+	cmd.Flags().String("domain", "", "Domain name of the Cumulocity tenant")
+	cmd.Flags().String("parent", "", "Identifier of the Cumulocity tenant's parent")
+
 	completion.WithOptions(
 		cmd,
+		completion.WithTenantID("parent", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
 		cmd,
 
 		flags.WithExtendedPipelineSupport("", "", false),
+		flags.WithPipelineAliases("parent", "tenant", "owner.tenant.id"),
 
 		flags.WithCollectionProperty("tenants"),
 	)
@@ -91,6 +97,9 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithStringValue("name", "company"),
+		flags.WithStringValue("domain", "domain"),
+		flags.WithStringDefaultValue(n.factory.GetTenant(), "parent", "parent"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tools/PSc8y/Public/Get-TenantCollection.ps1
+++ b/tools/PSc8y/Public/Get-TenantCollection.ps1
@@ -22,7 +22,20 @@ Get a list of tenants
     [Alias()]
     [OutputType([object])]
     Param(
+        # Company name associated with the Cumulocity tenant
+        [Parameter()]
+        [string]
+        $Name,
 
+        # Domain name of the Cumulocity tenant
+        [Parameter()]
+        [string]
+        $Domain,
+
+        # Identifier of the Cumulocity tenant's parent
+        [Parameter()]
+        [object]
+        $Parent
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"


### PR DESCRIPTION
Add support tenant list filters like name and domain.

**Examples**

```
# filter by company name
c8y tenants list --name "example"

# filter by domain
c8y tenants list --domain example.cumulocity.com
```