### PR TITLE
feat(microservices): add option to unsubscribe all microservice whilst deleting it

### DIFF
--- a/api/spec/json/microservices.json
+++ b/api/spec/json/microservices.json
@@ -283,6 +283,14 @@
             "id"
           ]
         }
+      ],
+      "queryParameters": [
+        {
+          "name": "unsubscribeAll",
+          "property": "force",
+          "type": "boolean",
+          "description": "Force deletion by unsubscribing all tenants from the application first and then deleting the application itself."
+        }
       ]
     },
     {

--- a/api/spec/yaml/microservices.yaml
+++ b/api/spec/yaml/microservices.yaml
@@ -208,6 +208,12 @@ commands:
           - application.id
           - id
 
+    queryParameters:
+      - name: unsubscribeAll
+        property: force
+        type: boolean
+        description: Force deletion by unsubscribing all tenants from the application first and then deleting the application itself.
+
   - name: updateMicroservice
     description: Update microservice details
     descriptionLong: |

--- a/pkg/cmd/microservices/delete/delete.auto.go
+++ b/pkg/cmd/microservices/delete/delete.auto.go
@@ -49,6 +49,7 @@ Delete a microservice by name
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("id", "", "Microservice id (required) (accepts pipeline)")
+	cmd.Flags().Bool("unsubscribeAll", false, "Force deletion by unsubscribing all tenants from the application first and then deleting the application itself.")
 
 	completion.WithOptions(
 		cmd,
@@ -97,6 +98,7 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 		query,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
+		flags.WithBoolValue("unsubscribeAll", "force", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tools/PSc8y/Public/Remove-Microservice.ps1
+++ b/tools/PSc8y/Public/Remove-Microservice.ps1
@@ -32,7 +32,12 @@ Delete a microservice by name
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]
         [object[]]
-        $Id
+        $Id,
+
+        # Force deletion by unsubscribing all tenants from the application first and then deleting the application itself.
+        [Parameter()]
+        [switch]
+        $UnsubscribeAll
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Delete"


### PR DESCRIPTION
Add the `unsubscribeAll` flag to the `c8y microservices delete` command which will first unsubscribe the microservice in all of the tenants it is subscribed to, then delete the microservice (all done by the server).

**Examples**

```sh
c8y microservices delete --id example-microservice --unsubscribeAll
```