### PR TITLE
feat(inventory): add support for feature preview flag withLatestValues

### DIFF
--- a/api/spec/json/agents.json
+++ b/api/spec/json/agents.json
@@ -185,6 +185,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },
@@ -263,6 +268,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },

--- a/api/spec/json/devices.json
+++ b/api/spec/json/devices.json
@@ -203,6 +203,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },
@@ -281,6 +286,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },

--- a/api/spec/json/inventory.json
+++ b/api/spec/json/inventory.json
@@ -133,6 +133,11 @@
           "name": "withGroups",
           "type": "boolean",
           "description": "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups."
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },
@@ -319,6 +324,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },
@@ -498,6 +508,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },
@@ -650,6 +665,11 @@
           "name": "withParents",
           "type": "boolean",
           "description": "Include a flat list of all parents and grandparents of the given object"
+        },
+        {
+          "name": "withLatestValues",
+          "type": "boolean",
+          "description": "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform"
         }
       ]
     },

--- a/api/spec/yaml/agents.yaml
+++ b/api/spec/yaml/agents.yaml
@@ -150,6 +150,10 @@ commands:
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
 
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+
   - name: getAgent
     description: 'Get agent'
     descriptionLong: Get an agent's managed object representation
@@ -206,6 +210,10 @@ commands:
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
+      
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
 
   - name: updateAgent
     description: 'Update agent'

--- a/api/spec/yaml/devices.yaml
+++ b/api/spec/yaml/devices.yaml
@@ -159,6 +159,10 @@ commands:
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
+      
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
 
   - name: getDevice
     description: Get device
@@ -216,6 +220,10 @@ commands:
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
+
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
 
   - name: updateDevice
     description: Update device

--- a/api/spec/yaml/inventory.yaml
+++ b/api/spec/yaml/inventory.yaml
@@ -107,6 +107,10 @@ commands:
         type: boolean
         description: When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
 
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+
   - name: count
     description: Get managed object count
     descriptionLong: Retrieve the total number of managed objects (e.g. devices, assets, etc.) registered in your tenant, or a subset based on queries.
@@ -247,6 +251,10 @@ commands:
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
+
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
 
 
   - name: findManagedObjectCollection
@@ -390,6 +398,10 @@ commands:
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
 
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+
   - name: newManagedObject
     method: POST
     path: inventory/managedObjects
@@ -499,6 +511,10 @@ commands:
       - name: withParents
         type: boolean
         description: Include a flat list of all parents and grandparents of the given object
+
+      - name: withLatestValues
+        type: boolean
+        description: (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
 
   - name: updateManagedObject
     method: PUT

--- a/pkg/cmd/agents/get/get.auto.go
+++ b/pkg/cmd/agents/get/get.auto.go
@@ -52,6 +52,7 @@ Get agent by id
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -104,6 +105,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/agents/list/list.auto.go
+++ b/pkg/cmd/agents/list/list.auto.go
@@ -76,6 +76,7 @@ Find an agent by name, then find other agents which the same type
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -135,6 +136,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/devices/get/get.auto.go
+++ b/pkg/cmd/devices/get/get.auto.go
@@ -52,6 +52,7 @@ Get device by id
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -104,6 +105,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/devices/list/list.auto.go
+++ b/pkg/cmd/devices/list/list.auto.go
@@ -77,6 +77,7 @@ Get devices with type 'c8y_MacOS' then devices with type 'c8y_Linux' (using pipe
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -136,6 +137,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/inventory/find/find.auto.go
+++ b/pkg/cmd/inventory/find/find.auto.go
@@ -72,6 +72,7 @@ Invert a given query received via piped input (stdin) by using a template
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -133,6 +134,7 @@ func (n *FindCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 
 		flags.WithCumulocityQuery(
 			[]flags.GetOption{

--- a/pkg/cmd/inventory/findbytext/findByText.auto.go
+++ b/pkg/cmd/inventory/findbytext/findByText.auto.go
@@ -59,6 +59,7 @@ Find managed objects which contain the text 'myText' and is a device (using pipe
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -114,6 +115,7 @@ func (n *FindByTextCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/inventory/get/get.auto.go
+++ b/pkg/cmd/inventory/get/get.auto.go
@@ -55,6 +55,7 @@ Get a managed object with parent references
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
 	cmd.Flags().Bool("withParents", false, "Include a flat list of all parents and grandparents of the given object")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -105,6 +106,7 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
 		flags.WithBoolValue("withParents", "withParents", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/pkg/cmd/inventory/list/list.auto.go
+++ b/pkg/cmd/inventory/list/list.auto.go
@@ -69,6 +69,7 @@ Get managed objects which have the same type as the managed object id=1234. pipe
 	cmd.Flags().Bool("withChildren", false, "Determines if children with ID and name should be returned when fetching the managed object. Set it to false to improve query performance.")
 	cmd.Flags().Bool("withChildrenCount", false, "When set to true, the returned result will contain the total number of children in the respective objects (childAdditions, childAssets and childDevices)")
 	cmd.Flags().Bool("withGroups", false, "When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.")
+	cmd.Flags().Bool("withLatestValues", false, "(FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform")
 
 	completion.WithOptions(
 		cmd,
@@ -132,6 +133,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithBoolValue("withChildren", "withChildren", ""),
 		flags.WithBoolValue("withChildrenCount", "withChildrenCount", ""),
 		flags.WithBoolValue("withGroups", "withGroups", ""),
+		flags.WithBoolValue("withLatestValues", "withLatestValues", ""),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)

--- a/tools/PSc8y/Public/Find-ByTextManagedObjectCollection.ps1
+++ b/tools/PSc8y/Public/Find-ByTextManagedObjectCollection.ps1
@@ -67,7 +67,12 @@ Find managed objects which contain the text 'myText' (using pipeline)
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Find-ManagedObjectCollection.ps1
+++ b/tools/PSc8y/Public/Find-ManagedObjectCollection.ps1
@@ -122,7 +122,12 @@ Find all managed objects with their names starting with 'roomUpperFloor_'
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-Agent.ps1
+++ b/tools/PSc8y/Public/Get-Agent.ps1
@@ -57,7 +57,12 @@ Get agent by name
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-AgentCollection.ps1
+++ b/tools/PSc8y/Public/Get-AgentCollection.ps1
@@ -112,7 +112,12 @@ Get a collection of agents with type "myType", and their names start with "senso
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-Device.ps1
+++ b/tools/PSc8y/Public/Get-Device.ps1
@@ -57,7 +57,12 @@ Get device by name
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-DeviceCollection.ps1
+++ b/tools/PSc8y/Public/Get-DeviceCollection.ps1
@@ -117,7 +117,12 @@ c8y devices list --name "sensor*" --type myType
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"

--- a/tools/PSc8y/Public/Get-ManagedObject.ps1
+++ b/tools/PSc8y/Public/Get-ManagedObject.ps1
@@ -62,7 +62,12 @@ Get a managed object with parent references
         # Include a flat list of all parents and grandparents of the given object
         [Parameter()]
         [switch]
-        $WithParents
+        $WithParents,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get"

--- a/tools/PSc8y/Public/Get-ManagedObjectCollection.ps1
+++ b/tools/PSc8y/Public/Get-ManagedObjectCollection.ps1
@@ -96,7 +96,12 @@ Get a list of managed objects by id
         # When set to true it returns additional information about the groups to which the searched managed object belongs. This results in setting the assetParents property with additional information about the groups.
         [Parameter()]
         [switch]
-        $WithGroups
+        $WithGroups,
+
+        # (FEATURE_PREVIEW) Include c8y_LatestMeasurements fragment, which contains the latest measurement values reported by the device to the platform
+        [Parameter()]
+        [switch]
+        $WithLatestValues
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Get", "Collection"


### PR DESCRIPTION
Note: The latest values is a platform feature which is currently in preview, and needs to be activated before you can use it.

Add the `--withLatestValues` flag to the following commands:

* `c8y devices list`
* `c8y agents list`
* `c8y inventory list`
* `c8y inventory find`
* `c8y inventory findByText`