### PR TITLE
fix(software versions uninstall): add softwareType flag

### DIFF
--- a/api/spec/json/softwareVersions.json
+++ b/api/spec/json/softwareVersions.json
@@ -481,6 +481,13 @@
           "description": "Software version name or id"
         },
         {
+          "name": "softwareType",
+          "type": "string",
+          "required": false,
+          "property": "c8y_SoftwareUpdate.0.softwareType",
+          "description": "Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository"
+        },
+        {
           "name": "action",
           "type": "string",
           "static": true,

--- a/api/spec/yaml/softwareVersions.yaml
+++ b/api/spec/yaml/softwareVersions.yaml
@@ -374,6 +374,12 @@ commands:
         property: c8y_SoftwareUpdate.0.version
         description: Software version name or id
 
+      - name: softwareType
+        type: string
+        required: false
+        property: c8y_SoftwareUpdate.0.softwareType
+        description: Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository
+
       - name: action
         type: string
         static: true

--- a/pkg/cmd/software/versions/uninstall/uninstall.auto.go
+++ b/pkg/cmd/software/versions/uninstall/uninstall.auto.go
@@ -48,6 +48,7 @@ Uninstall a software package version
 	cmd.Flags().StringSlice("device", []string{""}, "Device or agent where the software should be installed (accepts pipeline)")
 	cmd.Flags().String("software", "", "Software name (required)")
 	cmd.Flags().String("version", "", "Software version name or id")
+	cmd.Flags().String("softwareType", "", "Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository")
 	cmd.Flags().String("action", "delete", "Software action")
 
 	completion.WithOptions(
@@ -147,6 +148,7 @@ func (n *UninstallCmd) RunE(cmd *cobra.Command, args []string) error {
 		c8yfetcher.WithDeviceByNameFirstMatch(n.factory, args, "device", "deviceId"),
 		flags.WithStringValue("software", "c8y_SoftwareUpdate.0.name"),
 		flags.WithStringValue("version", "c8y_SoftwareUpdate.0.version"),
+		flags.WithStringValue("softwareType", "c8y_SoftwareUpdate.0.softwareType"),
 		flags.WithStringValue("action", "c8y_SoftwareUpdate.0.action"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),

--- a/tools/PSc8y/Public/Remove-SoftwareVersion.ps1
+++ b/tools/PSc8y/Public/Remove-SoftwareVersion.ps1
@@ -38,6 +38,11 @@ Uninstall a software package version
         [object[]]
         $Version,
 
+        # Software type. Leave blank to automatically set it if a matching software/version is found in the c8y software repository
+        [Parameter()]
+        [string]
+        $SoftwareType,
+
         # Software action
         [Parameter()]
         [ValidateSet('delete')]


### PR DESCRIPTION
Allow users to uninstall software which is not in the software repository by allow users to provide the required information manually (by flags).

**Example**

```sh
c8y software versions uninstall --device device001  --software packageA --softwareType apt
```