### PR TITLE
feat: add host information to the confirmation text

### DIFF
--- a/pkg/worker/generic_worker.go
+++ b/pkg/worker/generic_worker.go
@@ -180,8 +180,15 @@ func (w *GenericWorker) run(iter iterator.Iterator, commonOptions config.CommonC
 
 	maxJobs := w.GetMaxJobs()
 	tenantName := ""
+	targetInfo := ""
 	if w.Client != nil {
 		tenantName = w.Client.TenantName
+		// Include tenant FQDN in the confirmation message
+		if w.Client.BaseURL != nil {
+			targetInfo = fmt.Sprintf("host %s (tenant %s)", w.Client.GetHostname(), tenantName)
+		} else {
+			targetInfo = fmt.Sprintf("tenant %s", tenantName)
+		}
 	}
 	w.Logger.Infof("Max jobs: %d", maxJobs)
 
@@ -259,7 +266,7 @@ func (w *GenericWorker) run(iter iterator.Iterator, commonOptions config.CommonC
 					operation = fmt.Sprintf("%s %s", os.Args[2], strings.TrimRight(os.Args[1], "s"))
 				}
 				promptMessage, _ := batchOptions.GetConfirmationMessage(operation, value, input)
-				confirmResult, err := prompt.Confirm(fmt.Sprintf("(job: %d)", jobID), promptMessage, "tenant "+tenantName, prompt.ConfirmYes.String(), false)
+				confirmResult, err := prompt.Confirm(fmt.Sprintf("(job: %d)", jobID), promptMessage, targetInfo, prompt.ConfirmYes.String(), false)
 
 				switch confirmResult {
 				case prompt.ConfirmYesToAll:

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -219,8 +219,15 @@ func (w *Worker) runBatched(requestIterator *requestiterator.RequestIterator, co
 
 	maxJobs := w.GetMaxJobs()
 	tenantName := ""
+	targetInfo := ""
 	if w.client != nil {
 		tenantName = w.client.TenantName
+		// Include tenant FQDN in the confirmation message
+		if w.client.BaseURL != nil {
+			targetInfo = fmt.Sprintf("host %s (tenant %s)", w.client.GetHostname(), tenantName)
+		} else {
+			targetInfo = fmt.Sprintf("tenant %s", tenantName)
+		}
 	}
 	w.logger.Infof("Max jobs: %d", maxJobs)
 
@@ -297,7 +304,7 @@ func (w *Worker) runBatched(requestIterator *requestiterator.RequestIterator, co
 					operation = fmt.Sprintf("%s %s", os.Args[2], strings.TrimRight(os.Args[1], "s"))
 				}
 				promptMessage, _ := w.getConfirmationMessage(operation, request, input)
-				confirmResult, err := prompt.Confirm(fmt.Sprintf("(job: %d)", jobID), promptMessage, "tenant "+tenantName, prompt.ConfirmYes.String(), false)
+				confirmResult, err := prompt.Confirm(fmt.Sprintf("(job: %d)", jobID), promptMessage, targetInfo, prompt.ConfirmYes.String(), false)
 
 				switch confirmResult {
 				case prompt.ConfirmYesToAll:


### PR DESCRIPTION
Add host information to the confirmation text to help users identify if they are in the correct context before issuing a command. Resolves https://github.com/reubenmiller/go-c8y-cli/issues/485

**Example**

```
$ c8y devices create --name rmi_hello1 --confirm
? Confirm (job: 1)
Create device on host example.c8y.io (tenant t12345)
[y] Yes  [a] Yes to All  [n] No  [l] No to All (y) 
```