### PR TITLE
feat: add URL encode/decode helpers

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/templates.md
+++ b/docs/go-c8y-cli/docs/concepts/templates.md
@@ -191,6 +191,9 @@ Below lists the additional functions which are available in jsonnet template fil
 |_.NowNano([offset='0s'])| Generate ISO8601 date (with nanosecond resolution) from a relative date or date string | `2021-05-09T07:48:33.0030745Z` |
 |_.Name([prefix=''],[postfix=''])| Generate a random name with an optional prefix and postfix | `GfheJoa;Ktx,F56s` |
 |_.Password([length=32])| Generate a randomized password of a specified length | `NlXYngK;bj!xeOvhpydJ4VIG6HuDcLBR`  |
+|_.PasswordUrlSafe([length=32])| Generate a randomized password of a specified length which is URL friendly | `uWhlijOVPz_mknJ4LrKyb0SR.GNoxDBA` |
+|_.UrlEncode([value='')| Encode a string to a URL compatible value | `foo#@%bar` => `foo%23%40%25bar`  |
+|_.UrlDecode([value='')| Decode a URL string | `foo%23%40%25bar` => `foo#@%bar`  |
 |_.Hex([length=16])| Random Hexadecimal string of a given length. | `8b7e0736a5a6ed80` |
 |_.Char([length=16])| Random string with only character a-zA-Z of a given length  | `exxUQqCDFwRHpUog` |
 |_.Digit([length=16])| Random 0 padded string with only digits | `0261177197719716` |

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -65,6 +65,33 @@ func registerNativeFunctions(vm *jsonnet.VM) {
 	})
 
 	vm.NativeFunction(&jsonnet.NativeFunction{
+		Name:   "PasswordUrlSafe",
+		Params: ast.Identifiers{"length"},
+		Func: func(parameters []interface{}) (interface{}, error) {
+			length := getIntParameter(parameters, 0)
+			return randdata.PasswordURLSafe(int(length)), nil
+		},
+	})
+
+	vm.NativeFunction(&jsonnet.NativeFunction{
+		Name:   "UrlEncode",
+		Params: ast.Identifiers{"value"},
+		Func: func(parameters []interface{}) (interface{}, error) {
+			value := getStringParameter(parameters, 0)
+			return url.QueryEscape(value), nil
+		},
+	})
+
+	vm.NativeFunction(&jsonnet.NativeFunction{
+		Name:   "UrlDecode",
+		Params: ast.Identifiers{"value"},
+		Func: func(parameters []interface{}) (interface{}, error) {
+			value := getStringParameter(parameters, 0)
+			return url.QueryUnescape(value)
+		},
+	})
+
+	vm.NativeFunction(&jsonnet.NativeFunction{
 		Name:   "Bool",
 		Params: ast.Identifiers{},
 		Func: func(parameters []interface{}) (interface{}, error) {
@@ -427,6 +454,9 @@ func evaluateJsonnet(imports string, snippets ...string) (string, error) {
 		GetURLPath(url):: std.native("GetURLPath")(url),
 		GetURLHost(url):: std.native("GetURLHost")(url),
 		Password(length=32):: std.native("Password")(length),
+		PasswordUrlSafe(length=32):: std.native("PasswordUrlSafe")(length),
+		UrlEncode(value=""):: std.native("UrlEncode")(value),
+		UrlDecode(value=""):: std.native("UrlDecode")(value),
 		Now(offset='0s'):: std.native("Now")(std.toString(offset)),
 		NowNano(offset='0s'):: std.native("NowNano")(std.toString(offset)),
 		Bool():: std.native("Bool"),

--- a/pkg/randdata/password.go
+++ b/pkg/randdata/password.go
@@ -25,3 +25,23 @@ func Password(total int) string {
 
 	return ""
 }
+
+func PasswordURLSafe(total int) string {
+	if total <= 4 {
+		total = 32
+	}
+	passwordGen, err := password.NewGenerator(&password.GeneratorInput{
+		// use url query parameter friendly values
+		Symbols: "-._~",
+	})
+
+	if err != nil {
+		return ""
+	}
+
+	if res, err := passwordGen.Generate(total, 2, 2, false, false); err == nil {
+		return res
+	}
+
+	return ""
+}

--- a/tests/manual/template/template_execute.yaml
+++ b/tests/manual/template/template_execute.yaml
@@ -301,3 +301,22 @@ tests:
           "name": "testdevice",
           "prop2": false
         }
+
+  It suports encoding a string to a URL compatible string:
+    command: |
+      c8y template execute --template "_.UrlEncode('foo#@%bar')"
+    exit-code: 0
+    stdout:
+      exactly: foo%23%40%25bar
+
+  It suports decoding a URL encoded string to a string:
+    command: |
+      c8y template execute --template "_.UrlDecode('foo%23%40%25bar')"
+    exit-code: 0
+    stdout:
+      exactly: foo#@%bar
+  
+  It creates a URL safe password which does not require any encoding:
+    command: |
+      c8y template execute --template "_.PasswordUrlSafe(12)"
+    exit-code: 0


### PR DESCRIPTION
Add new template functions to make it easier to generate values which are URL Query Parameter friendly.

```sh
# Create password that does not require URL encoding
c8y template execute --template "_.PasswordUrlSafe(32)"
# => gOw_lmHqtR4iTCXvy~P3bfkhdDQNeVMF

# Encode a string using URL escaping
c8y template execute --template "_.UrlEncode('foo#@%bar')"
# => foo%23%40%25bar

# Decode a URL encoded string
c8y template execute --template '_.UrlDecode("foo%23%40%25bar")'
# => foo#@%bar
```