### PR TITLE
docs: add examples for downloading inventory binaries using template variables

### DIFF
--- a/api/spec/json/binaries.json
+++ b/api/spec/json/binaries.json
@@ -91,7 +91,7 @@
     {
       "name": "download",
       "description": "Download binary",
-      "descriptionLong": "Download a binary stored in Cumulocity and display it on the console. \n\nFor non text based binaries or if the output should be saved to file, the output parameter should be used to write the file directly to a local file.\n",
+      "descriptionLong": "Download a binary stored in Cumulocity and display it on the console. \n\nFor non text based binaries or if the output should be saved to file, the output parameter should be used to write the file directly to a local file.\n\nWhen downloading a binary it is useful to use the outputFileRaw global parameter and to use one of the following references:\n\n* {filename} - Filename found in the Content-Disposition response header\n* {id} - An id like value found in the request path (/inventory/binaries/12345 => 12345)\n* {basename} - The last path section of the request path (/some/nested/url/withafilename.json => withafilename.json)\n",
       "method": "GET",
       "path": "/inventory/binaries/{id}",
       "accept": "*/*",
@@ -134,6 +134,11 @@
           {
             "description": "Get a binary and save it to a file",
             "command": "c8y binaries get --id 12345 --outputFileRaw \"./download-binary1.txt\""
+          },
+          {
+            "description": "Download a list of binaries and save the files to the current working directory",
+            "command": "c8y binaries list | c8y binaries get --outputFileRaw \"download-{id}-{filename}\" > /dev/null",
+            "skipTest": true
           }
         ]
       },

--- a/api/spec/yaml/binaries.yaml
+++ b/api/spec/yaml/binaries.yaml
@@ -77,6 +77,12 @@ commands:
       Download a binary stored in Cumulocity and display it on the console. 
 
       For non text based binaries or if the output should be saved to file, the output parameter should be used to write the file directly to a local file.
+
+      When downloading a binary it is useful to use the outputFileRaw global parameter and to use one of the following references:
+
+      * {filename} - Filename found in the Content-Disposition response header
+      * {id} - An id like value found in the request path (/inventory/binaries/12345 => 12345)
+      * {basename} - The last path section of the request path (/some/nested/url/withafilename.json => withafilename.json)
     method: GET
     path: /inventory/binaries/{id}
     accept: '*/*'
@@ -110,6 +116,10 @@ commands:
 
         - description: Get a binary and save it to a file
           command: c8y binaries get --id 12345 --outputFileRaw "./download-binary1.txt"
+
+        - description: Download a list of binaries and save the files to the current working directory
+          command: c8y binaries list | c8y binaries get --outputFileRaw "download-{id}-{filename}" > /dev/null
+          skipTest: true
     pathParameters:
       - name: id
         type: id[]

--- a/pkg/cmd/binaries/get/get.auto.go
+++ b/pkg/cmd/binaries/get/get.auto.go
@@ -36,6 +36,12 @@ func NewGetCmd(f *cmdutil.Factory) *GetCmd {
 		Long: `Download a binary stored in Cumulocity and display it on the console. 
 
 For non text based binaries or if the output should be saved to file, the output parameter should be used to write the file directly to a local file.
+
+When downloading a binary it is useful to use the outputFileRaw global parameter and to use one of the following references:
+
+* {filename} - Filename found in the Content-Disposition response header
+* {id} - An id like value found in the request path (/inventory/binaries/12345 => 12345)
+* {basename} - The last path section of the request path (/some/nested/url/withafilename.json => withafilename.json)
 `,
 		Example: heredoc.Doc(`
 $ c8y binaries get --id 12345
@@ -43,6 +49,9 @@ Get a binary and display the contents on the console
 
 $ c8y binaries get --id 12345 --outputFileRaw "./download-binary1.txt"
 Get a binary and save it to a file
+
+$ c8y binaries list | c8y binaries get --outputFileRaw "download-{id}-{filename}" > /dev/null
+Download a list of binaries and save the files to the current working directory
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil

--- a/tests/auto/binaries/tests/binaries_get.yaml
+++ b/tests/auto/binaries/tests/binaries_get.yaml
@@ -1,4 +1,12 @@
 tests:
+    binaries_get_Download a list of binaries and save the files to the current working directory:
+        command: $TEST_SHELL -c 'c8y binaries list | c8y binaries get --outputFileRaw "download-{id}-{filename}" > /dev/null'
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                method: GET
+                path: /inventory/binaries/{id}
     binaries_get_Get a binary and display the contents on the console:
         command: c8y binaries get --id 12345
         exit-code: 0

--- a/tools/PSc8y/Public/Get-Binary.ps1
+++ b/tools/PSc8y/Public/Get-Binary.ps1
@@ -9,6 +9,12 @@ Download a binary stored in Cumulocity and display it on the console.
 
 For non text based binaries or if the output should be saved to file, the output parameter should be used to write the file directly to a local file.
 
+When downloading a binary it is useful to use the outputFileRaw global parameter and to use one of the following references:
+
+* {filename} - Filename found in the Content-Disposition response header
+* {id} - An id like value found in the request path (/inventory/binaries/12345 => 12345)
+* {basename} - The last path section of the request path (/some/nested/url/withafilename.json => withafilename.json)
+
 
 .LINK
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/binaries_get


### PR DESCRIPTION
Add examples for downloading inventory binaries and to save the binary using the meta information from the binary object itself.

**Example**

```
$ c8y binaries list | c8y binaries get --outputFileRaw "download-{id}-{filename}" > /dev/null
Download a list of binaries and save the files to the current working directory
```