### PR TITLE
feat: create session files that are only readable by the current user

### DIFF
--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -377,7 +377,7 @@ func (n *CmdCreate) writeSessionFile(outputDir, outputFile string, session c8yse
 	}
 	log.Debugf("output file: %s", outputPath)
 
-	if err := os.WriteFile(path.Join(outputDir, outputFile), data, 0644); err != nil {
+	if err := os.WriteFile(path.Join(outputDir, outputFile), data, 0600); err != nil {
 		return errors.Wrap(err, "failed to write to file")
 	}
 	return nil


### PR DESCRIPTION
Set unix permission `0o600` when writing new session files instead of `0o644` (to align with permissions used by private ssh keys).

Suggestion was mentioned in https://github.com/reubenmiller/go-c8y-cli/issues/493