### PR TITLE
feat: enable session encryption by default

### DIFF
--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -482,7 +482,7 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsStorageStoreToken, true),
 		WithBindEnv(SettingsModeConfirmation, "PUT POST DELETE"),
 
-		WithBindEnv(SettingsEncryptionEnabled, false),
+		WithBindEnv(SettingsEncryptionEnabled, true),
 		WithBindEnv(SettingsActivityLogEnabled, true),
 		WithBindEnv(SettingsActivityLogPath, path.Join(c.GetSessionHomeDir(), ActivityLogDirName)),
 		WithBindEnv(SettingsActivityLogMethodFilter, "GET PUT POST DELETE"),


### PR DESCRIPTION
Enable encrypted storage of sensitive information within the session file by default.

If you don't wish to have session encryption, then you can also disable it per session, or disable it globally in your shell profile using:

```
export  C8Y_SETTINGS_ENCRYPTION_ENABLED='false'
```

The preference for enabling encryption by default was mentioned in https://github.com/reubenmiller/go-c8y-cli/issues/493