### PR TITLE
docs: fix rendering of remoteaccess server man page

### DIFF
--- a/docs/go-c8y-cli/docs/cli/c8y/remoteaccess/c8y_remoteaccess_server.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/remoteaccess/c8y_remoteaccess_server.md
@@ -13,16 +13,16 @@ connect to your device with ssh without having to manually launch the proxy your
 
 To do this add the following configuration to your device.
 
----
-Host \{\{device}}
-	User \{\{device_username}}
+````
+Host [device]
+	User [device_username]
 	PreferredAuthentications publickey
-	IdentityFile \{\{identify_file}}
+	IdentityFile [identify_file]
 	ServerAliveInterval 120
 	StrictHostKeyChecking no
 	UserKnownHostsFile /dev/null
 	ProxyCommand c8y remoteaccess server --device %n --listen -
----
+````
 
 Note: When using the "--browser" flag, by default the URL scheme (e.g. http, https) will be
 auto detected based on the Remote Access configuration's name. For example, if the configuration

--- a/pkg/cmd/remoteaccess/server/server.manual.go
+++ b/pkg/cmd/remoteaccess/server/server.manual.go
@@ -40,7 +40,7 @@ func NewCmdServer(f *cmdutil.Factory) *CmdServer {
 	cmd := &cobra.Command{
 		Use:   "server",
 		Short: "Start a local proxy server",
-		Long: heredoc.Doc(`
+		Long: heredoc.Docf(`
 			Start a local proxy server
 
 			You can add use the remote access local proxy within your ssh config file, to use it to
@@ -48,22 +48,22 @@ func NewCmdServer(f *cmdutil.Factory) *CmdServer {
 
 			To do this add the following configuration to your device.
 
-			---
-			Host {{device}}
-				User {{device_username}}
+			%[1]s
+			Host [device]
+				User [device_username]
 				PreferredAuthentications publickey
-				IdentityFile {{identify_file}}
+				IdentityFile [identify_file]
 				ServerAliveInterval 120
 				StrictHostKeyChecking no
 				UserKnownHostsFile /dev/null
-				ProxyCommand c8y remoteaccess server --device %n --listen -
-			---
+				ProxyCommand c8y remoteaccess server --device %%n --listen -
+			%[1]s
 
 			Note: When using the "--browser" flag, by default the URL scheme (e.g. http, https) will be
 			auto detected based on the Remote Access configuration's name. For example, if the configuration
 			name has the "https:" prefix, then http will be used, otherwise http will be used. This aligns
 			with the naming convention used in https://github.com/Cumulocity-IoT/cumulocity-remote-access-cloud-http-proxy
-		`),
+		`, "````"),
 		Example: heredoc.Doc(`
 			$ c8y remoteaccess server --device 12345
 			Start a local proxy server on a random local port


### PR DESCRIPTION
Fixing a rendering issue on the `c8y remoteaccess server` man page due to usage of non-markdown characters within the help text.

Link:
* https://goc8ycli.netlify.app/docs/cli/c8y/remoteaccess/c8y_remoteaccess_server/

**Example**

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/d0911742-e4e7-4d62-9975-1b0c6f242a72" />
