### PR TITLE
fix(jsonnet): check if value is an object before accessing nested properties

### DIFF
--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -500,7 +500,9 @@ func evaluateJsonnet(imports string, snippets ...string) (string, error) {
 				},
 		Get(o, f, default=null)::
 			local get_(o, ks) =
-				if ! std.objectHas(o, ks[0]) then
+				if std.type(o) != 'object' then
+					default
+				else if ! std.objectHas(o, ks[0]) then
 					default
 				else if std.length(ks) == 1 then
 					o[ks[0]]
@@ -509,7 +511,9 @@ func evaluateJsonnet(imports string, snippets ...string) (string, error) {
 				get_(o, std.split(f, '.')),
 		Has(o, f)::
 			local has_(o, ks) =
-				if ! std.objectHas(o, ks[0]) then
+				if std.type(o) != 'object' then
+					false
+				else if ! std.objectHas(o, ks[0]) then
 					false
 				else if std.length(ks) == 1 then
 					true

--- a/tests/manual/template/template_get.yml
+++ b/tests/manual/template/template_get.yml
@@ -41,3 +41,50 @@ tests:
             "dummy": 2
           }
         }
+
+  It safely access input if when there is no piped input:
+    command: |
+        c8y template execute --template "_.Get(input.value, 'nestedProp2', {dummy: 2})" -c=false -o json
+    stdout:
+      exactly: |
+        {
+          "dummy": 2
+        }
+
+  It safely access nested properties of input if when there is no piped input:
+    command: |
+        c8y template execute --template "_.Get(input, 'value.nestedProp2', {dummy: 2})" -c=false -o json
+    stdout:
+      exactly: |
+        {
+          "dummy": 2
+        }
+
+  It safely access nested properties of input if when there is piped input:
+    command: |
+        c8y template execute --template "{nestedProp2: 1}" \
+        | c8y template execute --template "{output: _.Get(input, 'value.nestedProp2', {dummy: 2})}" -c=false -o json
+    stdout:
+      exactly: |
+        {
+          "output": 1
+        }
+  
+  It safely checks for nested properties when there is piped input:
+    command: |
+        c8y template execute --template "{nestedProp2: 1}" \
+        | c8y template execute --template "{output: _.Has(input, 'value.nestedProp2')}" -c=false -o json
+    stdout:
+      exactly: |
+        {
+          "output": true
+        }
+
+  It safely checks for nested properties when there is no piped input:
+    command: |
+        c8y template execute --template "{output: _.Has(input, 'value.nestedProp2')}" -c=false -o json
+    stdout:
+      exactly: |
+        {
+          "output": false
+        }


### PR DESCRIPTION
Fix the handling of the following jsonnet template helpers where they would fail if the given value was not an object (or anywhere along the nested key path).

* `_.Get()`
* `_.Has()`

**Before**

The following commands would throw an error:

```sh
$ c8y template execute --template "_.Get(input, 'value.nestedProp2', {dummy: 2})" -o json

2025-04-30T09:23:04.096+0200	ERROR	commandError: failed to merge json. Could not create json from template. Error: RUNTIME ERROR: Unexpected type null, expected object
	<std>:1545:5-33	function <anonymous>
	file:53:9-32	function <get_>
	file:58:5-27	function <get_>
	file:59:4-30	function <anonymous>
	file:94:1-46	$
	During evaluation

Hint:
Some shells are sensitive about double quotes, try escaping any double quotes:

	--template "{\"name\": \"my example text\"}"

Alternatively, jsonnet is more relaxed than json so you can use single quotes:

	--template "{name: 'my example text'}"
```

**After**

```sh
$ c8y template execute --template "_.Get(input, 'value.nestedProp2', {dummy: 2})" -o json

{
  "dummy": 2
}
```
