### PR TITLE
fix(ui plugins): fix incorrect reference to path template variable

### DIFF
--- a/api/spec/json/uiPluginsVersions.json
+++ b/api/spec/json/uiPluginsVersions.json
@@ -127,7 +127,7 @@
       "description": "Create a new version of a plugin",
       "descriptionLong": "Uploaded version and tags can only contain upper and lower case letters, integers and ., +, -. Other characters are prohibited.",
       "method": "POST",
-      "path": "/application/applications/{application}/versions",
+      "path": "/application/applications/{plugin}/versions",
       "accept": "application/json",
       "collectionProperty": "-",
       "alias": {
@@ -211,9 +211,6 @@
           "type": "json_custom",
           "description": "data"
         }
-      ],
-      "bodyRequiredKeys": [
-        "tags"
       ]
     },
     {

--- a/api/spec/yaml/uiPluginsVersions.yaml
+++ b/api/spec/yaml/uiPluginsVersions.yaml
@@ -95,7 +95,7 @@ commands:
     description: Create a new version of a plugin
     descriptionLong: Uploaded version and tags can only contain upper and lower case letters, integers and ., +, -. Other characters are prohibited.
     method: POST
-    path: /application/applications/{application}/versions
+    path: /application/applications/{plugin}/versions
     accept: application/json
     collectionProperty: "-"
     alias:
@@ -161,8 +161,6 @@ commands:
         type: json_custom
         description: data
 
-    bodyRequiredKeys:
-      - tags
 
   - name: delete
     description: Delete a specific version of a plugin

--- a/pkg/cmd/ui/plugins/versions/create/create.auto.go
+++ b/pkg/cmd/ui/plugins/versions/create/create.auto.go
@@ -156,14 +156,13 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		cmd,
 		body,
 		inputIterators,
-		flags.WithRequiredProperties("tags"),
 	)
 	if err != nil {
 		return cmderrors.NewUserError(err)
 	}
 
 	// path parameters
-	path := flags.NewStringTemplate("/application/applications/{application}/versions")
+	path := flags.NewStringTemplate("/application/applications/{plugin}/versions")
 	err = flags.WithPathParameters(
 		cmd,
 		path,

--- a/tests/auto/uipluginsversions/tests/ui/plugins/versions_create.yaml
+++ b/tests/auto/uipluginsversions/tests/ui/plugins/versions_create.yaml
@@ -6,4 +6,4 @@ tests:
         stdout:
             json:
                 method: POST
-                path: /application/applications/{application}/versions
+                path: /application/applications/1234/versions


### PR DESCRIPTION
Fix bugs in the `c8y ui plugins versions create` command as highlighted in #498.

* Fix incorrect reference to the plugin variable in the path template
* Incorrect required body parameters as FormData is being used instead of a conventional body

Resolves #498