### PR TITLE
fix: handling of custom header values when adding to outgoing request

### DIFF
--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -142,6 +142,12 @@ func WithHeaders(cmd *cobra.Command, header http.Header, inputIterators *Request
 				for key, val := range v {
 					header.Add(key, val)
 				}
+			case map[string][]string:
+				for key, values := range v {
+					for _, val := range values {
+						header.Add(key, val)
+					}
+				}
 			default:
 				headerValue := fmt.Sprintf("%v", value)
 				header.Add(name, headerValue)

--- a/tests/manual/common/common.yaml
+++ b/tests/manual/common/common.yaml
@@ -34,3 +34,14 @@ tests:
         method: GET
         path: /event/events
         pathEncoded: /event/events?fragmentType=test1&pageSize=21
+
+  It supports custom header values:
+    command: >
+      c8y events create -n --device 1 --text "Example event" --type "c8y_Example" --header "X-Cumulocity-Processing-Mode: TRANSIENT, X-Hello: value" --dry --dryFormat json
+    exit-code: 0
+    stdout:
+      json:
+        method: POST
+        path: /event/events
+        headers.X-Cumulocity-Processing-Mode: TRANSIENT
+        headers.X-Hello: value


### PR DESCRIPTION
Fix the handling of custom headers provided via the `--header` global option where the values were incorrectly being parsed as a map.

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/500