### PR TITLE
ci: free up disk space for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,19 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      # free disk space due to avoid runner errors when it runs out of space
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Free up disk space in the runner during a release as a release workflow run failed due to an out of disk space error:
* https://github.com/reubenmiller/go-c8y-cli/actions/runs/15018014174