### PR TITLE
fix(registration): add confirmation prompts to device registration commands

### DIFF
--- a/pkg/cmd/deviceregistration/registerBulk/register-basic.manual.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-basic.manual.go
@@ -67,6 +67,9 @@ func NewRegisterBasicCmd(f *cmdutil.Factory) *RegisterBasicCmd {
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true, "externalId", "name", "id"),
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("POST"),
 	)
 
 	// Required flags

--- a/pkg/cmd/deviceregistration/registerBulk/register-ca.manual.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-ca.manual.go
@@ -72,6 +72,9 @@ func NewRegisterCumulocityCACmd(f *cmdutil.Factory) *RegisterCumulocityCACmd {
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true, "externalId", "name", "id"),
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("POST"),
 	)
 
 	// Required flags

--- a/pkg/cmd/deviceregistration/registerBulk/register-external-ca.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-external-ca.go
@@ -69,6 +69,9 @@ func NewRegisterExternalCACmd(f *cmdutil.Factory) *RegisterExternalCACmd {
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true, "externalId", "name", "id"),
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("POST"),
 	)
 
 	// Required flags


### PR DESCRIPTION
Add missing confirmation prompts to the device registration commands.

Affected commands:

* `c8y deviceregistration register-basic`
* `c8y deviceregistration register-ca`
* `c8y deviceregistration register-external-ca`