### PR TITLE
fix(certificate-authority): add confirmation prompts to certificate-authority commands

### DIFF
--- a/pkg/cmd/devicemanagement/certificate_authority/create/create.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/create/create.manual.go
@@ -8,6 +8,8 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
 )
@@ -63,6 +65,16 @@ Create new certificate authority but disable it
 		completion.WithValidateSet("status", "ENABLED", "DISABLED"),
 	)
 
+	flags.WithOptions(
+		cmd,
+		flags.WithProcessingMode(),
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("POST"),
+	)
+
 	// Required flags
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
@@ -81,21 +93,24 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cert, err := client.CertificateAuthority.Create(context.Background(), c8y.CertificateAuthorityOptions{
-		AutoRegistration: n.AutoRegistrationEnabled,
-		Status:           n.Status,
+	return n.factory.RunWithGenericWorkers(cmd, nil, nil, func(j worker.Job) (any, error) {
+		cert, err := client.CertificateAuthority.Create(context.Background(), c8y.CertificateAuthorityOptions{
+			AutoRegistration: n.AutoRegistrationEnabled,
+			Status:           n.Status,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if cfg.DryRun() {
+			return nil, nil
+		}
+
+		b, err := json.Marshal(cert)
+		if err != nil {
+			return nil, err
+		}
+
+		err = n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
+		return nil, err
 	})
-	if err != nil {
-		return err
-	}
-	if cfg.DryRun() {
-		return nil
-	}
-
-	b, err := json.Marshal(cert)
-	if err != nil {
-		return err
-	}
-
-	return n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/delete/delete.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/delete/delete.manual.go
@@ -7,6 +7,8 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +41,13 @@ Delete certificate authority
 		RunE: ccmd.RunE,
 	}
 
+	flags.WithOptions(
+		cmd,
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("DELETE"),
+	)
+
 	cmd.SilenceUsage = true
 
 	// Required flags
@@ -61,13 +70,15 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, err = client.CertificateAuthority.Delete(context.Background(), "")
-	if err != nil {
-		return err
-	}
-	if cfg.DryRun() {
-		return nil
-	}
-	fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Deleted certificate-authority for tenant %s\n", cs.SuccessIconWithColor(cs.Red), client.GetTenantName(context.Background()))
-	return nil
+	return n.factory.RunWithGenericWorkers(cmd, nil, nil, func(j worker.Job) (any, error) {
+		_, err = client.CertificateAuthority.Delete(context.Background(), "")
+		if err != nil {
+			return nil, err
+		}
+		if cfg.DryRun() {
+			return nil, nil
+		}
+		_, err = fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Deleted certificate-authority for tenant %s\n", cs.SuccessIconWithColor(cs.Red), client.GetTenantName(context.Background()))
+		return nil, err
+	})
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/get/get.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/get/get.manual.go
@@ -7,6 +7,8 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +41,13 @@ Get certificate authority to allow auto registration
 		RunE: ccmd.RunE,
 	}
 
+	flags.WithOptions(
+		cmd,
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("GET"),
+	)
+
 	cmd.SilenceUsage = true
 
 	// Required flags
@@ -60,18 +69,21 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cert, err := client.CertificateAuthority.Get(context.Background())
-	if err != nil {
-		return err
-	}
-	if cfg.DryRun() {
-		return nil
-	}
+	return n.factory.RunWithGenericWorkers(cmd, nil, nil, func(j worker.Job) (any, error) {
+		cert, err := client.CertificateAuthority.Get(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		if cfg.DryRun() {
+			return nil, nil
+		}
 
-	b, err := json.Marshal(cert)
-	if err != nil {
-		return err
-	}
+		b, err := json.Marshal(cert)
+		if err != nil {
+			return nil, err
+		}
 
-	return n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
+		err = n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
+		return nil, err
+	})
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/update/update.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/update/update.manual.go
@@ -8,6 +8,8 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
 )
@@ -54,6 +56,16 @@ Disable certificate authority
 		completion.WithValidateSet("status", "ENABLED", "DISABLED"),
 	)
 
+	flags.WithOptions(
+		cmd,
+		flags.WithProcessingMode(),
+		flags.WithData(),
+		f.WithTemplateFlag(cmd),
+
+		// Enable confirmation prompts
+		flags.WithSemanticMethod("PUT"),
+	)
+
 	// Required flags
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
@@ -83,18 +95,21 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		certOptions.WithAutoRegistration(n.AutoRegistrationEnabled)
 	}
 
-	cert, _, err := client.CertificateAuthority.Update(context.Background(), "", certOptions)
-	if err != nil {
-		return err
-	}
-	if cfg.DryRun() {
-		return nil
-	}
+	return n.factory.RunWithGenericWorkers(cmd, nil, nil, func(j worker.Job) (any, error) {
+		cert, _, err := client.CertificateAuthority.Update(context.Background(), "", certOptions)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.DryRun() {
+			return nil, nil
+		}
 
-	b, err := json.Marshal(cert)
-	if err != nil {
-		return err
-	}
+		b, err := json.Marshal(cert)
+		if err != nil {
+			return nil, err
+		}
 
-	return n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
+		err = n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
+		return nil, err
+	})
 }

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -222,6 +222,11 @@ func (f *Factory) RunWithGenericWorkers(cmd *cobra.Command, inputIterators *flag
 		return err
 	}
 
+	// set a default run once iterator if one is not defined
+	if iter == nil {
+		iter = iterator.NewRunOnceIterator()
+	}
+
 	activityLogger, err := f.ActivityLogger()
 	if err != nil {
 		return err
@@ -260,6 +265,11 @@ func (f *Factory) RunSequentiallyWithGenericWorkers(cmd *cobra.Command, iter ite
 	activityLogger, err := f.ActivityLogger()
 	if err != nil {
 		return err
+	}
+
+	// set a default run once iterator if one is not defined
+	if iter == nil {
+		iter = iterator.NewRunOnceIterator()
 	}
 
 	w, err := worker.NewGenericWorker(log, cfg, f.IOStreams, client, activityLogger, runFunc, f.CheckPostCommandError)

--- a/pkg/iterator/repeat.go
+++ b/pkg/iterator/repeat.go
@@ -41,3 +41,11 @@ func NewRepeatIterator(value string, n int64) *RepeatIterator {
 		endIndex: n,
 	}
 }
+
+// NewRunOnceIterator creates a simple iterator that only runs once
+func NewRunOnceIterator() *RepeatIterator {
+	return &RepeatIterator{
+		value:    "",
+		endIndex: 1,
+	}
+}

--- a/pkg/worker/generic_worker.go
+++ b/pkg/worker/generic_worker.go
@@ -92,11 +92,6 @@ type Job struct {
 }
 
 func (w *GenericWorker) RunSequentially(cmd *cobra.Command, iter iterator.Iterator, inputIterators *flags.RequestInputIterators) error {
-	// TODO: How does an unbound iterator get caught here?
-	if inputIterators == nil {
-		return fmt.Errorf("missing input iterators")
-	}
-
 	// get common options and batch settings
 	commonOptions, err := w.Config.GetOutputCommonOptions(cmd)
 	if err != nil {
@@ -109,7 +104,9 @@ func (w *GenericWorker) RunSequentially(cmd *cobra.Command, iter iterator.Iterat
 	}
 
 	// Configure post actions
-	batchOptions.PostActions = inputIterators.PipeOptions.PostActions
+	if inputIterators != nil {
+		batchOptions.PostActions = inputIterators.PipeOptions.PostActions
+	}
 
 	out, input, err := iter.GetNext()
 	if err != nil {
@@ -128,11 +125,6 @@ func (w *GenericWorker) RunSequentially(cmd *cobra.Command, iter iterator.Iterat
 }
 
 func (w *GenericWorker) Run(cmd *cobra.Command, iter iterator.Iterator, inputIterators *flags.RequestInputIterators) error {
-	// TODO: How does an unbound iterator get caught here?
-	if inputIterators == nil {
-		return fmt.Errorf("missing input iterators")
-	}
-
 	// get common options and batch settings
 	commonOptions, err := w.Config.GetOutputCommonOptions(cmd)
 	if err != nil {
@@ -145,7 +137,9 @@ func (w *GenericWorker) Run(cmd *cobra.Command, iter iterator.Iterator, inputIte
 	}
 
 	// Configure post actions
-	batchOptions.PostActions = inputIterators.PipeOptions.PostActions
+	if inputIterators != nil {
+		batchOptions.PostActions = inputIterators.PipeOptions.PostActions
+	}
 
 	return w.run(iter, commonOptions, *batchOptions)
 }


### PR DESCRIPTION
Add missing confirmation prompts for the certificate-authority commands so the commands are consistent with all other go-c8y-cli confirmation behaviour.

Affected commands:

* `c8y devicemanagement certificate-authority create`
* `c8y devicemanagement certificate-authority delete`
* `c8y devicemanagement certificate-authority get`
* `c8y devicemanagement certificate-authority update`
