### PR TITLE
feat: support complex non-json output from jsonnet templates

### DIFF
--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -639,6 +639,9 @@ func (f *Factory) WriteOutputWithRows(output []byte, params OutputContext, commo
 			logg.Infof("Unfiltered array size. len=%d", unfilteredSize)
 		}
 
+		// Trim space from json object/array output
+		trimSpaceFromOutput := isJSONResponse
+
 		// Apply output template (before the data is processed as the template can transform text to json or other way around)
 		if commonOptions.HasOutputTemplate() {
 			var tempBody []byte
@@ -659,14 +662,16 @@ func (f *Factory) WriteOutputWithRows(output []byte, params OutputContext, commo
 				output = pretty.Ugly(tmplOutput)
 				outputJSON = gjson.ParseBytes(output)
 			} else {
-				isJSONResponse = false
-				// TODO: Is removing the quotes doing too much, what happens if someone is building csv, and it using quotes around some fields?
-				// e.g. `"my value",100`, that would get transformed to `my value",100`
-				// Trim any quotes wrapping the values
-				tmplOutput = bytes.TrimSpace(tmplOutput)
+				// Preserve output
+				trimSpaceFromOutput = false
 
-				output = pretty.Ugly(bytes.Trim(tmplOutput, "\""))
-				outputJSON = gjson.ParseBytes([]byte(""))
+				// Decode output
+				if parsedOutput := gjson.ParseBytes(tmplOutput); parsedOutput.Exists() && parsedOutput.Type == gjson.String {
+					output = []byte(parsedOutput.Str)
+				} else {
+					output = tmplOutput
+				}
+				isJSONResponse = false
 			}
 		}
 
@@ -771,7 +776,7 @@ func (f *Factory) WriteOutputWithRows(output []byte, params OutputContext, commo
 			responseText,
 			!isJSONResponse,
 			jsonformatter.WithFileOutput(commonOptions.OutputFile != "", commonOptions.OutputFile, false),
-			jsonformatter.WithTrimSpace(true),
+			jsonformatter.WithTrimSpace(trimSpaceFromOutput),
 			jsonformatter.WithJSONStreamOutput(isJSONResponse, consol.IsJSONStream(), consol.IsTextOutput()),
 			jsonformatter.WithSuffix(len(responseText) > 0, "\n"),
 		)

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -831,6 +831,9 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 
 	unfilteredSize := 0
 
+	// Trim space from json object/array output
+	trimSpaceFromOutput := true
+
 	if resp != nil && (len(resp.Body()) > 0 || hasOutputTemplate) {
 		// estimate size based on utf8 encoding. 1 char is 1 byte
 		printResponseSize(r.Logger, resp)
@@ -872,28 +875,19 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 				isJSONResponse = true
 				resp.SetBody(pretty.Ugly(tmplOutput))
 			} else {
+				// Preserve output
+				trimSpaceFromOutput = false
 				isJSONResponse = false
-				// Try to unmarshal json for situations when the user has used "response.body"
-				// and body contains escaped json chars (e.g. \n)
-				// https://github.com/reubenmiller/go-c8y-cli/issues/306
-				var maybeJSON any
-				jsonErr := json.Unmarshal(tmplOutput, &maybeJSON)
-				skipTrimming := false
-				if jsonErr == nil {
-					switch v := maybeJSON.(type) {
-					case string:
-						tmplOutput = []byte(v)
-						skipTrimming = true
-					}
+
+				// Decode output
+				var tmplOutputDecoded []byte
+				if parsedOutput := gjson.ParseBytes(tmplOutput); parsedOutput.Exists() && parsedOutput.Type == gjson.String {
+					tmplOutputDecoded = []byte(parsedOutput.Str)
+				} else {
+					tmplOutputDecoded = tmplOutput
 				}
-				if !skipTrimming {
-					// TODO: Is removing the quotes doing too much, what happens if someone is building csv, and it using quotes around some fields?
-					// e.g. `"my value",100`, that would get transformed to `my value",100`
-					// Trim any quotes wrapping the values
-					tmplOutput = bytes.TrimSpace(tmplOutput)
-					tmplOutput = bytes.Trim(tmplOutput, "\"")
-				}
-				resp.SetBody(tmplOutput)
+
+				resp.SetBody(tmplOutputDecoded)
 			}
 		}
 
@@ -1002,7 +996,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 				responseText,
 				!isJSONResponse,
 				jsonformatter.WithFileOutput(commonOptions.OutputFile != "", commonOptions.OutputFile, false),
-				jsonformatter.WithTrimSpace(true),
+				jsonformatter.WithTrimSpace(trimSpaceFromOutput),
 				jsonformatter.WithJSONStreamOutput(isJSONResponse, consol.IsJSONStream(), consol.IsTextOutput()),
 				jsonformatter.WithSuffix(len(responseText) > 0, "\n"),
 			)

--- a/tests/manual/common/outputTemplate/outputTemplate.yaml
+++ b/tests/manual/common/outputTemplate/outputTemplate.yaml
@@ -5,6 +5,7 @@ config:
     C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
     C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
     C8Y_SETTINGS_DEFAULTS_OUTPUT: json
+    C8Y_SETTINGS_DEFAULTS_PAGESIZE: " "
     C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
     C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
     C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
@@ -65,3 +66,18 @@ tests:
     stdout:
       json:
         id: r/^\d+$
+
+  It supports outputting toml output:
+    command: |
+      c8y devices get --id agent01 --outputTemplate 'std.manifestTomlEx({c8y:{name: output.name}}, "  ")'
+    exit-code: 0
+    stdout:
+      exactly: |
+        [c8y]
+          name = "agent01"
+
+  # Note: use shell to compare the exact string output as the test framework seems to have an issue
+  It preserves leading and trailing whitespace:
+    command: |
+      [ "$(c8y devices get --id agent01 --outputTemplate '" a\n b "')" = "$(printf ' a\n b ')" ]
+    exit-code: 0


### PR DESCRIPTION
Support complex non-json outputs from Jsonnet templates (either from `--template` and `--outputTemplate` flags)

Previously


**Example**

Register a device with basic auth credentials, and format the response in toml format, so it can be used with thin-edge.io.

```sh
c8y deviceregistration register-basic \
    --id example \
    --outputTemplate '
    std.manifestTomlEx({
        c8y: {
            username: output.username,
            password: output.password
        }
    }, "  ")'
```

**Output (After)**

```toml
[c8y]
  password = "<<strong_password>>"
  username = "t12354/device_example"
```

Note, previously the output was mangled due to incorrect interpretation of newline and quotes, for example:

```
\n\n[c8y]\npassword=\"<<strong_password>>\"\n  username = \"t12354/device_example\
```
