### PR TITLE
feat: improve stdin detection

### DIFF
--- a/pkg/clio/clio.go
+++ b/pkg/clio/clio.go
@@ -1,0 +1,120 @@
+package clio
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+)
+
+// isInputPiped checks if os.Stdin is receiving piped input.
+// It does this by checking the file mode of os.Stdin.
+// A named pipe (FIFO) typically indicates piped input.
+// A character device indicates an interactive terminal.
+// Any other mode might indicate a redirected file or other non-interactive source.
+func IsInputPiped(f *os.File) bool {
+	// return IsNamedPipe(f) || !IsInteractiveTerminal(f)
+	return IsNamedPipe(f) && !IsInteractiveTerminal(f) // works ok, but does not handle empty input silently
+}
+
+func IsNamedPipe(f *os.File) bool {
+	// Get file information for standard input.
+	if f == nil {
+		f = os.Stdin
+	}
+	fileInfo, err := f.Stat()
+	if err != nil {
+		// Return the error if we can't get stat info for stdin.
+		return false
+	}
+
+	// Check if the mode indicates a named pipe (FIFO).
+	// This is the most reliable way to detect piped input.
+	return (fileInfo.Mode() & os.ModeNamedPipe) != 0
+}
+
+// IsInteractiveTerminal checks if os.Stdin is connected to an interactive terminal.
+// This is true if the stdin is a character device.
+func IsInteractiveTerminal(f *os.File) bool {
+	if f == nil {
+		f = os.Stdin
+	}
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
+func IsWritable(f *os.File) bool {
+	if f == nil {
+		f = os.Stdin
+	}
+
+	// test if io is writable
+	inputWritable := false
+	if _, writeErr := f.Write([]byte("")); writeErr == nil {
+		inputWritable = true
+	}
+	// fmt.Fprintf(os.Stderr, "Debug Stdin FD: inputWritable=%v\n", inputWritable)
+	return inputWritable
+
+	// stat, err := f.Stat()
+	// if err != nil {
+	// 	return false
+	// }
+
+	// mode := stat.Mode().Perm().String()
+	// fmt.Fprintf(os.Stderr, "Debug Stdin FD: mode=%s\n", mode)
+	// if len(mode) < 4 {
+	// 	return false
+	// }
+	// return strings.Contains(mode[3:], "w")
+}
+
+func ConfigMaybePiped(f *os.File) bool {
+	if f == nil {
+		f = os.Stdin
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+
+	isPipe := (stat.Mode()&os.ModeNamedPipe) != 0 ||
+		(stat.Mode()&(os.ModeCharDevice|os.ModeDir|os.ModeSymlink)) == 0
+
+	return isPipe
+}
+
+var EmptyMarker = []byte("\u0000")
+
+func WriteEmptyMarker(w io.Writer) (int, error) {
+	switch v := w.(type) {
+	case *os.File:
+		fmt.Fprintf(os.Stderr, "fName=%s\n", v.Name())
+		if !strings.EqualFold(v.Name(), "stdout") {
+			if IsNamedPipe(v) {
+				return v.Write(EmptyMarker)
+			}
+		}
+
+	default:
+		if !IsTerminal(os.Stdout) {
+			return v.Write(EmptyMarker)
+		}
+	}
+	return 0, nil
+}
+
+func IsEmptyMarker(b []byte) bool {
+	return bytes.EqualFold(b, EmptyMarker)
+}
+
+func IsTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/termenv"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/vbauerster/mpb/v6"
 	"golang.org/x/term"
@@ -140,8 +141,7 @@ func (s *IOStreams) IsStderrTTY() bool {
 }
 
 func (s *IOStreams) HasStdin() bool {
-	stat, _ := os.Stdin.Stat()
-	return (stat.Mode() & os.ModeCharDevice) == 0
+	return clio.IsInputPiped(nil)
 }
 
 func (s *IOStreams) CanPrompt() bool {

--- a/pkg/iterator/pipe.go
+++ b/pkg/iterator/pipe.go
@@ -11,6 +11,7 @@ import (
 
 	"errors"
 
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonUtilities"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/stream"
 	"github.com/tidwall/gjson"
@@ -149,27 +150,33 @@ func (i *PipeIterator) MarshalJSON() (line []byte, err error) {
 	return MarshalJSON(i)
 }
 
-// NewPipeIterator returns a new pipe iterator
-func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
-	var input io.Reader
+func NewPipeReader(in io.Reader) (*bufio.Reader, error) {
+	var reader *bufio.Reader
+
 	switch v := in.(type) {
 	case *os.File:
-		// check if there is input (otherwise calling .Peek(1) will hang)
-		info, err := v.Stat()
-		if err != nil {
-			return nil, err
-		}
 
-		if info.Mode()&os.ModeCharDevice != 0 {
+		if !clio.IsInputPiped(v) {
 			return nil, ErrNoPipeInput
 		}
-		input = v
+
+		reader = bufio.NewReader(v)
+
 	case io.Reader:
-		input = v
+		reader = bufio.NewReader(v)
 	}
 
-	reader := bufio.NewReader(input)
 	if err := PeekReader(reader); err != nil {
+		return nil, err
+	}
+
+	return reader, nil
+}
+
+// NewPipeIterator returns a new pipe iterator
+func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
+	reader, err := NewPipeReader(in)
+	if err != nil {
 		return nil, err
 	}
 
@@ -189,25 +196,8 @@ func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
 
 // NewJSONPipeIterator returns a new pipe iterator
 func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) (Iterator, error) {
-	var input io.Reader
-	switch v := in.(type) {
-	case *os.File:
-		// check if there is input (otherwise calling .Peek(1) will hang)
-		info, err := v.Stat()
-		if err != nil {
-			return nil, err
-		}
-
-		if info.Mode()&os.ModeCharDevice != 0 {
-			return nil, ErrNoPipeInput
-		}
-		input = v
-	case io.Reader:
-		input = v
-	}
-
-	reader := bufio.NewReader(input)
-	if err := PeekReader(reader); err != nil {
+	reader, err := NewPipeReader(in)
+	if err != nil {
 		return nil, err
 	}
 
@@ -231,18 +221,25 @@ func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) 
 // is whitespace
 func PeekReader(r *bufio.Reader) error {
 	peek, err := r.Peek(1)
+	outErr := err
 	if err != nil {
 		if err == io.EOF {
-			return ErrEmptyPipeInput
+			outErr = ErrEmptyPipeInput
+			if len(peek) == 0 {
+				outErr = ErrNoPipeInput
+			}
 		}
-		return err
+		return outErr
 	}
-	// check first character contains only whitespace
-	if len(bytes.Trim(peek, "\n\r")) == 0 {
+
+	if clio.IsEmptyMarker(peek) {
+		outErr = ErrEmptyPipeInput
+	} else if len(bytes.Trim(peek, "\n\r")) == 0 {
+		// check first character contains only whitespace
 		// Treat input starting with an empty line like
 		// no pipe input, as when it runs in a cronjob
 		// stdin starts with a new lineline char
-		return ErrNoPipeInput
+		outErr = ErrNoPipeInput
 	}
-	return nil
+	return outErr
 }

--- a/pkg/jsonformatter/jsonformatter.go
+++ b/pkg/jsonformatter/jsonformatter.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 	"github.com/tidwall/gjson"
 )
 
@@ -24,6 +25,14 @@ func WithOutputFormatters(w io.Writer, input []byte, out bool, formatters ...Out
 	if out {
 		fmt.Fprintf(w, "%s", input)
 	}
+
+	if len(input) == 0 {
+		// If there is no output, write an null marker so that downstream commands
+		// can determine if there was empty input or if it is the stdin is
+		// mapped to some unexpected fifo (like in Github / CI environments)
+		clio.WriteEmptyMarker(w)
+	}
+
 	return input
 }
 

--- a/pkg/prompt/confirm.go
+++ b/pkg/prompt/confirm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 )
 
 // ErrAbortAction indicates that the user did not confirm an action
@@ -125,8 +126,7 @@ func Confirm(prefix, label string, target, defaultValue string, force bool) (Con
 	}
 
 	stdIn := os.Stdin
-	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
+	if !clio.IsInteractiveTerminal(stdIn) {
 		// stdin is handling Piped input, so we have to prompt on a different input
 		if runtime.GOOS == "windows" {
 			if file, err := os.Open("CON"); err == nil {


### PR DESCRIPTION
Draft:


* [ ] Detect when stdin is a FIFO (which is the case in the Github Runners)
* [ ] Use null terminated output when there is no output and output is being piped
* [x] Don't require users to set `-n` when being used within a while/for loop and using `read`
