### PR TITLE
feat: improve shell detect when installing and loading shell helpers

### DIFF
--- a/pkg/cmd/cli/install/install.manual.go
+++ b/pkg/cmd/cli/install/install.manual.go
@@ -13,13 +13,17 @@ import (
 	"github.com/cli/safeexec"
 	"github.com/mitchellh/go-homedir"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
 	"github.com/spf13/cobra"
 )
 
 var ErrInstallFailed = errors.New("failed to install one or more profiles")
-var validShells = []string{"bash", "fish", "powershell", "zsh"}
+var validShells = []string{"bash", "fish", "powershell", "zsh", "sh"}
+
+// Skip sh when installing all shells as it generally does not have a profile defined
+var defaultShells = []string{"bash", "fish", "powershell", "zsh"}
 
 type CmdInstall struct {
 	*subcommand.SubCommand
@@ -50,7 +54,7 @@ func NewCmdInstall(f *cmdutil.Factory) *CmdInstall {
 		RunE: ccmd.RunE,
 	}
 
-	cmd.Flags().StringSliceVar(&ccmd.shell, "shell", validShells, "Type of shell")
+	cmd.Flags().StringSliceVar(&ccmd.shell, "shell", defaultShells, "Type of shell")
 
 	cmd.SilenceUsage = true
 
@@ -65,24 +69,30 @@ func NewCmdInstall(f *cmdutil.Factory) *CmdInstall {
 	return ccmd
 }
 
+type Shell struct {
+	Name   string
+	Binary string
+}
+
 func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 	cfg, err := n.factory.Config()
 	if err != nil {
 		return err
 	}
 
-	shells := map[string]struct {
-		Name   string
-		Binary string
-	}{
+	shells := map[string]Shell{
 		"bash":       {Name: "bash", Binary: "bash"},
 		"zsh":        {Name: "zsh", Binary: "zsh"},
+		"sh":         {Name: "sh", Binary: "sh"},
 		"powershell": {Name: "powershell", Binary: "pwsh"},
 		"fish":       {Name: "fish", Binary: "fish"},
 	}
 
 	var Errs []error
 	reloadRequired := false
+
+	// Detect shells
+	detectedShells := make([]Shell, 0, len(n.shell))
 	for _, name := range n.shell {
 		shell, ok := shells[name]
 		if !ok {
@@ -92,14 +102,34 @@ func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 
 		cfg.Logger.Debugf("Checking shell. name=%s, shell=%s", shell.Name, shell.Binary)
 		if _, err := safeexec.LookPath(shell.Binary); err == nil {
-			changed, installErr := n.InstallProfile(shell.Name)
-			if installErr != nil {
-				Errs = append(Errs, installErr)
-			}
-			reloadRequired = reloadRequired || changed
+			detectedShells = append(detectedShells, shell)
 		} else {
 			cfg.Logger.Debugf("Shell was not found. name=%s, shell=%s", shell.Name, shell.Binary)
 		}
+	}
+
+	if len(detectedShells) == 0 {
+		// Add sh as a last resort, but since it does not have a commonly used
+		// configuration file, don't display this warning all the time, otherwise it would be really
+		// annoying to users as sh is installed on all Linux and macOS versions
+		if _, err := safeexec.LookPath("sh"); err == nil {
+			detectedShells = append(detectedShells, Shell{
+				Name:   "sh",
+				Binary: "sh",
+			})
+		} else {
+			fmt.Fprint(n.factory.IOStreams.ErrOut, "Did not detect any valid shells\n")
+			return nil
+		}
+	}
+
+	// Install profiles in each shell that was found
+	for _, shell := range detectedShells {
+		changed, installErr := n.InstallProfile(shell.Name)
+		if installErr != nil {
+			Errs = append(Errs, installErr)
+		}
+		reloadRequired = reloadRequired || changed
 	}
 
 	if len(Errs) == 0 {
@@ -107,6 +137,10 @@ func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 			fmt.Fprint(n.factory.IOStreams.ErrOut, "\nPlease reload your shell\n\n")
 		}
 		return nil
+	}
+
+	if len(Errs) == 1 {
+		return Errs[0]
 	}
 
 	summaryErr := ErrInstallFailed
@@ -126,12 +160,29 @@ func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
 	profileSnippet := ""
 
 	switch shell {
+	case "sh":
+		// sh/ash uses a special env variable called 'ENV' which controls whether a profile is auto loaded or not
+		profilePath = os.Getenv("ENV")
+		profileSnippet = `eval "$(c8y cli profile --shell sh)"`
+		if profilePath == "" {
+			if n.factory.IOStreams != nil {
+				fmt.Fprintf(
+					n.factory.IOStreams.ErrOut,
+					"%s sh is not using a config file (set via the 'ENV' env variable), so you will need to load the profile yourself using:\n\n  %s\n\n",
+					n.factory.IOStreams.ColorScheme().FailureIcon(),
+					profileSnippet,
+				)
+			}
+			return false, cmderrors.NewSilentError()
+		}
+
 	case "zsh":
 		profilePath = "~/.zshrc"
 		profileSnippet = "source <(c8y cli profile --shell zsh)"
 	case "bash":
+		// use eval over source as process substitution was only added in bash >= v4
 		profilePath = "~/.bashrc"
-		profileSnippet = "source <(c8y cli profile --shell bash)"
+		profileSnippet = `eval "$(c8y cli profile --shell bash)"`
 	case "fish":
 		profilePath = "~/.config/fish/config.fish"
 		profileSnippet = "c8y cli profile --shell fish | source"

--- a/pkg/cmd/cli/profile/profile.manual.go
+++ b/pkg/cmd/cli/profile/profile.manual.go
@@ -7,7 +7,6 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
-	"github.com/reubenmiller/go-c8y-cli/v2/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -17,8 +16,14 @@ var scriptPowerShell string
 //go:embed scripts/plugin.sh
 var scriptBash string
 
+//go:embed scripts/plugin.posix.sh
+var scriptPosixShell string
+
 //go:embed scripts/plugin.sh
 var scriptZsh string
+
+//go:embed scripts/plugin.auto.sh
+var scriptLinuxAuto string
 
 //go:embed scripts/plugin.fish
 var scriptFish string
@@ -44,17 +49,22 @@ func NewCmdProfile(f *cmdutil.Factory) *CmdProfile {
 			This command can be used to load the associated shell helpers.
 		`),
 		Example: heredoc.Doc(`
+		## zsh/bash/sh
+			eval "$(c8y cli profile)"
+
 		## zsh
 			source <(c8y cli profile --shell zsh)
 		
 		## bash
-			source <(c8y cli profile --shell bash)
+			eval "$(c8y cli profile --shell bash)"
+		
+		## sh (posix)
+			eval "$(c8y cli profile --shell sh)"
 
 		## fish
 			c8y cli profile --shell fish | source
 
 		## PowerShell
-
 			c8y cli profile --shell powershell | Out-String | Invoke-Expression
 		`),
 		RunE: ccmd.RunE,
@@ -66,7 +76,7 @@ func NewCmdProfile(f *cmdutil.Factory) *CmdProfile {
 
 	completion.WithOptions(
 		cmd,
-		completion.WithValidateSet("shell", "bash", "zsh", "powershell", "fish"),
+		completion.WithValidateSet("shell", "bash", "zsh", "powershell", "fish", "sh"),
 	)
 
 	cmdutil.DisableAuthCheck(cmd)
@@ -77,16 +87,29 @@ func NewCmdProfile(f *cmdutil.Factory) *CmdProfile {
 
 func (n *CmdProfile) RunE(cmd *cobra.Command, args []string) error {
 	activeShell := n.shell
-	if n.shell == "" {
-		activeShell = shell.DetectShell("zsh")
+	if activeShell == "" {
+		activeShell = "sh"
 	}
 	var script *string
 
+	// Note: for sh based shells, use a generic entrypoint
+	// which is able to detect the exact shell type before running
+	// the eval, as the process can't do it as it does not have access
+	// to the special shell variables as they are not exposed as env variables
+	// so a minimal source is still required to then detect the correct variant,
+	// and then the real shell type (with a prefixed "__{shell}") is used after
+	// the real shell type has been determined.
+	// This does not work for fish, or powershell as the syntax is too different
 	switch activeShell {
-	case "zsh":
+	case "zsh", "bash", "sh", "auto":
+		// generic entry point which will find the correct shell
+		script = &scriptLinuxAuto
+	case "__zsh":
 		script = &scriptZsh
-	case "bash":
+	case "__bash":
 		script = &scriptBash
+	case "__sh":
+		script = &scriptPosixShell
 	case "fish":
 		script = &scriptFish
 	case "powershell":

--- a/pkg/cmd/cli/profile/scripts/plugin.auto.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.auto.sh
@@ -1,0 +1,34 @@
+
+# detect which shell it is being sourced in
+C8Y_SHELL="sh"
+if [ -n "${BASH_VERSION:-}" ]; then
+    case "$BASH_VERSION" in
+        1*|2*|3*)
+            # older bash versions don't support completions
+            # and other syntax which
+            C8Y_SHELL="sh"
+            ;;
+        *)
+            C8Y_SHELL="bash"
+            ;;
+    esac
+elif [ -n "$ZSH_VERSION" ]; then
+    C8Y_SHELL="zsh"
+fi
+
+# dot source the real shell value
+case "$C8Y_SHELL" in
+    sh)
+        eval "$(c8y cli profile --shell __sh)"
+        ;;
+    bash)
+        eval "$(c8y cli profile --shell __bash)"
+        ;;
+    zsh)
+        eval "$(c8y cli profile --shell __zsh)"
+        ;;
+    *)
+        # fallback to something sensible
+        eval "$(c8y cli profile --shell __bash)" 2>/dev/null || eval "$(c8y cli profile --shell __sh)"
+        ;;
+esac

--- a/pkg/cmd/cli/profile/scripts/plugin.posix.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.posix.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Force encoding
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+
+# Note: Bash v3, and some older posix shells don't support function names with a hyphen
+# so underscores need to be used, then define an alias which can use hyphens
+
+
+########################################################################
+# c8y helpers
+########################################################################
+# -------------
+# session
+# -------------
+# Description: Get the current cumulocity session
+# Usage:
+#   session
+#
+session() {
+    c8y sessions get "$@"
+}
+
+# -----------
+# set-session
+# -----------
+# Description: Switch Cumulocity session interactively
+# Usage:
+#   set-session
+#
+set_session() {
+    c8yenv=$( c8y sessions set --noColor=false $@ )
+    code=$?
+    if [ $code -ne 0 ]; then
+        echo "Set session failed"
+        return 1
+    fi
+    eval "$c8yenv"
+}
+alias set-session=set_session
+
+# -------------
+# clear-session
+# -------------
+# Description: Clear all cumulocity session variables
+# Usage:
+#   clear-session
+#
+clear_session() {
+    c8yenv=$(c8y sessions clear)
+    eval "$c8yenv"
+}
+alias clear-session=clear_session
+
+# -------------------
+# clear-c8ypassphrase
+# -------------------
+# Description: Clear the encryption passphrase environment variables
+# Usage:
+#   clear-c8ypassphrase
+#
+clear_c8ypassphrase() {
+    unset C8Y_PASSPHRASE
+    unset C8Y_PASSPHRASE_TEXT
+}
+alias clear-c8ypassphrase=clear_c8ypassphrase
+
+# ----------------
+# set-c8ymode-xxxx
+# ----------------
+# Description: Set temporary mode by setting the environment variables
+# Usage:
+#   set-c8ymode-dev     (enable PUT, POST and DELETE)
+#   set-c8ymode-qual    (enable PUT, POST)
+#   set-c8ymode-prod    (disable PUT, POST and DELETE)
+#
+set_c8ymode() {
+    eval "$(c8y settings update --shell auto mode "$1")"
+    printf "\e[32mEnabled %s mode (temporarily)\e[0m\n" "$1";
+}
+alias set-c8ymode=set_c8ymode
+alias set-c8ymode-dev='set_c8ymode dev'
+alias set-c8ymode-qual='set_c8ymode qual'
+alias set-c8ymode-prod='set_c8ymode prod'


### PR DESCRIPTION
Improve the shell detection when:

* installing the profile via `c8y cli install`
* detecting which shell profile to load when using `c8y cli profile`

The detection should now be aware of posix shells, bash v3 (which does not support process substitution).