### PR TITLE
refactor: move stdin detection to a separate package

### DIFF
--- a/pkg/clio/clio.go
+++ b/pkg/clio/clio.go
@@ -1,0 +1,48 @@
+package clio
+
+import (
+	"os"
+)
+
+// HasPipedInput checks if os.Stdin is receiving piped input.
+// It does this by checking the file mode of os.Stdin.
+// A named pipe (FIFO) typically indicates piped input.
+// A character device indicates an interactive terminal.
+// Any other mode might indicate a redirected file or other non-interactive source.
+func HasPipedInput(f *os.File) bool {
+	// Get file information for standard input.
+	if f == nil {
+		f = os.Stdin
+	}
+	fileInfo, err := f.Stat()
+	if err != nil {
+		// Return the error if we can't get stat info for stdin.
+		return false
+	}
+
+	if (fileInfo.Mode() & os.ModeNamedPipe) != 0 {
+		return true
+	} else if (fileInfo.Mode() & os.ModeCharDevice) != 0 {
+		// Stdin is a character device (e.g., a terminal)
+		return false
+	} else if fileInfo.Mode().IsRegular() {
+		// Stdin is a regular file
+		return true
+	} else {
+		// Stdin is something else (e.g., a socket)
+		return true
+	}
+}
+
+// IsInteractiveTerminal checks if os.Stdin is connected to an interactive terminal.
+// This is true if the stdin is a character device.
+func IsInteractiveTerminal(f *os.File) bool {
+	if f == nil {
+		f = os.Stdin
+	}
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/muesli/termenv"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/vbauerster/mpb/v6"
 	"golang.org/x/term"
@@ -140,8 +141,7 @@ func (s *IOStreams) IsStderrTTY() bool {
 }
 
 func (s *IOStreams) HasStdin() bool {
-	stat, _ := os.Stdin.Stat()
-	return (stat.Mode() & os.ModeCharDevice) == 0
+	return clio.HasPipedInput(nil)
 }
 
 func (s *IOStreams) CanPrompt() bool {

--- a/pkg/iterator/pipe.go
+++ b/pkg/iterator/pipe.go
@@ -11,6 +11,7 @@ import (
 
 	"errors"
 
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonUtilities"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/stream"
 	"github.com/tidwall/gjson"
@@ -149,27 +150,30 @@ func (i *PipeIterator) MarshalJSON() (line []byte, err error) {
 	return MarshalJSON(i)
 }
 
-// NewPipeIterator returns a new pipe iterator
-func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
-	var input io.Reader
+// NewPipeReader returns a reader from any detected input pipeline
+func NewPipeReader(in io.Reader) (*bufio.Reader, error) {
+	var reader *bufio.Reader
 	switch v := in.(type) {
 	case *os.File:
-		// check if there is input (otherwise calling .Peek(1) will hang)
-		info, err := v.Stat()
-		if err != nil {
-			return nil, err
-		}
-
-		if info.Mode()&os.ModeCharDevice != 0 {
+		if !clio.HasPipedInput(v) {
 			return nil, ErrNoPipeInput
 		}
-		input = v
+		reader = bufio.NewReader(v)
 	case io.Reader:
-		input = v
+		reader = bufio.NewReader(v)
 	}
 
-	reader := bufio.NewReader(input)
 	if err := PeekReader(reader); err != nil {
+		return nil, err
+	}
+
+	return reader, nil
+}
+
+// NewPipeIterator returns a new pipe iterator
+func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
+	reader, err := NewPipeReader(in)
+	if err != nil {
 		return nil, err
 	}
 
@@ -189,25 +193,8 @@ func NewPipeIterator(in io.Reader, filter ...Filter) (Iterator, error) {
 
 // NewJSONPipeIterator returns a new pipe iterator
 func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) (Iterator, error) {
-	var input io.Reader
-	switch v := in.(type) {
-	case *os.File:
-		// check if there is input (otherwise calling .Peek(1) will hang)
-		info, err := v.Stat()
-		if err != nil {
-			return nil, err
-		}
-
-		if info.Mode()&os.ModeCharDevice != 0 {
-			return nil, ErrNoPipeInput
-		}
-		input = v
-	case io.Reader:
-		input = v
-	}
-
-	reader := bufio.NewReader(input)
-	if err := PeekReader(reader); err != nil {
+	reader, err := NewPipeReader(in)
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/prompt/confirm.go
+++ b/pkg/prompt/confirm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 )
 
 // ErrAbortAction indicates that the user did not confirm an action
@@ -125,8 +126,7 @@ func Confirm(prefix, label string, target, defaultValue string, force bool) (Con
 	}
 
 	stdIn := os.Stdin
-	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
+	if !clio.IsInteractiveTerminal(stdIn) {
 		// stdin is handling Piped input, so we have to prompt on a different input
 		if runtime.GOOS == "windows" {
 			if file, err := os.Open("CON"); err == nil {

--- a/tests/manual/common/pipe/stdin-detection/check.sh
+++ b/tests/manual/common/pipe/stdin-detection/check.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+pushd "$SCRIPT_DIR"
+
+FAIL_COUNT=0
+
+# Create dummy input file used in some tests
+INPUT_FILE=./input.txt
+c8y inventory list -p 3 --select id -o csv > "$INPUT_FILE"
+
+fail() {
+	printf '\n\033[31m FAIL %s \033[0m\n' "$1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+pass() {
+	printf '\n\033[32m PASS %s \033[0m\n' "$1"
+}
+
+echo "
+------------------------------------
+# Normal command
+------------------------------------
+"
+if c8y devices list -p 1 --name asdfasdfasdf --select id -o csv; then
+    pass
+else
+    fail
+fi
+
+
+echo "
+------------------------------------
+# Empty does not return any characters
+------------------------------------
+"
+if [ -z "$(c8y devices list -p 1 --name asdfasdfasdf --select id -o csv)" ]; then
+    pass
+else
+    fail
+fi
+
+
+echo "
+------------------------------------
+# Pipe to another command
+------------------------------------
+"
+if c8y devices list -p 1 --select id -o csv | wc -c | awk '{print $1}' ; then
+    pass
+else
+    fail
+fi
+
+echo "
+------------------------------------
+# Cat to while loop (requires -n)
+------------------------------------
+"
+# shellcheck disable=SC2002
+OUTPUT=$(
+    cat "$INPUT_FILE" | while read -r line; do
+        current_id="$line"
+        c8y devices get -n --id "$current_id" --select id --output csv
+    done
+)
+
+if [ "$OUTPUT" = "$(cat "$INPUT_FILE" )" ]; then
+    pass
+else
+    fail
+fi
+
+echo "
+------------------------------------
+# While loop
+------------------------------------
+"
+COUNT=0
+
+while read -r line
+do
+    {
+        COUNT=$((COUNT + 1))
+        current_id="$line"
+        c8y devices get --id "$current_id" --select id,name,type,lastUpdated --output csv >/dev/null
+        c8y devices get --id "$current_id" --select creationTime -o csv >/dev/null 2>&1
+    } </dev/null
+done <"$INPUT_FILE"
+
+if [ "$COUNT" -eq 3 ]; then
+    pass "(count=$COUNT)"
+else
+    fail "(got=$COUNT, want=3)"
+fi
+
+
+echo "
+------------------------------------
+# Empty pipe
+------------------------------------
+"
+if c8y devices list --name "somethingThatDoesNotExist123456789" | c8y devices get; then
+    pass
+else
+    fail
+fi
+
+
+echo "
+------------------------------------
+# normal pipe
+------------------------------------
+"
+LINE_COUNT=$(c8y devices list -p 1 | c8y devices get | wc -l | awk '{print $1}')
+if [ "$LINE_COUNT" -eq 1 ]; then
+    pass
+else
+    fail
+fi
+
+echo "
+------------------------------------
+# FIFO (github) with newline on fifo
+------------------------------------
+"
+run_command() {
+    result="$1"
+    c8y devices list -p 1 > "$result"
+}
+
+RESULT_FILE=./fifo_result
+rm -f dummy_fifo
+mkfifo dummy_fifo
+run_command "$RESULT_FILE" <dummy_fifo &
+echo "" > dummy_fifo
+sleep 1
+LINE_COUNT=$(wc -l "$RESULT_FILE" | awk '{print $1}')
+if [ "$LINE_COUNT" -eq 1 ]; then
+    pass
+else
+    fail
+fi
+rm -f dummy_fifo
+rm -f "$RESULT_FILE"
+
+echo "
+------------------------------------
+# FIFO (github) with unterminated newline on fifo
+------------------------------------
+"
+run_command() {
+    result="$1"
+    c8y devices list -p 1 > "$result"
+}
+
+RESULT_FILE=./fifo_result
+rm -f dummy_fifo
+mkfifo dummy_fifo
+run_command "$RESULT_FILE" <dummy_fifo &
+echo -n "" > dummy_fifo
+sleep 1
+LINE_COUNT=$(wc -l "$RESULT_FILE" | awk '{print $1}')
+if [ "$LINE_COUNT" -eq 1 ]; then
+    pass
+else
+    fail
+fi
+rm -f dummy_fifo
+rm -f "$RESULT_FILE"
+echo
+
+popd >/dev/null ||:
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Refactor the stdin detection logic to a single package so it can be consistently used and modified in the future.

This PR does not include any changes to the existing behaviour.