### PR TITLE
feat: support external commands to prompt for the encryption passphrase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/google/go-jsonnet v0.20.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/websocket v1.5.3
-	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef
 	github.com/karrick/tparse/v2 v2.8.2
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-colorable v0.1.14

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
-github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
-github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/karrick/tparse/v2 v2.8.2 h1:NhvrrB7nXYa0VLn0JKn9L3oG/GZN+LB/+g5QfWE30rU=

--- a/pkg/cmd/sessions/decrypttext/decryptText.manual.go
+++ b/pkg/cmd/sessions/decrypttext/decryptText.manual.go
@@ -1,11 +1,17 @@
 package decrypttext
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 
-	"github.com/howeyc/gopass"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/encrypt"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/stream"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +49,10 @@ Encrypt the text "Hello World", the text will be encrypted using the given passp
 	cmdutil.DisableEncryptionCheck(cmd)
 	cmd.SilenceUsage = true
 
-	cmd.Flags().String("text", "", "Encrypted text. (required)")
-	cmd.Flags().StringVar(&ccmd.passphrase, "passphrase", "", "Passphrase use for encoding your files")
+	cmd.Flags().String("text", "", "Encrypted text. (required) (accepts pipeline)")
+	cmd.Flags().StringVar(&ccmd.passphrase, "passphrase", "", "Passphrase to use for encrypting the text. Read from env C8Y_PASSPHRASE or prompted if missing")
 
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("text")
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
 	return ccmd
 }
@@ -60,30 +66,67 @@ func (n *CmdDecryptText) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if n.passphrase == "" {
-		cmd.Printf("Enter password 🔒: [input is hidden] ")
-		inputPassphrase, err := gopass.GetPasswd() // Silent
-		if err != nil {
-			return err
+
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
+	if err != nil {
+		return err
+	}
+	_ = log
+
+	var iter iterator.Iterator
+	_, input, err := flags.WithPipelineIterator(&flags.PipelineOptions{
+		Name:     "text",
+		Disabled: inputIterators.PipeOptions.Disabled,
+		Formatter: func(b []byte) []byte {
+			return bytes.TrimPrefix(bytes.TrimSpace(b), cfg.SecureData.Prefix)
+		},
+		InputFilter: func(b []byte) bool {
+			return true
+		},
+		Required: true,
+		Mode:     stream.ModeText,
+	})(cmd, inputIterators)
+
+	if err != nil {
+		return &flags.ParameterError{
+			Name: "text",
+			Err:  fmt.Errorf("missing required parameter or pipeline input. %w", flags.ErrParameterMissing),
 		}
-		n.passphrase = string(inputPassphrase)
 	}
 
-	password := ""
+	switch v := input.(type) {
+	case iterator.Iterator:
+		iter = v
+	default:
+		// use a single input iterator
+		iter = iterator.NewRepeatIterator("", 1)
+	}
 
-	if v, err := cmd.Flags().GetString("text"); err == nil && v != "" {
+	return n.factory.RunWithGenericWorkers(cmd, inputIterators, iter, func(j worker.Job) (any, error) {
+		if v, ok := j.Value.([]byte); ok {
 
-		if cfg.SecureData.IsEncrypted(v) != 0 {
-			password, err = cfg.SecureData.DecryptString(v, n.passphrase)
-			if err != nil {
-				return err
+			if n.passphrase == "" {
+				inputPassphrase, err := cfg.PromptPassphrase()
+				if err != nil {
+					return nil, err
+				}
+				n.passphrase = string(inputPassphrase)
 			}
-		} else {
-			log.Info("Text is already decrypted")
-			password = v
-		}
-	}
 
-	fmt.Printf("%s\n", password)
-	return nil
+			data, err := cfg.SecureData.DecryptString(string(v), n.passphrase)
+
+			// Don't treat the text (most likely being unencrypted as an error)
+			if errors.Is(err, encrypt.ErrNotEncrypted) {
+				err = nil
+			}
+
+			if err != nil {
+				return "", fmt.Errorf("failed to decrypt text. %w", err)
+			}
+
+			err = n.factory.WriteOutputWithoutPropertyGuess([]byte(data), cmdutil.OutputContext{})
+			return "", err
+		}
+		return "", nil
+	})
 }

--- a/pkg/cmd/sessions/encrypttext/encryptText.manual.go
+++ b/pkg/cmd/sessions/encrypttext/encryptText.manual.go
@@ -3,15 +3,16 @@ package encrypttext
 import (
 	"fmt"
 
-	"github.com/howeyc/gopass"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/spf13/cobra"
 )
 
 type CmdEncryptText struct {
 	passphrase string
-	raw        bool
 
 	*subcommand.SubCommand
 
@@ -31,13 +32,13 @@ func NewCmdEncryptText(f *cmdutil.Factory) *CmdEncryptText {
 Example 1: Encrypt the text "Hello World". You will be prompted for the passphrase to encrypt the data.
 
 > c8y sessions encryptText --text "Hello World"
-Enter password 🔒: [input is hidden] 
-Password: {encrypted}ec5b837a03408ffb731307584eac40ac047989a002951e4b7139fa60189e504b6840bc027cece28b3f36717839d96af1c5dba8c850b9a9079846066ee1596cc8d26f4138f76ce3
+Enter passphrase 🔒: [input is hidden] 
+{encrypted}ec5b837a03408ffb731307584eac40ac047989a002951e4b7139fa60189e504b6840bc027cece28b3f36717839d96af1c5dba8c850b9a9079846066ee1596cc8d26f4138f76ce3
 
 Example 2: Encrypt the text "Hello World", the text will be encrypted using the given passphrase (without being prompted)
 
 > c8y sessions encryptText --text "Hello World" --passphrase "so4methIng-7hat-Matters"
-Password: {encrypted}ec5b837a03408ffb731307584eac40ac047989a002951e4b7139fa60189e504b6840bc027cece28b3f36717839d96af1c5dba8c850b9a9079846066ee1596cc8d26f4138f76ce3
+{encrypted}ec5b837a03408ffb731307584eac40ac047989a002951e4b7139fa60189e504b6840bc027cece28b3f36717839d96af1c5dba8c850b9a9079846066ee1596cc8d26f4138f76ce3
 		`,
 		RunE: ccmd.RunE,
 	}
@@ -45,11 +46,10 @@ Password: {encrypted}ec5b837a03408ffb731307584eac40ac047989a002951e4b7139fa60189
 	cmdutil.DisableEncryptionCheck(cmd)
 	cmd.SilenceUsage = true
 
-	cmd.Flags().String("text", "", "Text to be encrypted. (required)")
-	cmd.Flags().StringVar(&ccmd.passphrase, "passphrase", "", "Passphrase use for encrypting the text")
-	cmd.Flags().BoolVar(&ccmd.raw, "raw", false, "Only return the encrypted text and nothing else")
+	cmd.Flags().String("text", "", "Text to be encrypted. (required) (accepts pipeline)")
+	cmd.Flags().StringVar(&ccmd.passphrase, "passphrase", "", "Passphrase to use for encrypting the text. Read from env C8Y_PASSPHRASE or prompted if missing")
 
-	ccmd.SubCommand = subcommand.NewSubCommand(cmd).SetRequiredFlags("text")
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
 	return ccmd
 }
@@ -64,35 +64,55 @@ func (n *CmdEncryptText) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if n.passphrase == "" {
-		cmd.Printf("Enter password 🔒: [input is hidden] ")
-		inputPassphrase, err := gopass.GetPasswd() // Silent
+		inputPassphrase, err := cfg.PromptPassphrase()
 		if err != nil {
 			return err
 		}
 		n.passphrase = string(inputPassphrase)
 	}
 
-	encryptedPassword := ""
-	if v, err := cmd.Flags().GetString("text"); err == nil && v != "" {
+	inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
+	if err != nil {
+		return err
+	}
 
-		if cfg.SecureData.IsEncrypted(v) != 1 {
-			data, err := cfg.SecureData.EncryptString(v, n.passphrase)
+	var iter iterator.Iterator
+	_, input, err := flags.WithPipelineIterator(&flags.PipelineOptions{
+		Name:     "text",
+		Disabled: inputIterators.PipeOptions.Disabled,
+		Required: true,
+	})(cmd, inputIterators)
 
-			if err != nil {
-				return err
-			}
-			encryptedPassword = data
-		} else {
-			log.Info("Text is already encrypted")
-			encryptedPassword = v
+	if err != nil {
+		return &flags.ParameterError{
+			Name: "text",
+			Err:  fmt.Errorf("missing required parameter or pipeline input. %w", flags.ErrParameterMissing),
 		}
 	}
 
-	if n.raw {
-		fmt.Printf("%s\n", encryptedPassword)
-	} else {
-		fmt.Printf("Password: %s\n", encryptedPassword)
+	switch v := input.(type) {
+	case iterator.Iterator:
+		iter = v
+	default:
+		// use a single input iterator
+		iter = iterator.NewRepeatIterator("", 1)
 	}
 
-	return nil
+	return n.factory.RunWithGenericWorkers(cmd, inputIterators, iter, func(j worker.Job) (any, error) {
+		if v, ok := j.Value.([]byte); ok {
+			encryptedText := v
+			if cfg.SecureData.IsEncrypted(string(encryptedText)) != 1 {
+				data, err := cfg.SecureData.EncryptString(string(encryptedText), n.passphrase)
+				if err != nil {
+					return nil, err
+				}
+				encryptedText = []byte(data)
+			} else {
+				log.Info("Text is already encrypted")
+			}
+
+			err = n.factory.WriteOutputWithoutPropertyGuess(encryptedText, cmdutil.OutputContext{})
+		}
+		return "", nil
+	})
 }

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -323,6 +323,8 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"false",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
+	"pinEntry": {"pinEntry", "string", config.SettingsPinEntry, []string{}, nil, cobra.ShellCompDirectiveDefault},
+
 	// cache
 	"defaults.cache": {"defaults.cache", "bool", config.SettingsDefaultsCacheEnabled, []string{
 		"true",

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -199,6 +199,9 @@ const (
 	// SettingsModeEnableDelete enables delete commands
 	SettingsModeEnableDelete = "settings.mode.enableDelete"
 
+	// SettingsPinEntry sets the command to run to get the user's passphrase
+	SettingsPinEntry = "settings.pinEntry"
+
 	// SettingsModeCI enable continuous integration mode (this will enable all commands)
 	SettingsModeCI = "settings.ci"
 
@@ -536,6 +539,7 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsForceTTY, false),
 
 		// Session options
+		WithBindEnv(SettingsPinEntry, ""),
 		WithBindEnv(SettingsSessionAlwaysIncludePassword, false),
 		WithBindEnv(SettingsSessionTokenValidFor, "8h"),
 		WithBindEnv(SettingsSessionHide, false),
@@ -551,6 +555,9 @@ func (c *Config) bindSettings() {
 	if err != nil {
 		c.Logger.Warnf("Could not bind settings. %s", err)
 	}
+
+	// Set pin entry command
+	c.prompter.PinEntry = c.PinEntry()
 }
 
 // SetLogger sets the logger
@@ -565,6 +572,11 @@ func (c *Config) ReadConfig(file string) error {
 	return c.Persistent.ReadInConfig()
 }
 
+// PinEntry returns the command to use to request a user's credentials
+func (c *Config) PinEntry() string {
+	return c.viper.GetString(SettingsPinEntry)
+}
+
 // CheckEncryption checks if the user has provided the correct encryption password or not by testing the decryption of the secret text
 func (c *Config) CheckEncryption(encryptedText ...string) (string, error) {
 	secretText := c.SecretText
@@ -573,7 +585,7 @@ func (c *Config) CheckEncryption(encryptedText ...string) (string, error) {
 	}
 
 	c.Logger.Infof("Checking encryption passphrase against secret text: %s", secretText)
-	pass, err := c.prompter.EncryptionPassphrase(secretText, c.Passphrase, "")
+	pass, err := c.prompter.EncryptionPassphrase(secretText, EnvPassphrase, c.Passphrase, "")
 	c.Passphrase = pass
 	return pass, err
 }

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -590,6 +590,19 @@ func (c *Config) CheckEncryption(encryptedText ...string) (string, error) {
 	return pass, err
 }
 
+// PromptPassphrase prompts the user for the passphrase if it is not already set
+func (c *Config) PromptPassphrase() (string, error) {
+	if c.Passphrase != "" {
+		return c.Passphrase, nil
+	}
+	prompter, err := c.prompter.GetPassphrasePrompter(EnvPassphrase)
+	if err != nil {
+		return "", err
+	}
+	pass, err := prompter.Prompt(0, 1)
+	return pass, err
+}
+
 // BindAuthorization binds environment variables related to the authorization to the configuration
 func (c *Config) BindAuthorization() error {
 	c.viper.SetEnvPrefix(EnvSettingsPrefix)

--- a/pkg/encrypt/encrypt.go
+++ b/pkg/encrypt/encrypt.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	ErrDecryptFailed = errors.New("decryption failed")
+	ErrNotEncrypted  = errors.New("text is not encrypted")
 )
 
 // Source:
@@ -79,8 +80,19 @@ func (s *SecureData) FromHex(data []byte) ([]byte, error) {
 	_, err := hex.Decode(decoded, data)
 	return decoded, err
 }
+
 func (s *SecureData) FromHexString(data string) ([]byte, error) {
 	decoded, err := hex.DecodeString(data)
+
+	if errors.Is(err, hex.ErrLength) {
+		return []byte(data), errors.Join(ErrNotEncrypted, err)
+	}
+
+	var byteError hex.InvalidByteError
+	if errors.As(err, &byteError) {
+		return []byte(data), errors.Join(ErrNotEncrypted, err)
+	}
+
 	return decoded, err
 }
 
@@ -145,7 +157,8 @@ func (s *SecureData) DecryptString(data string, passphrase string) (string, erro
 	decodedData, err := s.FromHexString(data)
 
 	if err != nil {
-		return "", err
+		// return input data as the data might not be encrypted
+		return data, err
 	}
 
 	v, err := s.Decrypt(decodedData, passphrase)

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8yquery"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/stream"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/timestamp"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/url"
 
@@ -1145,6 +1146,7 @@ type PipelineOptions struct {
 	Aliases     []string            `json:"aliases"`
 	IsID        bool                `json:"isID"`
 	Values      []string            `json:"values"`
+	Mode        stream.Mode         `json:"mode"`
 	Validator   iterator.Validator  `json:"-"`
 	Formatter   func([]byte) []byte `json:"-"`
 	Format      string              `json:"-"`

--- a/pkg/flags/pipeline.go
+++ b/pkg/flags/pipeline.go
@@ -44,6 +44,7 @@ func NewFlagWithPipeIterator(cmd *cobra.Command, pipeOpt *PipelineOptions, suppo
 			AllowEmpty: !pipeOpt.Required,
 			Formatter:  pipeOpt.Formatter,
 			Format:     pipeOpt.Format,
+			Mode:       pipeOpt.Mode,
 		}
 		lineFilter := FilterJsonLines
 		if pipeOpt.InputFilter != nil {

--- a/pkg/iterator/pipe.go
+++ b/pkg/iterator/pipe.go
@@ -63,6 +63,9 @@ type PipeOptions struct {
 
 	// Format simple custom format string
 	Format string
+
+	// Pipe detection mode
+	Mode stream.Mode
 }
 
 // PipeIterator is a thread safe iterator to retrieve the input values from piped standard input
@@ -110,7 +113,7 @@ func (i *PipeIterator) GetNext() (line []byte, input interface{}, err error) {
 	}
 
 	// check if json, if so pluck the value from it
-	if i.opts != nil && jsonUtilities.IsJSONObject(line) {
+	if i.opts != nil && i.opts.Mode == stream.ModeAuto && jsonUtilities.IsJSONObject(line) {
 		if len(i.opts.Properties) > 0 {
 			// select first property
 			for _, prop := range i.opts.Properties {
@@ -203,10 +206,16 @@ func NewJSONPipeIterator(in io.Reader, pipeOpts *PipeOptions, filter ...Filter) 
 		pipelineFilter = filter[0]
 	}
 
+	streamMode := stream.ModeAuto
+	if pipeOpts != nil {
+		streamMode = pipeOpts.Mode
+	}
+
 	return &PipeIterator{
 		reader: reader,
 		stream: &stream.InputStreamer{
 			Buffer: reader,
+			Mode:   streamMode,
 		},
 		filter: pipelineFilter,
 		opts:   pipeOpts,

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -189,9 +189,16 @@ func NewPrompt(l *logger.Logger) *Prompt {
 // EncryptionPassphrase prompt for the encryption passphrase, and test the
 // passphrase against the encrypted content to see if it is valid
 func (p *Prompt) EncryptionPassphrase(encryptedData string, key string, initPassphrase string, message string) (string, error) {
-	var err error
-	secure := encrypt.NewSecureData("{encrypted}")
+	prompter, err := p.WithPrompters(
+		p.Logger,
+		WithExternalPrompt(p.PinEntry, key),
+		WithCommandLinePrompt("Session is encrypted"),
+	)
+	if err != nil {
+		return "", err
+	}
 
+	secure := encrypt.NewSecureData("{encrypted}")
 	validate := func(input string) error {
 		if secure.IsEncrypted(encryptedData) != 0 {
 			_, err = secure.DecryptString(encryptedData, input)
@@ -199,14 +206,68 @@ func (p *Prompt) EncryptionPassphrase(encryptedData string, key string, initPass
 		}
 		return nil
 	}
+	promptWrapper := NewPromptWithPostValidate(prompter, validate)
 
-	var prompter Prompter
+	// check if init passphrase is ok without prompting the user
+	if err := validate(initPassphrase); err == nil {
+		return initPassphrase, nil
+	}
+	if message != "" {
+		p.ShowMessage(message)
+	}
+	return promptWrapper.Run()
+}
 
-	// Check for custom pin entry, but don't fail if it does not exist, just warn the user that it isn't being used for a good reason
-	if p.PinEntry != "" {
-		pinEntryCommand, err := shellquote.Split(p.PinEntry)
+type UserPrompter func(*logger.Logger) Prompter
+
+func (p *Prompt) WithPrompters(l *logger.Logger, opts ...UserPrompter) (Prompter, error) {
+	for _, prompter := range opts {
+		curPrompter := prompter(l)
+		if curPrompter != nil {
+			return curPrompter, nil
+		}
+	}
+	return nil, fmt.Errorf("no prompter found")
+}
+
+func (p *Prompt) GetPassphrasePrompter(key string) (Prompter, error) {
+	return p.WithPrompters(
+		p.Logger,
+		WithExternalPrompt(p.PinEntry, key),
+		WithCommandLinePrompt(""),
+	)
+}
+
+func WithCommandLinePrompt(userPrompt string) UserPrompter {
+	return func(l *logger.Logger) Prompter {
+		label := "enter passphrase 🔒 [input is hidden]"
+		if userPrompt != "" {
+			label = strings.Join([]string{userPrompt, label}, ", ")
+		}
+		return &CommandLinePrompter{
+			prompt: &promptui.Prompt{
+				Stdin:       os.Stdin,
+				Stdout:      os.Stderr,
+				Default:     "",
+				Mask:        ' ',
+				HideEntered: true,
+				Label:       label,
+				Templates: &promptui.PromptTemplates{
+					Valid: "{{ . | bold }}: ",
+				},
+			},
+		}
+	}
+}
+
+func WithExternalPrompt(command string, key string) UserPrompter {
+	return func(l *logger.Logger) Prompter {
+		if command == "" {
+			return nil
+		}
+		pinEntryCommand, err := shellquote.Split(command)
 		if err != nil {
-			pinEntryCommand = []string{p.PinEntry}
+			pinEntryCommand = []string{command}
 		}
 
 		externalCommandArgs := []string{}
@@ -221,40 +282,12 @@ func (p *Prompt) EncryptionPassphrase(encryptedData string, key string, initPass
 			Args:    externalCommandArgs,
 		}
 		if _, promptErr := pinEntryPrompter.Exists(); promptErr != nil {
-			p.Logger.Warnf("user defined pin entry command (%s) does not exist. The default will be used instead. error=%s", p.PinEntry, promptErr)
-		} else {
-			p.Logger.Infof("Using external pin entry command. %s %s", pinEntryCommand[0], strings.Join(externalCommandArgs, " "))
-			prompter = pinEntryPrompter
+			l.Warnf("user defined pin entry command (%s) does not exist. The default will be used instead. error=%s", command, promptErr)
+			return nil
 		}
+		l.Infof("Using external pin entry command. %s %s", pinEntryCommand[0], strings.Join(externalCommandArgs, " "))
+		return pinEntryPrompter
 	}
-
-	// Fallback to the default cli prompter
-	if prompter == nil {
-		prompter = &CommandLinePrompter{
-			prompt: &promptui.Prompt{
-				Stdin:       os.Stdin,
-				Stdout:      os.Stderr,
-				Default:     "",
-				Mask:        ' ',
-				HideEntered: true,
-				Label:       "Session is encrypted, enter passphrase 🔒 [input is hidden]",
-				Templates: &promptui.PromptTemplates{
-					Valid: "{{ . | bold }}: ",
-				},
-			},
-		}
-	}
-
-	promptWrapper := NewPromptWithPostValidate(prompter, validate)
-
-	// check if init passphrase is ok without prompting the user
-	if err := validate(initPassphrase); err == nil {
-		return initPassphrase, nil
-	}
-	if message != "" {
-		p.ShowMessage(message)
-	}
-	return promptWrapper.Run()
 }
 
 func (p *Prompt) ShowMessage(m string) {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -1,12 +1,17 @@
 package prompt
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/cli/safeexec"
+	"github.com/kballard/go-shellquote"
 	"github.com/manifoldco/promptui"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/encrypt"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
@@ -19,18 +24,112 @@ var (
 	ErrorUserCancelled    = fmt.Errorf("user cancelled input")
 )
 
+// ErrNoRetry error where retries will not be attempted as the error is unrecoverable
+var ErrNoRetry = errors.New("no retry")
+
 // NewPromptWithPostValidate create a new prompt with a lazy validation function which is only
 // run when the user hits enter.
-func NewPromptWithPostValidate(p *promptui.Prompt, validate func(string) error) *PromptWithPostValidate {
+func NewPromptWithPostValidate(p Prompter, validate func(string) error) *PromptWithPostValidate {
 	return &PromptWithPostValidate{
-		prompt:       p,
+		Prompter:     p,
 		PostValidate: validate,
 		MaxAttempts:  2,
 	}
 }
 
+// Prompter interface for prompting the user for input
+type Prompter interface {
+	Prompt(attempt int, maxAttempts int) (string, error)
+	Exists() (bool, error)
+}
+
+func NewPinEntryPromptWithPostValidate(r Prompter, validate func(string) error) *PromptWithPostValidate {
+	return &PromptWithPostValidate{
+		Prompter:     r,
+		PostValidate: validate,
+		MaxAttempts:  2,
+	}
+}
+
+// CommandLinePrompter prompts the user for input from the command line
+type CommandLinePrompter struct {
+	prompt *promptui.Prompt
+}
+
+func (p *CommandLinePrompter) Prompt(attempt int, maxAttempts int) (string, error) {
+	p.prompt.Templates.Prompt = "test me "
+	if attempt > 1 {
+		p.prompt.Templates.Valid = fmt.Sprintf("{{ \"(Attempt %d of %d)\" | red }} {{ . | bold }}: ", attempt, maxAttempts)
+	}
+	return p.prompt.Run()
+}
+
+func (p *CommandLinePrompter) Exists() (bool, error) {
+	return true, nil
+}
+
+type ExternalPrompter struct {
+	Command string
+	Args    []string
+}
+
+func NewErrPrompt(err error, message string) *ErrPrompt {
+	return &ErrPrompt{
+		Inner:   err,
+		Message: message,
+	}
+}
+
+// ErrPrompt wraps an error and provides a custom message.
+// It can be used to provide more context to an error without losing the original error.
+type ErrPrompt struct {
+	Inner   error
+	Message string
+}
+
+func (e *ErrPrompt) Error() string {
+	return e.Message
+}
+
+func (e *ErrPrompt) Unwrap() error {
+	return e.Inner
+}
+
+// Prompt for input by executing an external command and parsing the output
+func (p *ExternalPrompter) Prompt(attempt int, maxAttempts int) (string, error) {
+	commandPath, err := safeexec.LookPath(p.Command)
+	if err != nil {
+		return "", NewErrPrompt(ErrNoRetry, err.Error())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, commandPath, p.Args...)
+
+	var errBuf, outBuf bytes.Buffer
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	// don't passthrough additional values as this could be sensitive information
+	cmd.Env = []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+	}
+	if err := cmd.Run(); err != nil {
+		return "", NewErrPrompt(ErrNoRetry, fmt.Sprintf("pin entry failed. command=%s, args=%v, error=%s, stderr=%q", commandPath, p.Args, err, bytes.TrimSpace(errBuf.Bytes())))
+	}
+
+	return string(bytes.TrimSpace(outBuf.Bytes())), nil
+}
+
+func (p *ExternalPrompter) Exists() (bool, error) {
+	_, err := safeexec.LookPath(p.Command)
+	return err == nil, err
+}
+
 type PromptWithPostValidate struct {
-	prompt       *promptui.Prompt
+	Prompter     Prompter
 	Attempts     int
 	MaxAttempts  int
 	PostValidate func(string) error
@@ -46,14 +145,13 @@ func (p *PromptWithPostValidate) Run() (string, error) {
 	var input string
 	p.Attempts = 1
 	for {
-		p.prompt.Templates.Prompt = "test me "
-		if p.Attempts > 1 {
-			p.prompt.Templates.Valid = fmt.Sprintf("{{ \"(Attempt %d of %d)\" | red }} {{ . | bold }}: ", p.Attempts, p.MaxAttempts)
-		}
-		input, err = p.prompt.Run()
+		input, err = p.Prompter.Prompt(p.Attempts, p.MaxAttempts)
 
 		if p.IsUserCancelled(err) {
 			err = ErrorUserCancelled
+			break
+		}
+		if errors.Is(err, ErrNoRetry) {
 			break
 		}
 		err = p.PostValidate(input)
@@ -77,6 +175,7 @@ type Validate func(string) error
 type Prompt struct {
 	Logger         *logger.Logger
 	ShowValueAfter bool
+	PinEntry       string
 }
 
 // NewPrompt returns a new Prompt which can be used to prompt the user for
@@ -89,7 +188,7 @@ func NewPrompt(l *logger.Logger) *Prompt {
 
 // EncryptionPassphrase prompt for the encryption passphrase, and test the
 // passphrase against the encrypted content to see if it is valid
-func (p *Prompt) EncryptionPassphrase(encryptedData string, initPassphrase string, message string) (string, error) {
+func (p *Prompt) EncryptionPassphrase(encryptedData string, key string, initPassphrase string, message string) (string, error) {
 	var err error
 	secure := encrypt.NewSecureData("{encrypted}")
 
@@ -100,18 +199,53 @@ func (p *Prompt) EncryptionPassphrase(encryptedData string, initPassphrase strin
 		}
 		return nil
 	}
-	prompt := promptui.Prompt{
-		Stdin:       os.Stdin,
-		Stdout:      os.Stderr,
-		Default:     "",
-		Mask:        ' ',
-		HideEntered: true,
-		Label:       "Session is encrypted, enter passphrase 🔒 [input is hidden]",
-		Templates: &promptui.PromptTemplates{
-			Valid: "{{ . | bold }}: ",
-		},
+
+	var prompter Prompter
+
+	// Check for custom pin entry, but don't fail if it does not exist, just warn the user that it isn't being used for a good reason
+	if p.PinEntry != "" {
+		pinEntryCommand, err := shellquote.Split(p.PinEntry)
+		if err != nil {
+			pinEntryCommand = []string{p.PinEntry}
+		}
+
+		externalCommandArgs := []string{}
+		if len(pinEntryCommand) == 0 {
+			externalCommandArgs = append(externalCommandArgs, "get")
+		} else {
+			externalCommandArgs = append(externalCommandArgs, pinEntryCommand[1:]...)
+		}
+		externalCommandArgs = append(externalCommandArgs, key)
+		pinEntryPrompter := &ExternalPrompter{
+			Command: pinEntryCommand[0],
+			Args:    externalCommandArgs,
+		}
+		if _, promptErr := pinEntryPrompter.Exists(); promptErr != nil {
+			p.Logger.Warnf("user defined pin entry command (%s) does not exist. The default will be used instead. error=%s", p.PinEntry, promptErr)
+		} else {
+			p.Logger.Infof("Using external pin entry command. %s %s", pinEntryCommand[0], strings.Join(externalCommandArgs, " "))
+			prompter = pinEntryPrompter
+		}
 	}
-	promptWrapper := NewPromptWithPostValidate(&prompt, validate)
+
+	// Fallback to the default cli prompter
+	if prompter == nil {
+		prompter = &CommandLinePrompter{
+			prompt: &promptui.Prompt{
+				Stdin:       os.Stdin,
+				Stdout:      os.Stderr,
+				Default:     "",
+				Mask:        ' ',
+				HideEntered: true,
+				Label:       "Session is encrypted, enter passphrase 🔒 [input is hidden]",
+				Templates: &promptui.PromptTemplates{
+					Valid: "{{ . | bold }}: ",
+				},
+			},
+		}
+	}
+
+	promptWrapper := NewPromptWithPostValidate(prompter, validate)
 
 	// check if init passphrase is ok without prompting the user
 	if err := validate(initPassphrase); err == nil {

--- a/pkg/stream/stream.go
+++ b/pkg/stream/stream.go
@@ -8,10 +8,18 @@ import (
 	"unicode"
 )
 
+type Mode int
+
+const (
+	ModeAuto Mode = 0
+	ModeText Mode = 1
+)
+
 // InputStreamer an input streamer which breaks down a buffer into input values
 type InputStreamer struct {
 	IgnoreEmptyLines bool
 	Buffer           *bufio.Reader
+	Mode             Mode
 }
 
 func (r *InputStreamer) isJSONObject() (bool, error) {
@@ -120,8 +128,10 @@ func (r *InputStreamer) Read() (output []byte, err error) {
 		}
 
 	} else {
-		if err := r.consumeWhitespaceOnLine(); err != nil {
-			return output, err
+		if r.Mode != ModeText {
+			if err := r.consumeWhitespaceOnLine(); err != nil {
+				return output, err
+			}
 		}
 	}
 
@@ -131,7 +141,7 @@ func (r *InputStreamer) Read() (output []byte, err error) {
 		return output, err
 	}
 
-	if isJSON {
+	if isJSON && r.Mode != ModeText {
 		output, err = r.ReadJSONObject()
 	} else {
 		output, err = r.ReadLine()


### PR DESCRIPTION
Allow users to define a custom `C8Y_SETTINGS_PINENTRY` command which will be called to prompt for the encryption passphrase (if needed).

This allows for a tigher integration with external tooling that will be invoked when dealing with with any of the encrypted data, like from the following commands:

* `c8y session set` (or via the helper `set-session`)
* `c8y settings update`
* `c8y sessions encryptText`
* `c8y sessions decryptText`

The pin entry command will be called with an additional positional argument `C8Y_PASSPHRASE`

**Real World Example (macOS)**

For macOs, if you install [reubenmiller/touchie](https://github.com/reubenmiller/touchie), then you can do the following flow:

```sh
# store your passphrase in keychain
touchie set C8Y_PASSPHRASE

# configure
export C8Y_SETTINGS_PINENTRY="touchie get"

# set session (using the default set-session, with zero modifications required)
set-session
```

In the above example, `touchie` will be called using:

```sh
touchie get C8Y_PASSPHRASE
```