### PR TITLE
feat: inject secrets from the pin entry app when calling an external provider

### DIFF
--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -3,6 +3,7 @@ package login
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonUtilities"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/prompt"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/shell"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
@@ -34,6 +36,7 @@ type CmdLogin struct {
 	Env      bool
 	Format   string
 	Provider string
+	Secrets  []string
 
 	// Login options
 	LoginType string
@@ -47,14 +50,6 @@ type CmdLogin struct {
 
 	factory *cmdutil.Factory
 }
-
-var (
-	ProviderTypeAuto     = "auto"
-	ProviderTypeFile     = "file"
-	ProviderTypeEnv      = "env"
-	ProviderTypeExternal = "external"
-	ProviderTypeStdin    = "stdin"
-)
 
 func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	ccmd := &CmdLogin{
@@ -78,7 +73,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 			$ eval "$( c8y sessions login --from-cmd "c8y sessions set --output json" )"
 			Set a session using the in-built "c8y sessions set"
 
-			$ eval "$( c8y sessions login --from-cmd "c8y-session-bitwarden list --folder c8y" --format json )"
+			$ eval "$( c8y sessions login --from-cmd "c8y-session-bitwarden list --folder c8y" --secrets BW_SESSION --format json )"
 			Set a session from an external command, where the external commands returns the selected session in json format on stdout
 		`),
 		RunE: ccmd.RunE,
@@ -96,12 +91,13 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().StringVar(&ccmd.OutputFormat, "output-format", "", "Output format")
 	cmd.Flags().StringVar(&ccmd.Shell, "shell", "", "Shell type to return the environment variables")
 	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL or BASIC. When set to BASIC, any existing token will be cleared")
+	cmd.Flags().StringSliceVar(&ccmd.Secrets, "secrets", []string{}, "List of secrets to include as env variables when running an external command. Only valid with from-cmd")
 
 	completion.WithOptions(
 		cmd,
 		completion.WithValidateSet("shell", "auto", "bash", "zsh", "fish", "powershell"),
 		completion.WithValidateSet("output-format", "json", "dotenv"),
-		completion.WithValidateSet("provider", ProviderTypeFile, ProviderTypeStdin, ProviderTypeEnv, ProviderTypeExternal, ProviderTypeAuto),
+		completion.WithValidateSet("provider", config.ProviderTypeFile, config.ProviderTypeStdin, config.ProviderTypeEnv, config.ProviderTypeExternal, config.ProviderTypeAuto),
 		completion.WithValidateSet("format", "json", "yaml", "toml", "dotenv"),
 		completion.WithValidateSet("loginType", c8y.AuthMethodOAuth2Internal, c8y.AuthMethodBasic),
 	)
@@ -171,23 +167,38 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 		return nil, err
 	}
 
-	providerCmd := strings.TrimSpace(n.Exec)
-	if providerCmd == "" {
-		providerCmd = strings.TrimSpace(cfg.GetString("settings.session.providerCmd"))
-	}
-	if providerCmd == "" {
-		return nil, fmt.Errorf("provider is not set")
+	// add secrets when executing the environment in case
+	// if the external command requires extra authentication
+	env := os.Environ()
+	for _, key := range n.Secrets {
+		if v := os.Getenv(key); v == "" {
+			secret, secretErr := cfg.PromptSecret(key)
+			if secretErr != nil {
+				if !errors.Is(secretErr, prompt.ErrNoPrompter) {
+					cfg.Logger.Warnf("Could not get secret. key=%s, err=%s", key, secretErr)
+				}
+			} else {
+				cfg.Logger.Debugf("Setting env variable secret for external provider. %s", key)
+				env = append(env, fmt.Sprintf("%s=%s", key, secret))
+			}
+		}
 	}
 
-	cmdArgs, err := shellquote.Split(providerCmd)
+	providerCmd := strings.TrimSpace(n.Exec)
+	if providerCmd == "" {
+		return nil, fmt.Errorf("provider command is not set")
+	}
+
+	cmdArgs, err := shellquote.Split(strings.TrimSpace(providerCmd))
 	if err != nil {
 		return nil, err
 	}
 	if len(cmdArgs) == 0 {
-		return nil, fmt.Errorf("executable is empty")
+		return nil, fmt.Errorf("provider command could not be parsed")
 	}
 	cmdExec := cmdArgs[0]
 	cmd := exec.Command(cmdExec, slices.Concat(cmdArgs[1:], args)...)
+	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 
@@ -281,51 +292,62 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Set defaults from config if values from flags aren't provided
+	if !cmd.Flags().Changed("provider") {
+		n.Provider = cfg.SessionProvider()
+		cfg.Logger.Debugf("Using session provider from configuration. type=%s", n.Provider)
+	}
+
+	if !cmd.Flags().Changed("from-cmd") {
+		n.Exec = cfg.SessionProviderCommand()
+	}
+
+	if !cmd.Flags().Changed("secrets") {
+		n.Secrets = cfg.SessionProviderSecrets()
+	}
+
 	if n.Provider == "" {
-		n.Provider = cfg.GetString("settings.session.provider")
-		if n.Provider == "" {
-			n.Provider = ProviderTypeAuto
-		}
+		n.Provider = config.ProviderTypeAuto
 	}
 
 	// Clear any existing session file.
 	// If the user wants to load from a file, then use the --from-file option
 	cfg.ClearSessionFile()
 
-	if strings.EqualFold(n.Provider, ProviderTypeAuto) {
+	if strings.EqualFold(n.Provider, config.ProviderTypeAuto) {
 		//
 		// Try guessing a sensible default
 		//
 		if n.File != "" {
-			n.Provider = ProviderTypeFile
+			n.Provider = config.ProviderTypeFile
 		} else if n.Stdin {
-			n.Provider = ProviderTypeStdin
+			n.Provider = config.ProviderTypeStdin
 		} else if n.Env {
-			n.Provider = ProviderTypeEnv
+			n.Provider = config.ProviderTypeEnv
 		} else if n.Exec != "" {
-			n.Provider = ProviderTypeExternal
+			n.Provider = config.ProviderTypeExternal
 		} else if os.Getenv("CI") != "" {
 			// CI environment and generally env variables are used here
-			n.Provider = ProviderTypeEnv
+			n.Provider = config.ProviderTypeEnv
 		} else if n.factory.IOStreams.HasStdin() {
-			n.Provider = ProviderTypeStdin
+			n.Provider = config.ProviderTypeStdin
 		}
 	}
 
 	var session *c8ysession.CumulocitySession
 
 	switch strings.ToLower(n.Provider) {
-	case ProviderTypeExternal:
+	case config.ProviderTypeExternal:
 		session, err = n.FromExternalProvider(args)
-	case ProviderTypeEnv:
+	case config.ProviderTypeEnv:
 		session, err = n.FromEnv()
-	case ProviderTypeStdin:
+	case config.ProviderTypeStdin:
 		if !n.factory.IOStreams.HasStdin() {
 			err = fmt.Errorf("no stdin detected")
 		} else {
 			session, err = n.FromStdin(n.Format, args)
 		}
-	case ProviderTypeFile:
+	case config.ProviderTypeFile:
 		session, err = n.FromFile(n.File, n.Format)
 	default:
 		return fmt.Errorf("unknown provider")

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -323,6 +323,17 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"false",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
+	// Session provider
+	"session.provider.type": {"session.provider.type", "string", config.SettingsSessionProviderType, []string{
+		config.ProviderTypeAuto,
+		config.ProviderTypeEnv,
+		config.ProviderTypeExternal,
+		config.ProviderTypeFile,
+		config.ProviderTypeStdin,
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+	"session.provider.command": {"session.provider.command", "string", config.SettingsSessionProviderCommand, []string{}, nil, cobra.ShellCompDirectiveDefault},
+	"session.provider.secrets": {"session.provider.secrets", "string", config.SettingsSessionProviderSecrets, []string{}, nil, cobra.ShellCompDirectiveNoFileComp},
+
 	"pinEntry": {"pinEntry", "string", config.SettingsPinEntry, []string{}, nil, cobra.ShellCompDirectiveDefault},
 
 	// cache

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -58,6 +58,14 @@ const (
 	SettingsGlobalName = "settings"
 )
 
+var (
+	ProviderTypeAuto     = "auto"
+	ProviderTypeFile     = "file"
+	ProviderTypeEnv      = "env"
+	ProviderTypeExternal = "external"
+	ProviderTypeStdin    = "stdin"
+)
+
 const (
 	// SettingsIncludeAllPageSize property name used to control the default page size when using includeAll parameter
 	SettingsIncludeAllPageSize = "settings.includeAll.pageSize"
@@ -304,6 +312,15 @@ const (
 	// SettingsAllowEmptyPipe allow empty piped data
 	SettingsAllowEmptyPipe = "settings.defaults.allowEmptyPipe"
 
+	// SettingsSessionProviderType provider to use when setting a session
+	SettingsSessionProviderType = "settings.session.provider.type"
+
+	// SettingsSessionProviderCommand sets the command to run when running set-session
+	SettingsSessionProviderCommand = "settings.session.provider.command"
+
+	// SettingsSessionProviderSecrets the secrets which should be included as environment variables when calling the external provider command
+	SettingsSessionProviderSecrets = "settings.session.provider.secrets"
+
 	// SettingsLoginType preferred login type, i.e. BASIC, OAUTH_INTERNAL etc.
 	SettingsLoginType = "settings.login.type"
 
@@ -539,6 +556,9 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsForceTTY, false),
 
 		// Session options
+		WithBindEnv(SettingsSessionProviderType, ""),
+		WithBindEnv(SettingsSessionProviderCommand, ""),
+		WithBindEnv(SettingsSessionProviderSecrets, ""),
 		WithBindEnv(SettingsPinEntry, ""),
 		WithBindEnv(SettingsSessionAlwaysIncludePassword, false),
 		WithBindEnv(SettingsSessionTokenValidFor, "8h"),
@@ -596,6 +616,16 @@ func (c *Config) PromptPassphrase() (string, error) {
 		return c.Passphrase, nil
 	}
 	prompter, err := c.prompter.GetPassphrasePrompter(EnvPassphrase)
+	if err != nil {
+		return "", err
+	}
+	pass, err := prompter.Prompt(0, 1)
+	return pass, err
+}
+
+// PromptSecret prompts the user for the passphrase if it is not already set
+func (c *Config) PromptSecret(key string) (string, error) {
+	prompter, err := c.prompter.GetExternalPrompter(key)
 	if err != nil {
 		return "", err
 	}
@@ -969,6 +999,21 @@ func (c *Config) GetStringSlice(key string) []string {
 // GetDefaultUsername returns the default username
 func (c *Config) GetDefaultUsername() string {
 	return c.viper.GetString("settings.session.defaultUsername")
+}
+
+// SessionCommand returns session provider
+func (c *Config) SessionProvider() string {
+	return c.viper.GetString(SettingsSessionProviderType)
+}
+
+// SessionProviderCommand returns the command to use when logging into a session
+func (c *Config) SessionProviderCommand() string {
+	return c.viper.GetString(SettingsSessionProviderCommand)
+}
+
+// SessionProviderSecrets returns the env variables to be included in the external command
+func (c *Config) SessionProviderSecrets() []string {
+	return c.viper.GetStringSlice(SettingsSessionProviderSecrets)
 }
 
 // AlwaysIncludePassword password when setting a session

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -27,6 +27,9 @@ var (
 // ErrNoRetry error where retries will not be attempted as the error is unrecoverable
 var ErrNoRetry = errors.New("no retry")
 
+// ErrNoPrompter no prompter found
+var ErrNoPrompter = errors.New("no prompter found")
+
 // NewPromptWithPostValidate create a new prompt with a lazy validation function which is only
 // run when the user hits enter.
 func NewPromptWithPostValidate(p Prompter, validate func(string) error) *PromptWithPostValidate {
@@ -227,7 +230,7 @@ func (p *Prompt) WithPrompters(l *logger.Logger, opts ...UserPrompter) (Prompter
 			return curPrompter, nil
 		}
 	}
-	return nil, fmt.Errorf("no prompter found")
+	return nil, ErrNoPrompter
 }
 
 func (p *Prompt) GetPassphrasePrompter(key string) (Prompter, error) {
@@ -235,6 +238,13 @@ func (p *Prompt) GetPassphrasePrompter(key string) (Prompter, error) {
 		p.Logger,
 		WithExternalPrompt(p.PinEntry, key),
 		WithCommandLinePrompt(""),
+	)
+}
+
+func (p *Prompt) GetExternalPrompter(key string) (Prompter, error) {
+	return p.WithPrompters(
+		p.Logger,
+		WithExternalPrompt(p.PinEntry, key),
 	)
 }
 


### PR DESCRIPTION
Improve the `c8y sessions login` command to improve lay the foundation for future work to allow a nicer customization of the `set-session` shell helper without having to edit it.


* Load session provider configuration from the configuration (type, external command, env secrets)
* Inject any specificed env secrets by using the pin-entry application