### PR TITLE
fix: update invalid doc string references to OAUTH_INTERNAL

### DIFF
--- a/api/spec/json/currentUser.json
+++ b/api/spec/json/currentUser.json
@@ -103,7 +103,7 @@
     {
       "name": "logout",
       "description": "Logout current user",
-      "descriptionLong": "Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL",
+      "descriptionLong": "Logout the current user. This will invalidate the token associated with the user when using OAUTH2_INTERNAL",
       "method": "POST",
       "path": "/user/logout",
       "accept": "",

--- a/api/spec/yaml/currentUser.yaml
+++ b/api/spec/yaml/currentUser.yaml
@@ -76,7 +76,7 @@ commands:
 
   - name: logout
     description: Logout current user
-    descriptionLong: Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL
+    descriptionLong: Logout the current user. This will invalidate the token associated with the user when using OAUTH2_INTERNAL
     method: POST
     path: /user/logout
     accept: ''

--- a/docs/go-c8y-cli/docs/cli/c8y/currentuser/c8y_currentuser_logout.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/currentuser/c8y_currentuser_logout.md
@@ -6,7 +6,7 @@ Logout current user
 
 ### Synopsis
 
-Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL
+Logout the current user. This will invalidate the token associated with the user when using OAUTH2_INTERNAL
 
 ```
 c8y currentuser logout [flags]

--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_create.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_create.md
@@ -44,7 +44,7 @@ $ c8y sessions create --type prod --host "https://localhost:443" --insecure
       --encrypt              Encrypt passwords and tokens (occurs when logging in)
   -h, --help                 help for create
       --host string          Host. .e.g. test.cumulocity.com. (required)
-      --loginType string     Login Type, e.g. BASIC, OAUTH_INTERNAL, NONE
+      --loginType string     Login Type, e.g. BASIC, OAUTH2_INTERNAL, NONE
       --name string          Name of the session
       --noStorage            Don't store any passwords or tokens in the session file
       --noTenantPrefix       Don't use tenant name as a prefix to the user name when using Basic Authentication. Defaults to false

--- a/docs/go-c8y-cli/docs/cli/psc8y/Users/Invoke-UserLogout.md
+++ b/docs/go-c8y-cli/docs/cli/psc8y/Users/Invoke-UserLogout.md
@@ -72,7 +72,7 @@ Invoke-UserLogout
 
 ## DESCRIPTION
 Logout the current user.
-This will invalidate the token associated with the user when using OAUTH_INTERNAL
+This will invalidate the token associated with the user when using OAUTH2_INTERNAL
 
 ## EXAMPLES
 

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -73,7 +73,7 @@ type LoginHandler struct {
 	onSave func()
 }
 
-// NewLoginHandler creates a new login handler to process the full Cumulocity login process for different login types, i.e. OAUTH_INTERNAL, BASIC etc.
+// NewLoginHandler creates a new login handler to process the full Cumulocity login process for different login types, i.e. OAUTH2_INTERNAL, BASIC etc.
 func NewLoginHandler(c *c8y.Client, w io.Writer, onSave func()) *LoginHandler {
 	h := &LoginHandler{
 		C8Yclient:   c,

--- a/pkg/cmd/currentuser/logout/logout.auto.go
+++ b/pkg/cmd/currentuser/logout/logout.auto.go
@@ -31,7 +31,7 @@ func NewLogoutCmd(f *cmdutil.Factory) *LogoutCmd {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Logout current user",
-		Long:  `Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL`,
+		Long:  `Logout the current user. This will invalidate the token associated with the user when using OAUTH2_INTERNAL`,
 		Example: heredoc.Doc(`
 $ c8y currentuser logout
 Log out the current user

--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -126,7 +126,7 @@ $ c8y sessions create --type prod --host "https://localhost:443" --insecure
 	cmd.Flags().StringVar(&ccmd.description, "description", "", "Description about the session")
 	cmd.Flags().StringVar(&ccmd.name, "name", "", "Name of the session")
 	cmd.Flags().StringVar(&ccmd.sessionType, "type", "", "Session type. List of predefined session types")
-	cmd.Flags().StringVar(&ccmd.loginType, "loginType", "", "Login Type, e.g. BASIC, OAUTH_INTERNAL, NONE")
+	cmd.Flags().StringVar(&ccmd.loginType, "loginType", "", "Login Type, e.g. BASIC, OAUTH2_INTERNAL, NONE")
 	cmd.Flags().BoolVar(&ccmd.noTenantPrefix, "noTenantPrefix", false, "Don't use tenant name as a prefix to the user name when using Basic Authentication. Defaults to false")
 	cmd.Flags().BoolVar(&ccmd.noStorage, "noStorage", false, "Don't store any passwords or tokens in the session file")
 	cmd.Flags().BoolVar(&ccmd.encrypt, "encrypt", false, "Encrypt passwords and tokens (occurs when logging in)")

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -321,7 +321,7 @@ const (
 	// SettingsSessionProviderSecrets the secrets which should be included as environment variables when calling the external provider command
 	SettingsSessionProviderSecrets = "settings.session.provider.secrets"
 
-	// SettingsLoginType preferred login type, i.e. BASIC, OAUTH_INTERNAL etc.
+	// SettingsLoginType preferred login type, i.e. BASIC, OAUTH2_INTERNAL etc.
 	SettingsLoginType = "settings.login.type"
 
 	// SettingsSessionAlwaysIncludePassword should the password always be included in the session variables or not

--- a/tools/PSc8y/Public/Invoke-UserLogout.ps1
+++ b/tools/PSc8y/Public/Invoke-UserLogout.ps1
@@ -5,7 +5,7 @@ Function Invoke-UserLogout {
 Logout current user
 
 .DESCRIPTION
-Logout the current user. This will invalidate the token associated with the user when using OAUTH_INTERNAL
+Logout the current user. This will invalidate the token associated with the user when using OAUTH2_INTERNAL
 
 .LINK
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/currentuser_logout

--- a/tools/schema/session.schema.json
+++ b/tools/schema/session.schema.json
@@ -92,7 +92,7 @@
                             "type": "string",
                             "enum": [
                                 "BASIC",
-                                "OAUTH_INTERNAL",
+                                "OAUTH2_INTERNAL",
                                 "NONE"
                             ]
                         }


### PR DESCRIPTION
Rename "OAUTH_INTERNAL" to "OAUTH2_INTERNAL". The incorrect name was only referenced in the command help text.