### PR TITLE
feat: use c8y sessions login within the set-session helper function

### DIFF
--- a/pkg/cmd/cli/profile/scripts/plugin.fish
+++ b/pkg/cmd/cli/profile/scripts/plugin.fish
@@ -33,7 +33,7 @@ end
 #   set-session
 #
 function set-session --description "Switch Cumulocity session interactively"
-    set c8yenv ( c8y sessions set --noColor=false $argv )
+    set c8yenv ( c8y sessions login --noColor=false $argv )
     if test $status -ne 0
         echo "Set session failed"
         return 1

--- a/pkg/cmd/cli/profile/scripts/plugin.posix.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.posix.sh
@@ -29,7 +29,7 @@ session() {
 #   set-session
 #
 set_session() {
-    c8yenv=$( c8y sessions set --noColor=false $@ )
+    c8yenv=$( c8y sessions login --noColor=false $@ )
     code=$?
     if [ $code -ne 0 ]; then
         echo "Set session failed"

--- a/pkg/cmd/cli/profile/scripts/plugin.ps1
+++ b/pkg/cmd/cli/profile/scripts/plugin.ps1
@@ -32,7 +32,7 @@ Set session and only show session matching "myhost"
 #>
     Param()
 
-    $c8yenv = c8y sessions set --noColor=false $args
+    $c8yenv = c8y sessions login --noColor=false $args
     if ($LASTEXITCODE -ne 0) {
         Write-Warning "Set session failed"
         return

--- a/pkg/cmd/cli/profile/scripts/plugin.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.sh
@@ -112,6 +112,7 @@ fi
 # Usage:
 #   session
 #
+unalias session 2>/dev/null ||:
 session() {
     c8y sessions get "$@"
 }
@@ -124,7 +125,7 @@ session() {
 #   set-session
 #
 set-session() {
-    c8yenv=$( c8y sessions set --noColor=false $@ )
+    c8yenv=$( c8y sessions login --noColor=false $@ )
     code=$?
     if [ $code -ne 0 ]; then
         echo "Set session failed"

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -282,6 +282,16 @@ func (n *CmdLogin) FromReader(r io.Reader, format string) (*c8ysession.Cumulocit
 	return n.FromViper(v)
 }
 
+func oneHasChanged(cmd *cobra.Command, names ...string) bool {
+	f := cmd.Flags()
+	for _, name := range names {
+		if f.Changed(name) {
+			return true
+		}
+	}
+	return false
+}
+
 func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 	cfg, err := n.factory.Config()
 	if err != nil {
@@ -315,13 +325,14 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Set defaults from config if values from flags aren't provided
-	if !cmd.Flags().Changed("provider") {
-		n.Provider = cfg.SessionProvider()
-		cfg.Logger.Debugf("Using session provider from configuration. type=%s", n.Provider)
-	}
+	if !oneHasChanged(cmd, "from-cmd", "from-file", "from-env", "from-stdin") {
 
-	if !cmd.Flags().Changed("from-cmd") {
+		// Set defaults from config if values from flags aren't provided
+		if !cmd.Flags().Changed("provider") {
+			n.Provider = cfg.SessionProvider()
+			cfg.Logger.Debugf("Using session provider from configuration. type=%s", n.Provider)
+		}
+
 		n.Exec = cfg.SessionProviderCommand()
 	}
 

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -292,6 +292,29 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	canChangeActiveSession := true
+	// Warn users if they try to use this command directly
+	if n.factory.IOStreams != nil {
+		if n.factory.IOStreams.IsStdoutTTY() {
+			canChangeActiveSession = false
+			notice := heredoc.Docf(`
+				You shouldn't run 'c8y session set' directly as it will have no effect on your current session.
+
+				Instead, you will need to use the 'set-session' helper function, or if you can't use the helper function, then run:
+		
+				  # zsh/bash/sh
+				  eval "$(c8y sessions login)"
+
+				  # fish
+				  c8y sessions login | source
+
+				  # powershell
+				  c8y sessions login | Out-String | Invoke-Expression
+			`)
+			fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s %s\n\n", strings.Repeat(n.factory.IOStreams.ColorScheme().WarningIcon(), 3), notice)
+		}
+	}
+
 	// Set defaults from config if values from flags aren't provided
 	if !cmd.Flags().Changed("provider") {
 		n.Provider = cfg.SessionProvider()
@@ -393,7 +416,12 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 	// Write session details to stderr (for humans)
 	cs := n.factory.IOStreams.ColorScheme()
-	fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
+
+	if canChangeActiveSession {
+		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
+	} else {
+		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is not active (see previous warning)\n", cs.WarningIcon())
+	}
 	if !n.NoBanner {
 		c8ysession.PrintSessionInfo(n.SubCommand.GetCommand().ErrOrStderr(), client, cfg, *session)
 	}

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -106,9 +106,11 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	canChangeActiveSession := true
 	// Warn users if they try to use this command directly
 	if n.factory.IOStreams != nil {
 		if n.factory.IOStreams.IsStdoutTTY() {
+			canChangeActiveSession = false
 			notice := heredoc.Docf(`
 				You shouldn't run 'c8y session set' directly as it will have no effect on your current session.
 
@@ -283,7 +285,11 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	// Write session details to stderr (for humans)
 	if outputFormat != config.OutputJSON.String() {
 		cs := n.factory.IOStreams.ColorScheme()
-		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
+		if canChangeActiveSession {
+			fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
+		} else {
+			fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is not active (see previous warning)\n", cs.WarningIcon())
+		}
 		if !n.NoBanner {
 			c8ysession.PrintSessionInfo(n.factory.IOStreams.ErrOut, client, cfg, *session)
 		}

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -556,8 +556,8 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsForceTTY, false),
 
 		// Session options
-		WithBindEnv(SettingsSessionProviderType, ""),
-		WithBindEnv(SettingsSessionProviderCommand, ""),
+		WithBindEnv(SettingsSessionProviderType, ProviderTypeExternal),
+		WithBindEnv(SettingsSessionProviderCommand, "c8y sessions set --no-banner --output json"),
 		WithBindEnv(SettingsSessionProviderSecrets, ""),
 		WithBindEnv(SettingsPinEntry, ""),
 		WithBindEnv(SettingsSessionAlwaysIncludePassword, false),


### PR DESCRIPTION
Change the `set-session` helper defintions to use the more generic `c8y sessions login` which now allows users to define they're own commands to get a session from external sources.

There should be now visible changes to the functionality.