### PR TITLE
feat: prompt users for confirmation on session mode mismatches

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,8 +51,7 @@ tasks:
         if [ ! -f /usr/bin/c8y ]; then \
           sudo ln -s "$(pwd)/tools/PSc8y/Dependencies/c8y.linux" /usr/bin/c8y; \
         fi
-        cp ./tools/shell/c8y.plugin.sh ~/
-        echo "source ~/c8y.plugin.sh"  >> ~/.bashrc
+        echo 'eval "$(c8y cli profile)"'  >> ~/.bashrc
 
         echo Installed c8y successfully
 

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pquerna/otp v1.4.0 h1:wZvl1TIVxKRThZIBiwOOHOGP/1+nZyWBil9Y2XNEDzg=
-github.com/pquerna/otp v1.4.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/reubenmiller/go-c8y v0.33.0 h1:U2iY25aewjEy/Ibm+R1W9bv8Y1USMpXn6uoCs3zLksY=

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -156,7 +156,9 @@ func PrintSessionInfo(w io.Writer, client *c8y.Client, cfg *config.Config, sessi
 	if session.Username != "" {
 		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "username")), value(maybeHideMessage(client, session.Username)))
 	}
-	fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "loginType")), value(client.AuthorizationMethod))
+	if client != nil {
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "loginType")), value(client.AuthorizationMethod))
+	}
 	fmt.Fprintf(w, "\n")
 }
 

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -235,7 +235,7 @@ func GetVariablesFromSession(session *CumulocitySession, cfg *config.Config, cli
 	}
 
 	if mode != "" {
-		output[cfg.GetEnvKey(config.SettingsMode)] = mode
+		output[config.EnvSessionMode] = mode
 	}
 
 	cache := cfg.CachePassphraseVariables()
@@ -283,7 +283,7 @@ func GetSessionEnvKeys() []string {
 		"C8Y_HEADER",
 		"C8Y_HEADER_AUTHORIZATION",
 		"C8Y_SETTINGS_LOGIN_TYPE",
-		"C8Y_SETTINGS_SESSION_MODE",
+		config.EnvSessionMode,
 	}
 	return keys
 }

--- a/pkg/clio/clio.go
+++ b/pkg/clio/clio.go
@@ -65,3 +65,10 @@ func GetTTYStdin() *os.File {
 	}
 	return stdIn
 }
+
+// IsLastInPipeline checks if a command is the last in the pipeline
+// The check isn't perfect, however it is a good enough check if data
+// is being written to the console or not
+func IsLastInPipeline() bool {
+	return IsInteractiveTerminal(os.Stdout)
+}

--- a/pkg/clio/clio.go
+++ b/pkg/clio/clio.go
@@ -3,6 +3,8 @@ package clio
 import (
 	"os"
 	"runtime"
+
+	"golang.org/x/term"
 )
 
 // HasPipedInput checks if os.Stdin is receiving piped input.
@@ -46,6 +48,14 @@ func IsInteractiveTerminal(f *os.File) bool {
 		return false
 	}
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
+// IsTerminal checks if the output is a terminal or not
+func IsTerminal(f *os.File) bool {
+	if f == nil {
+		f = os.Stdout
+	}
+	return term.IsTerminal(int(f.Fd()))
 }
 
 func GetTTYStdin() *os.File {

--- a/pkg/cmd/agents/create/create.auto.go
+++ b/pkg/cmd/agents/create/create.auto.go
@@ -42,7 +42,7 @@ $ c8y agents create --name myAgent --data "custom_value1=1234"
 Create agent with custom properties
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/agents/delete/delete.auto.go
+++ b/pkg/cmd/agents/delete/delete.auto.go
@@ -46,7 +46,7 @@ $ c8y agents delete --id 12345 --withDeviceUser
 Delete agent and related device user/credentials
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/agents/update/update.auto.go
+++ b/pkg/cmd/agents/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y agents update --id 12345
 Update agent by id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/alarms/create/create.auto.go
+++ b/pkg/cmd/alarms/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y alarms create --device 12345 --type c8y_TestAlarm --time "-0s" --text "Tes
 Create a new alarm for device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/alarms/deletecollection/deleteCollection.auto.go
@@ -41,7 +41,7 @@ $ c8y alarms deleteCollection --device 12345 --dateFrom "-10m" --status ACTIVE
 Remove alarms on the device which are active and created in the last 10 minutes
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/alarms/update/update.auto.go
+++ b/pkg/cmd/alarms/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y alarms update --id 12345 --severity CRITICAL
 Update severity of an existing alarm to CRITICAL
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/alarms/updatecollection/updateCollection.auto.go
+++ b/pkg/cmd/alarms/updatecollection/updateCollection.auto.go
@@ -38,7 +38,7 @@ $ c8y alarms updateCollection --device 12345 --status ACTIVE --newStatus ACKNOWL
 Update the status of all active alarms on a device to ACKNOWLEDGED
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -233,19 +233,19 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if strings.EqualFold(method, http.MethodPut) {
-		if err := n.factory.UpdateModeEnabled(); err != nil {
+		if err := n.factory.UpdateModeEnabled(cmd); err != nil {
 			return err
 		}
 	}
 
 	if strings.EqualFold(method, http.MethodPost) {
-		if err := n.factory.CreateModeEnabled(); err != nil {
+		if err := n.factory.CreateModeEnabled(cmd); err != nil {
 			return err
 		}
 	}
 
 	if strings.EqualFold(method, http.MethodDelete) {
-		if err := n.factory.DeleteModeEnabled(); err != nil {
+		if err := n.factory.DeleteModeEnabled(cmd); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/applications/copy/copy.auto.go
+++ b/pkg/cmd/applications/copy/copy.auto.go
@@ -47,7 +47,7 @@ $ c8y applications copy --id my-example-app
 Copy an existing application
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/create/create.auto.go
+++ b/pkg/cmd/applications/create/create.auto.go
@@ -37,7 +37,7 @@ $ c8y applications create --name myapp --type HOSTED --key "myapp-key" --context
 Create a new hosted application
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/createbinary/createBinary.auto.go
+++ b/pkg/cmd/applications/createbinary/createBinary.auto.go
@@ -46,7 +46,7 @@ $ c8y applications createBinary --id 12345 --file ./helloworld.zip
 Upload application microservice binary
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
+++ b/pkg/cmd/applications/createhostedapplication/createHostedApplication.manual.go
@@ -79,7 +79,7 @@ func NewCmdCreateHostedApplication(f *cmdutil.Factory) *CmdCreateHostedApplicati
 			Create/update hosted web application but don't activate it, so the current version (if any) will be untouched
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/delete/delete.auto.go
+++ b/pkg/cmd/applications/delete/delete.auto.go
@@ -47,7 +47,7 @@ $ c8y applications delete --id 12345 --unsubscribeAll
 Unsubscribe and application then delete it
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
+++ b/pkg/cmd/applications/deleteapplicationbinary/deleteApplicationBinary.auto.go
@@ -41,7 +41,7 @@ $ c8y applications deleteApplicationBinary --application 12345 --binaryId 9876
 Remove an application binary related to a Hosted (web) application
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/update/update.auto.go
+++ b/pkg/cmd/applications/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y applications update --id "my-example-app" --availability MARKET
 Update application availability to MARKET
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/versions/create/create.auto.go
+++ b/pkg/cmd/applications/versions/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y applications versions create --application 1234 --file "./testdata/myapp.z
 Create a new application version
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/versions/delete/delete.auto.go
+++ b/pkg/cmd/applications/versions/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y applications versions delete --application 1234 --version 1.0
 Delete application version by version name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/applications/versions/update/update.auto.go
+++ b/pkg/cmd/applications/versions/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y applications versions update --application 1234 --version 1.0 --tag tag1,l
 Replace application version's tags
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/auditrecords/create/create.auto.go
+++ b/pkg/cmd/auditrecords/create/create.auto.go
@@ -37,7 +37,7 @@ $ c8y auditrecords create --type "Inventory" --time "0s" --text "Managed Object 
 Create an audit record for a custom managed object update
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/binaries/create/create.auto.go
+++ b/pkg/cmd/binaries/create/create.auto.go
@@ -44,7 +44,7 @@ $ c8y binaries create --file "myConfig.json" --file "device01-myConfig.json" --t
 Upload a file with a custom name and custom meta information
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/binaries/delete/delete.auto.go
+++ b/pkg/cmd/binaries/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y binaries delete --id 12345
 Delete a binary
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/binaries/update/update.auto.go
+++ b/pkg/cmd/binaries/update/update.auto.go
@@ -40,7 +40,7 @@ $ c8y binaries update --id 12345 --file ./myfile.log
 Update an existing binary file
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/bulkoperations/create/create.auto.go
+++ b/pkg/cmd/bulkoperations/create/create.auto.go
@@ -41,7 +41,7 @@ $ c8y devicegroups get --id 12345 | c8y bulkoperations create --startDate "10s" 
 Create bulk operation for a group (using pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/bulkoperations/delete/delete.auto.go
+++ b/pkg/cmd/bulkoperations/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y bulkoperations delete --id 12345
 Remove bulk operation by id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/bulkoperations/update/update.auto.go
+++ b/pkg/cmd/bulkoperations/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y bulkoperations update --id 12345 --creationRampSec 15
 Update an bulk operation
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/cli/profile/scripts/plugin.fish
+++ b/pkg/cmd/cli/profile/scripts/plugin.fish
@@ -52,18 +52,6 @@ function clear-session --description "Clear all cumulocity session variables"
     c8y sessions clear | source
 end
 
-# -------------------
-# clear-c8ypassphrase
-# -------------------
-# Description: Clear the encryption passphrase environment variables
-# Usage:
-#   clear-c8ypassphrase
-#
-function clear-c8ypassphrase --description "Clear the encryption passphrase environment variables"
-    set -u C8Y_PASSPHRASE
-    set -u C8Y_PASSPHRASE_TEXT
-end
-
 # ----------------
 # set-c8ymode-xxxx
 # ----------------

--- a/pkg/cmd/cli/profile/scripts/plugin.fish
+++ b/pkg/cmd/cli/profile/scripts/plugin.fish
@@ -51,29 +51,3 @@ end
 function clear-session --description "Clear all cumulocity session variables"
     c8y sessions clear | source
 end
-
-# ----------------
-# set-c8ymode-xxxx
-# ----------------
-# Description: Set temporary mode by setting the environment variables
-# Usage:
-#   set-c8ymode-dev     (enable PUT, POST and DELETE)
-#   set-c8ymode-qual    (enable PUT, POST)
-#   set-c8ymode-prod    (disable PUT, POST and DELETE)
-#
-function set-c8ymode --description "Enable a c8y temporary mode by setting the environment variables"
-    c8y settings update --shell auto mode $argv[1] | source
-    echo (set_color green)"Enabled "$argv[1]" mode (temporarily)"(set_color normal)
-end
-
-function set-c8ymode-dev --description "Enable dev mode (All enabled)"
-    set-c8ymode dev
-end
-
-function set-c8ymode-qual --description "Enable qual mode (DELETE disabled)"
-    set-c8ymode qual
-end
-
-function set-c8ymode-prod --description "Enable prod mode (POST/PUT/DELETE disabled)"
-    set-c8ymode prod
-end

--- a/pkg/cmd/cli/profile/scripts/plugin.posix.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.posix.sh
@@ -17,9 +17,7 @@ export LC_ALL=C.UTF-8
 # Usage:
 #   session
 #
-session() {
-    c8y sessions get "$@"
-}
+alias session='c8y sessions get'
 
 # -----------
 # set-session

--- a/pkg/cmd/cli/profile/scripts/plugin.posix.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.posix.sh
@@ -49,21 +49,3 @@ clear_session() {
     eval "$c8yenv"
 }
 alias clear-session=clear_session
-
-# ----------------
-# set-c8ymode-xxxx
-# ----------------
-# Description: Set temporary mode by setting the environment variables
-# Usage:
-#   set-c8ymode-dev     (enable PUT, POST and DELETE)
-#   set-c8ymode-qual    (enable PUT, POST)
-#   set-c8ymode-prod    (disable PUT, POST and DELETE)
-#
-set_c8ymode() {
-    eval "$(c8y settings update --shell auto mode "$1")"
-    printf "\e[32mEnabled %s mode (temporarily)\e[0m\n" "$1";
-}
-alias set-c8ymode=set_c8ymode
-alias set-c8ymode-dev='set_c8ymode dev'
-alias set-c8ymode-qual='set_c8ymode qual'
-alias set-c8ymode-prod='set_c8ymode prod'

--- a/pkg/cmd/cli/profile/scripts/plugin.posix.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.posix.sh
@@ -52,19 +52,6 @@ clear_session() {
 }
 alias clear-session=clear_session
 
-# -------------------
-# clear-c8ypassphrase
-# -------------------
-# Description: Clear the encryption passphrase environment variables
-# Usage:
-#   clear-c8ypassphrase
-#
-clear_c8ypassphrase() {
-    unset C8Y_PASSPHRASE
-    unset C8Y_PASSPHRASE_TEXT
-}
-alias clear-c8ypassphrase=clear_c8ypassphrase
-
 # ----------------
 # set-c8ymode-xxxx
 # ----------------

--- a/pkg/cmd/cli/profile/scripts/plugin.ps1
+++ b/pkg/cmd/cli/profile/scripts/plugin.ps1
@@ -54,35 +54,3 @@ Clear session variables
     Param()
     c8y sessions clear | Out-String | Invoke-Expression
 }
-
-Function set-c8ymode {
-<#
-.SYNOPSIS
-Enable a c8y temporary mode by setting the environment variables
-
-.EXAMPLE
-set-c8ymode dev
-
-Enable dev mode (enables POST, PUT and DELETE commands)
-#>
-    [cmdletbinding()]
-    Param(
-        # Mode
-        [Parameter(
-            Mandatory = $true,
-            Position = 0
-        )]
-        [ValidateSet("dev", "qual", "prod")]
-        [string]
-        $Mode,
-
-        [parameter(ValueFromRemainingArguments=$true)]
-        $Options
-    )
-    c8y settings update --shell auto mode $Mode $Options | Out-String | Invoke-Expression
-    Write-Host "Enabled "$Mode" mode (temporarily)" -ForegroundColor Green
-}
-
-Function set-c8ymode-dev () { set-c8ymode dev; }
-Function set-c8ymode-qual () { set-c8ymode qual; }
-Function set-c8ymode-prod () { set-c8ymode prod; }

--- a/pkg/cmd/cli/profile/scripts/plugin.ps1
+++ b/pkg/cmd/cli/profile/scripts/plugin.ps1
@@ -55,22 +55,6 @@ Clear session variables
     c8y sessions clear | Out-String | Invoke-Expression
 }
 
-Function clear-c8ypassphrase {
-<#
-.SYNOPSIS
-Clear the encryption passphrase environment variables
-
-.EXAMPLE
-clear-c8ypassphrase
-
-Clear encryption passphrase variables
-#>
-    [cmdletbinding()]
-    Param()
-    $env:C8Y_PASSPHRASE = $null
-    $env:C8Y_PASSPHRASE_TEXT = $null
-}
-
 Function set-c8ymode {
 <#
 .SYNOPSIS

--- a/pkg/cmd/cli/profile/scripts/plugin.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.sh
@@ -142,20 +142,3 @@ clear-session() {
     c8yenv=$(c8y sessions clear)
     eval "$c8yenv"
 }
-
-# ----------------
-# set-c8ymode-xxxx
-# ----------------
-# Description: Set temporary mode by setting the environment variables
-# Usage:
-#   set-c8ymode-dev     (enable PUT, POST and DELETE)
-#   set-c8ymode-qual    (enable PUT, POST)
-#   set-c8ymode-prod    (disable PUT, POST and DELETE)
-#
-set-c8ymode() {
-    eval "$(c8y settings update --shell auto mode "$1")"
-    printf "\e[32mEnabled %s mode (temporarily)\e[0m\n" "$1";
-}
-set-c8ymode-dev() { set-c8ymode dev; }
-set-c8ymode-qual() { set-c8ymode qual; }
-set-c8ymode-prod() { set-c8ymode prod; }

--- a/pkg/cmd/cli/profile/scripts/plugin.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.sh
@@ -112,10 +112,7 @@ fi
 # Usage:
 #   session
 #
-unalias session 2>/dev/null ||:
-session() {
-    c8y sessions get "$@"
-}
+alias session='c8y sessions get'
 
 # -----------
 # set-session

--- a/pkg/cmd/cli/profile/scripts/plugin.sh
+++ b/pkg/cmd/cli/profile/scripts/plugin.sh
@@ -146,18 +146,6 @@ clear-session() {
     eval "$c8yenv"
 }
 
-# -------------------
-# clear-c8ypassphrase
-# -------------------
-# Description: Clear the encryption passphrase environment variables
-# Usage:
-#   clear-c8ypassphrase
-#
-clear-c8ypassphrase() {
-    unset C8Y_PASSPHRASE
-    unset C8Y_PASSPHRASE_TEXT
-}
-
 # ----------------
 # set-c8ymode-xxxx
 # ----------------

--- a/pkg/cmd/configuration/create/create.auto.go
+++ b/pkg/cmd/configuration/create/create.auto.go
@@ -45,7 +45,7 @@ available for multiple device types
 
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/configuration/delete/delete.auto.go
+++ b/pkg/cmd/configuration/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y configuration delete --id 12345 --forceCascade=false
 Delete a configuration package but keep any related binaries
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/configuration/send/send.auto.go
+++ b/pkg/cmd/configuration/send/send.auto.go
@@ -54,7 +54,7 @@ $ c8y configuration send --device 12345 --configurationType apt-lists --url "htt
 Send a custom configuration by manually providing the type and url
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/configuration/update/update.auto.go
+++ b/pkg/cmd/configuration/update/update.auto.go
@@ -40,7 +40,7 @@ $ c8y configuration update --id 12345 --newName "my_custom_name" --data "{\"com_
 Update a configuration file
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/currentapplication/update/update.auto.go
+++ b/pkg/cmd/currentapplication/update/update.auto.go
@@ -37,7 +37,7 @@ $ c8y currentapplication update --data "myCustomProp=1"
 Update custom properties of the current application (requires using application credentials)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/currentuser/logout/logout.auto.go
+++ b/pkg/cmd/currentuser/logout/logout.auto.go
@@ -37,7 +37,7 @@ $ c8y currentuser logout
 Log out the current user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/currentuser/update/update.auto.go
+++ b/pkg/cmd/currentuser/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y currentuser update --lastName "Smith"
 Update the current user's last name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/databroker/update/update.auto.go
+++ b/pkg/cmd/databroker/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y databroker update --id 12345 --status SUSPENDED
 Change the status of a specific data broker connector by given connector id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/datahub/jobs/cancel/cancel.auto.go
+++ b/pkg/cmd/datahub/jobs/cancel/cancel.auto.go
@@ -37,7 +37,7 @@ $ c8y datahub jobs cancel --id "22feee74-875a-561c-5508-04114bdda000"
 Cancel a datahub job
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/datahub/jobs/create/create.auto.go
+++ b/pkg/cmd/datahub/jobs/create/create.auto.go
@@ -40,7 +40,7 @@ $ c8y datahub jobs create --sql "SELECT * FROM alarms" --context myTenantIdDataL
 Create a new datahub job using context
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/assigndevice/assignDevice.auto.go
+++ b/pkg/cmd/devicegroups/assigndevice/assignDevice.auto.go
@@ -43,7 +43,7 @@ $ c8y devicegroups assignDevice --group 12345 --newChildDevice 43234,99292,12222
 Add multiple devices to a group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/assigngroup/assignGroup.auto.go
+++ b/pkg/cmd/devicegroups/assigngroup/assignGroup.auto.go
@@ -43,7 +43,7 @@ $ c8y devicegroups assignGroup --group 12345 --newChildGroup 43234,99292,12222
 Add multiple groups to a group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/children/assign/assign.auto.go
+++ b/pkg/cmd/devicegroups/children/assign/assign.auto.go
@@ -38,7 +38,7 @@ $ c8y devicegroups children assign --id 12345 --child 6789 --childType addition
 Add a related managed object as a child to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/children/create/create.auto.go
+++ b/pkg/cmd/devicegroups/children/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y devicegroups children create --id 12345 --data "custom.value=test" --globa
 Create a child addition and link it to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/children/unassign/unassign.auto.go
+++ b/pkg/cmd/devicegroups/children/unassign/unassign.auto.go
@@ -41,7 +41,7 @@ $ c8y devicegroups children unassign --id 12345 --child 22553 --childType device
 Unassign a child device from a managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/create/create.auto.go
+++ b/pkg/cmd/devicegroups/create/create.auto.go
@@ -41,7 +41,7 @@ $ c8y devicegroups create --name mygroup --data "custom_value1=1234"
 Create device group with custom properties
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/delete/delete.auto.go
+++ b/pkg/cmd/devicegroups/delete/delete.auto.go
@@ -39,7 +39,7 @@ $ c8y devicegroups delete --id 12345
 Get device group by id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/unassigndevice/unassignDevice.auto.go
+++ b/pkg/cmd/devicegroups/unassigndevice/unassignDevice.auto.go
@@ -40,7 +40,7 @@ $ c8y devicegroups unassignDevice --group 12345 --childDevice 22553
 Unassign a child device from its parent device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/unassigngroup/unassignGroup.auto.go
+++ b/pkg/cmd/devicegroups/unassigngroup/unassignGroup.auto.go
@@ -40,7 +40,7 @@ $ c8y devicegroups unassignGroup --id 12345 --child 22553
 Unassign a child device from its parent device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicegroups/update/update.auto.go
+++ b/pkg/cmd/devicegroups/update/update.auto.go
@@ -39,7 +39,7 @@ $ c8y devicegroups update --id 12345
 Update device group by id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificate_authority/create/create.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/create/create.manual.go
@@ -50,7 +50,7 @@ $ c8y devicemanagement certificate-authority create --status DISABLED
 Create new certificate authority but disable it
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificate_authority/delete/delete.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/delete/delete.manual.go
@@ -36,7 +36,7 @@ $ c8y devicemanagement certificate-authority delete
 Delete certificate authority
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificate_authority/get/get.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/get/get.manual.go
@@ -36,7 +36,7 @@ $ c8y devicemanagement certificate-authority get
 Get certificate authority to allow auto registration
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificate_authority/update/update.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/update/update.manual.go
@@ -41,7 +41,7 @@ $ c8y devicemanagement certificate-authority update --status DISABLED
 Disable certificate authority
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificates/create/create.auto.go
+++ b/pkg/cmd/devicemanagement/certificates/create/create.auto.go
@@ -41,7 +41,7 @@ $ c8y devicemanagement certificates list | c8y devicemanagement certificates cre
 Copy device certificates from one Cumulocity tenant to another (tenants must not be hosted on the same instance!)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificates/delete/delete.auto.go
+++ b/pkg/cmd/devicemanagement/certificates/delete/delete.auto.go
@@ -42,7 +42,7 @@ $ c8y devicemanagement certificates delete --id MyCert
 Remove trusted device certificate by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devicemanagement/certificates/update/update.auto.go
+++ b/pkg/cmd/devicemanagement/certificates/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y devicemanagement certificates update --id MyCert --status DISABLED
 Update device certificate by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceprofiles/create/create.auto.go
+++ b/pkg/cmd/deviceprofiles/create/create.auto.go
@@ -37,7 +37,7 @@ $ c8y deviceprofiles create --name "python3-requests"
 Create a device profile
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceprofiles/delete/delete.auto.go
+++ b/pkg/cmd/deviceprofiles/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y deviceprofiles delete --id 12345
 Delete a device profile
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceprofiles/update/update.auto.go
+++ b/pkg/cmd/deviceprofiles/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y deviceprofiles update --id 12345 --newName "my_custom_name" --data "{\"com
 Update a device profile
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceregistration/approve/approve.auto.go
+++ b/pkg/cmd/deviceregistration/approve/approve.auto.go
@@ -41,7 +41,7 @@ $ c8y deviceregistration approve --id "1234010101s01ldk208" --securityToken "abc
 Approve a new device request and provide a security token
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceregistration/delete/delete.auto.go
+++ b/pkg/cmd/deviceregistration/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y deviceregistration delete --id "91019192078"
 Delete a new device request
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceregistration/register/register.auto.go
+++ b/pkg/cmd/deviceregistration/register/register.auto.go
@@ -45,7 +45,7 @@ $ c8y deviceregistration register --id "ASDF098SD1J10912UD92JDLCNCU8" --group "M
 Register a new device and assign to a group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceregistration/registerBulk/register-basic.manual.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-basic.manual.go
@@ -40,7 +40,7 @@ func NewRegisterBasicCmd(f *cmdutil.Factory) *RegisterBasicCmd {
 			Register 2 devices, and set the names based on their external id (using basic auth)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceregistration/registerBulk/register-ca.manual.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-ca.manual.go
@@ -45,7 +45,7 @@ func NewRegisterCumulocityCACmd(f *cmdutil.Factory) *RegisterCumulocityCACmd {
 			Register 2 devices, and set the names based on their external id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/deviceregistration/registerBulk/register-external-ca.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-external-ca.go
@@ -43,7 +43,7 @@ func NewRegisterExternalCACmd(f *cmdutil.Factory) *RegisterExternalCACmd {
 			Register 2 devices, and set the names based on their external id (using CERTIFICATES auth)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/assignchild/assignChild.auto.go
+++ b/pkg/cmd/devices/assignchild/assignChild.auto.go
@@ -40,7 +40,7 @@ $ c8y devices assignChild --device 12345 --newChild 44235
 Assign a device as a child device to an existing device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/availability/set/set.auto.go
+++ b/pkg/cmd/devices/availability/set/set.auto.go
@@ -44,7 +44,7 @@ $ c8y devices list | c8y devices availability set --interval 10
 Set the required availability for a list of devices using pipeline
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/children/assign/assign.auto.go
+++ b/pkg/cmd/devices/children/assign/assign.auto.go
@@ -38,7 +38,7 @@ $ c8y devices children assign --id 12345 --child 6789 --childType addition
 Add a related managed object as a child to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/children/create/create.auto.go
+++ b/pkg/cmd/devices/children/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y devices children create --id 12345 --data "custom.value=test" --global --c
 Create a child addition and link it to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/children/unassign/unassign.auto.go
+++ b/pkg/cmd/devices/children/unassign/unassign.auto.go
@@ -41,7 +41,7 @@ $ c8y devices children unassign --id 12345 --child 22553 --childType device
 Unassign a child device from a managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/create/create.auto.go
+++ b/pkg/cmd/devices/create/create.auto.go
@@ -41,7 +41,7 @@ $ c8y devices create --name myDevice --data "custom_value1=1234"
 Create device with custom properties
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/delete/delete.auto.go
+++ b/pkg/cmd/devices/delete/delete.auto.go
@@ -45,7 +45,7 @@ $ c8y devices delete --id 12345 --withDeviceUser
 Delete device and related device user/credentials
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/services/create/create.auto.go
+++ b/pkg/cmd/devices/services/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y devices services create --device 12345 --name ntp --status up --serviceTyp
 Create a new service for a device (as a child addition)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/services/delete/delete.auto.go
+++ b/pkg/cmd/devices/services/delete/delete.auto.go
@@ -44,7 +44,7 @@ $ c8y devices services list --device 12345 | c8y devices services delete
 Get service status (using pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/services/update/update.auto.go
+++ b/pkg/cmd/devices/services/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y devices services list --device 12345 --name ntp | c8y devices services upd
 Update service status
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/unassignchild/unassignChild.auto.go
+++ b/pkg/cmd/devices/unassignchild/unassignChild.auto.go
@@ -40,7 +40,7 @@ $ c8y devices unassignChild --device 12345 --childDevice 22553
 Unassign a child device from its parent device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/update/update.auto.go
+++ b/pkg/cmd/devices/update/update.auto.go
@@ -47,7 +47,7 @@ $ c8y devices update --id 12345 --data "myFragment=null"
 Remove a property from a device by setting it to null
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/devices/user/update/update.auto.go
+++ b/pkg/cmd/devices/user/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y devices user update --id device01 --enabled=false
 Disable a device user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/create/create.auto.go
+++ b/pkg/cmd/events/create/create.auto.go
@@ -41,7 +41,7 @@ $ c8y devices get --id 12345 | c8y events create --type c8y_TestEvent --text "Te
 Create a new event for a device (using pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/createbinary/createBinary.auto.go
+++ b/pkg/cmd/events/createbinary/createBinary.auto.go
@@ -42,7 +42,7 @@ $ c8y events createBinary --id 12345 --file ./myfile.log --name "myfile-2022-03-
 Add a binary to an event using a custom name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/delete/delete.auto.go
+++ b/pkg/cmd/events/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y events delete --id 12345
 Delete an event
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/deletebinary/deleteBinary.auto.go
+++ b/pkg/cmd/events/deletebinary/deleteBinary.auto.go
@@ -39,7 +39,7 @@ $ c8y events deleteBinary --id 12345
 Delete an binary attached to an event
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/events/deletecollection/deleteCollection.auto.go
@@ -41,7 +41,7 @@ $ c8y events deleteCollection --device 12345
 Remove events from a device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/update/update.auto.go
+++ b/pkg/cmd/events/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y events update --id 12345 --data "{\"my_event\":{\"active\": true }}"
 Update custom properties of an existing event
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/events/updatebinary/updateBinary.auto.go
+++ b/pkg/cmd/events/updatebinary/updateBinary.auto.go
@@ -40,7 +40,7 @@ $ c8y events updateBinary --id 12345 --file ./myfile.log
 Update a binary related to an event
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/delete/delete.auto.go
+++ b/pkg/cmd/features/delete/delete.auto.go
@@ -37,7 +37,7 @@ $ c8y features delete --key example
 Remove the feature override for the current tenant
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/disable/disable.auto.go
+++ b/pkg/cmd/features/disable/disable.auto.go
@@ -37,7 +37,7 @@ $ c8y features disable --key example
 Disable a feature in the current tenant
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/enable/enable.auto.go
+++ b/pkg/cmd/features/enable/enable.auto.go
@@ -37,7 +37,7 @@ $ c8y features enable --key example
 Enable a feature in the current tenant
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/tenants/delete/delete.auto.go
+++ b/pkg/cmd/features/tenants/delete/delete.auto.go
@@ -37,7 +37,7 @@ $ c8y features tenants delete --key example --tenant t12345
 Remove the feature override from a given tenant
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/tenants/disable/disable.auto.go
+++ b/pkg/cmd/features/tenants/disable/disable.auto.go
@@ -40,7 +40,7 @@ $ c8y features tenants list --key ui.datapoint-graph.v2 | c8y features tenants d
 Disable the feature when it is active on subtenants
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/tenants/enable/enable.auto.go
+++ b/pkg/cmd/features/tenants/enable/enable.auto.go
@@ -40,7 +40,7 @@ $ c8y tenants list | c8y features tenants enable --key ui.datapoint-graph.v2
 Enable a specific feature on all subtenants
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/tenants/update/update.auto.go
+++ b/pkg/cmd/features/tenants/update/update.auto.go
@@ -37,7 +37,7 @@ $ c8y features tenants update --key example --active --tenant t12345
 Enable a feature for a given specific tenant
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/features/update/update.auto.go
+++ b/pkg/cmd/features/update/update.auto.go
@@ -37,7 +37,7 @@ $ c8y features update --key example --active
 Enable a feature in the current tenant
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/create/create.auto.go
+++ b/pkg/cmd/firmware/create/create.auto.go
@@ -40,7 +40,7 @@ $ echo -e "c8y_Linux\nc8y_MacOS" | c8y firmware create --name "iot-linux" --desc
 Create the same firmware package for multiple device types
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/delete/delete.auto.go
+++ b/pkg/cmd/firmware/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y firmware delete --id 12345 --forceCascade=false
 Delete a firmware package but keep the binaries
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/patches/create/create.manual.go
+++ b/pkg/cmd/firmware/patches/create/create.manual.go
@@ -47,7 +47,7 @@ func NewCreatePatchCmd(f *cmdutil.Factory) *CreateCmd {
 			Create a new patch with an empty version number and url
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/patches/delete/delete.auto.go
+++ b/pkg/cmd/firmware/patches/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y firmware patches delete --id 12345 --forceCascade=false
 Delete a firmware patch (but keep the related binary)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/update/update.auto.go
+++ b/pkg/cmd/firmware/update/update.auto.go
@@ -41,7 +41,7 @@ $ echo "12345" | c8y firmware update --newName "my_custom_name"
 Update a firmware package name (using pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/versions/create/create.manual.go
+++ b/pkg/cmd/firmware/versions/create/create.manual.go
@@ -47,7 +47,7 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 			Create a new version with an empty version number and url
 			`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/versions/delete/delete.auto.go
+++ b/pkg/cmd/firmware/versions/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y firmware versions delete --id 12345 --forceCascade=false
 Delete a firmware package (but keep any child binaries)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/firmware/versions/install/install.auto.go
+++ b/pkg/cmd/firmware/versions/install/install.auto.go
@@ -43,7 +43,7 @@ $ c8y firmware versions install --device 1234 --firmware linux-iot --version 1.0
 Install a firmware version with an explicit url
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/identity/create/create.auto.go
+++ b/pkg/cmd/identity/create/create.auto.go
@@ -41,7 +41,7 @@ $ c8y devices list | c8y identity create --type c8y_Serial --template "{ externa
 Create an external identity by using the .name property of the device (via the input template variable)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/identity/delete/delete.auto.go
+++ b/pkg/cmd/identity/delete/delete.auto.go
@@ -40,7 +40,7 @@ $ c8y devices list | c8y identity list --filter 'type eq c8y_Serial' | c8y ident
 Delete a specific external identity type (via pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/additions/assign/assign.auto.go
+++ b/pkg/cmd/inventory/additions/assign/assign.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory additions assign --id 12345 --child 6789
 Add a related managed object as a child to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/additions/create/create.auto.go
+++ b/pkg/cmd/inventory/additions/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory additions create --id 12345 --data "custom.value=test" --global
 Create a child addition and link it to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/additions/unassign/unassign.auto.go
+++ b/pkg/cmd/inventory/additions/unassign/unassign.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory additions unassign --id 12345 --child 22553
 Unassign a child addition from its parent managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/assets/assign/assign.auto.go
+++ b/pkg/cmd/inventory/assets/assign/assign.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory assets assign --id 12345 --childGroup 43234
 Create group hierarchy (parent group -> child group)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/assets/unassign/unassign.auto.go
+++ b/pkg/cmd/inventory/assets/unassign/unassign.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory assets unassign --id 12345 --child 22553
 Unassign a child device from its parent device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/children/assign/assign.auto.go
+++ b/pkg/cmd/inventory/children/assign/assign.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory children assign --id 12345 --child 6789 --childType addition
 Add a related managed object as a child to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/children/create/create.auto.go
+++ b/pkg/cmd/inventory/children/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y inventory children create --id 12345 --data "custom.value=test" --global -
 Create a child addition and link it to an existing managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/children/unassign/unassign.auto.go
+++ b/pkg/cmd/inventory/children/unassign/unassign.auto.go
@@ -41,7 +41,7 @@ $ c8y inventory children unassign --id 12345 --child 22553 --childType device
 Unassign a child device from a managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/create/create.auto.go
+++ b/pkg/cmd/inventory/create/create.auto.go
@@ -37,7 +37,7 @@ $ c8y inventory create --name "testMO" --type "custom_type"
 Create a managed object
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/delete/delete.auto.go
+++ b/pkg/cmd/inventory/delete/delete.auto.go
@@ -47,7 +47,7 @@ $ c8y inventory delete --id 12345 --forceCascade
 Delete a device and any related child assets, additions and/or devices
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/inventory/update/update.auto.go
+++ b/pkg/cmd/inventory/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y inventory update --id 12345 --data "my_Fragment=null"
 Remove a property (by setting it to null)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/measurements/create/create.auto.go
+++ b/pkg/cmd/measurements/create/create.auto.go
@@ -53,7 +53,7 @@ $ c8y measurements list --device 12345 --select '!id,**' | c8y measurements crea
 Copy measurements from one device to another
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/measurements/createBulk/createBulk.manual.go
+++ b/pkg/cmd/measurements/createBulk/createBulk.manual.go
@@ -52,7 +52,7 @@ func NewCreateBulkCmd(f *cmdutil.Factory) *CreateBulkCmd {
 			Copy measurements from one device to another modifying the measurements slightly but adding 100 to the value
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/measurements/delete/delete.auto.go
+++ b/pkg/cmd/measurements/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y measurements delete --id 12345
 Delete measurement
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
@@ -38,7 +38,7 @@ $ c8y measurements deleteCollection --device 12345
 Delete measurement collection for a device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/create/create.manual.go
+++ b/pkg/cmd/microservices/create/create.manual.go
@@ -76,7 +76,7 @@ $ c8y microservices create --file ./manifest/cumulocity.json
 Create or update an existing microservice using it's manifest file. This will set the requiredRoles and roles defined in the given manifest file
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/createbinary/createBinary.auto.go
+++ b/pkg/cmd/microservices/createbinary/createBinary.auto.go
@@ -47,7 +47,7 @@ $ c8y microservices createBinary --id 12345 --file ./helloworld.zip
 Upload microservice binary
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/delete/delete.auto.go
+++ b/pkg/cmd/microservices/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y microservices delete --id report-agent
 Delete a microservice by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/disable/disable.auto.go
+++ b/pkg/cmd/microservices/disable/disable.auto.go
@@ -42,7 +42,7 @@ $ c8y microservices disable --id report-agent
 Disable (unsubscribe) to a microservice
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/enable/enable.auto.go
+++ b/pkg/cmd/microservices/enable/enable.auto.go
@@ -42,7 +42,7 @@ $ c8y microservices enable --id report-agent
 Enable (subscribe) to a microservice by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/loglevels/delete/delete.auto.go
+++ b/pkg/cmd/microservices/loglevels/delete/delete.auto.go
@@ -43,7 +43,7 @@ $ c8y microservices loglevels delete --name my-microservice --loggerName org.exa
 Delete configured log level of microservice for a specific class
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/loglevels/set/set.auto.go
+++ b/pkg/cmd/microservices/loglevels/set/set.auto.go
@@ -42,7 +42,7 @@ $ c8y microservices loglevels set --name my-microservice --loggerName org.exampl
 Set log level of microservice for a specific class
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/serviceuser/create/create.manual.go
+++ b/pkg/cmd/microservices/serviceuser/create/create.manual.go
@@ -37,7 +37,7 @@ $ c8y microservices serviceusers create --name my-user
 Create new application service user
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/microservices/update/update.auto.go
+++ b/pkg/cmd/microservices/update/update.auto.go
@@ -39,7 +39,7 @@ $ c8y microservices update --id "report-agent" --availability MARKET
 Update microservice availability to MARKET
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/notification2/subscriptions/create/create.auto.go
+++ b/pkg/cmd/notification2/subscriptions/create/create.auto.go
@@ -44,7 +44,7 @@ $ c8y devices list | c8y notification2 subscriptions create --name devicegroup -
 Create a subscription which groups all devices in a single subscription name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/notification2/subscriptions/delete/delete.auto.go
+++ b/pkg/cmd/notification2/subscriptions/delete/delete.auto.go
@@ -43,7 +43,7 @@ $ c8y notification2 subscriptions list --filter "subscription like mysub" -p 100
 Delete all subscriptions which share the same subscription name (using client side filtering)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/notification2/subscriptions/deletebysource/deleteBySource.auto.go
+++ b/pkg/cmd/notification2/subscriptions/deletebysource/deleteBySource.auto.go
@@ -38,7 +38,7 @@ $ c8y notification2 subscriptions deleteBySource --device 12345
 Delete a subscription associated with a device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/notification2/tokens/create/create.auto.go
+++ b/pkg/cmd/notification2/tokens/create/create.auto.go
@@ -40,7 +40,7 @@ $ c8y notification2 tokens create --name testSubscription --subscriber testSubsc
 Create a new token which is valid for 30 minutes
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/notification2/tokens/unsubscribe/unsubscribe.auto.go
+++ b/pkg/cmd/notification2/tokens/unsubscribe/unsubscribe.auto.go
@@ -43,7 +43,7 @@ $ c8y notification2 tokens unsubscribe --token "eyJhbGciOiJSUzI1NiJ9"
 Unsubscribe a subscriber using its token
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/operations/cancel/cancel.auto.go
+++ b/pkg/cmd/operations/cancel/cancel.auto.go
@@ -41,7 +41,7 @@ $ c8y operations cancel --id 12345
 Cancel an operation
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/operations/create/create.auto.go
+++ b/pkg/cmd/operations/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y operations create --device 12345 --data "c8y_Restart={}"
 Create operation for a device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/operations/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/operations/deletecollection/deleteCollection.auto.go
@@ -41,7 +41,7 @@ $ c8y operations deleteCollection --device 12345 --status PENDING
 Remove all pending operations for a given device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/operations/update/update.auto.go
+++ b/pkg/cmd/operations/update/update.auto.go
@@ -39,7 +39,7 @@ $ c8y operations update --id 12345 --status EXECUTING
 Update an operation
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/configurations/create_passthrough/createPassthrough.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/create_passthrough/createPassthrough.auto.go
@@ -49,7 +49,7 @@ $ c8y remoteaccess configurations create-passthrough --device device01 --hostnam
 Create a SSH passthrough configuration with custom details
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/configurations/create_telnet/createTelnet.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/create_telnet/createTelnet.auto.go
@@ -40,7 +40,7 @@ $ c8y remoteaccess configurations create-telnet --device device01
 Create a telnet configuration
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/configurations/create_vnc/createVnc.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/create_vnc/createVnc.auto.go
@@ -43,7 +43,7 @@ $ c8y remoteaccess configurations create-vnc --device device01 --password 'asd08
 Create a VNC configuration that requires a password
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/configurations/create_webssh/createWebssh.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/create_webssh/createWebssh.auto.go
@@ -43,7 +43,7 @@ $ c8y remoteaccess configurations create-webssh --device device01 --hostname 127
 Create a webssh configuration with a custom hostname and port (with ssh key authentication)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/configurations/delete/delete.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y remoteaccess configurations delete --device device01 --id 1
 Delete an existing remote access configuration
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/remoteaccess/configurations/update/update.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/update/update.auto.go
@@ -40,7 +40,7 @@ $ c8y remoteaccess configurations update --device device01 --id 1 --newName hell
 Update an existing remote access configuration
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/retentionrules/create/create.auto.go
+++ b/pkg/cmd/retentionrules/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y retentionrules create --dataType ALARM --maximumAge 180
 Create a retention rule
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/retentionrules/delete/delete.auto.go
+++ b/pkg/cmd/retentionrules/delete/delete.auto.go
@@ -39,7 +39,7 @@ $ c8y retentionrules delete --id 12345
 Delete a retention rule
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/retentionrules/update/update.auto.go
+++ b/pkg/cmd/retentionrules/update/update.auto.go
@@ -39,7 +39,7 @@ $ c8y retentionrules update --id 12345 --maximumAge 90
 Update a retention rule
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -317,7 +317,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		if n.factory.IOStreams.IsStdoutTTY() {
 			canChangeActiveSession = false
 			notice := heredoc.Docf(`
-				You shouldn't run 'c8y session set' directly as it will have no effect on your current session.
+				You shouldn't run 'c8y session login' directly as it will have no effect on your current session.
 
 				Instead, you will need to use the 'set-session' helper function, or if you can't use the helper function, then run:
 		

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -130,7 +130,7 @@ func (n *CmdLogin) FromEnv() (*c8ysession.CumulocitySession, error) {
 		Tenant:   os.Getenv("C8Y_TENANT"),
 		Password: os.Getenv("C8Y_PASSWORD"),
 		Token:    os.Getenv("C8Y_TOKEN"),
-		Mode:     os.Getenv("C8Y_MODE"),
+		Mode:     os.Getenv(config.EnvSessionMode),
 	}
 
 	// Choose the first non-empty value

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -157,6 +157,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		unsetEnvSettings := []string{
 			cfg.GetEnvKey(config.SettingsLoginType),
 			cfg.GetEnvKey(config.SettingsMode),
+			cfg.GetEnvKey(config.EnvSessionMode),
 		}
 		env_prefix := strings.ToUpper(config.EnvSettingsPrefix)
 		for _, env := range os.Environ() {

--- a/pkg/cmd/smartgroups/create/create.auto.go
+++ b/pkg/cmd/smartgroups/create/create.auto.go
@@ -44,7 +44,7 @@ $ c8y smartgroups create --name mySmartGroup --query "type eq 'IS*'" --invisible
 Create a smart group which is not visible in the UI
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/smartgroups/delete/delete.auto.go
+++ b/pkg/cmd/smartgroups/delete/delete.auto.go
@@ -39,7 +39,7 @@ $ c8y smartgroups delete --id 12345
 Get smart group by id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/smartgroups/update/update.auto.go
+++ b/pkg/cmd/smartgroups/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y smartgroups update --id 12345
 Update smart group by id
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/create/create.auto.go
+++ b/pkg/cmd/software/create/create.auto.go
@@ -46,7 +46,7 @@ $ c8y software create --name "python3-requests" | c8y software versions create -
 Create a software package and create a new version
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/delete/delete.auto.go
+++ b/pkg/cmd/software/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y software delete --id 12345 --forceCascade=false
 Delete a software package but keep all related versions
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/update/update.auto.go
+++ b/pkg/cmd/software/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y software update --id 12345 --newName "my_custom_name" --data "{\"com_my_pr
 Update a software package
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/versions/create/create.manual.go
+++ b/pkg/cmd/software/versions/create/create.manual.go
@@ -47,7 +47,7 @@ func NewCreateCmd(f *cmdutil.Factory) *CreateCmd {
 			Create a new version with an empty version number and url
 			`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/versions/delete/delete.auto.go
+++ b/pkg/cmd/software/versions/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y software versions delete --id 12345 --forceCascade=false
 Delete a software package (but keep any child binaries)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/versions/install/install.auto.go
+++ b/pkg/cmd/software/versions/install/install.auto.go
@@ -44,7 +44,7 @@ Install a software package version with an explicit url
 
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/software/versions/uninstall/uninstall.auto.go
+++ b/pkg/cmd/software/versions/uninstall/uninstall.auto.go
@@ -38,7 +38,7 @@ $ c8y software versions uninstall --device 1234 --software go-c8y-cli --version 
 Uninstall a software package version
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenantoptions/create/create.auto.go
+++ b/pkg/cmd/tenantoptions/create/create.auto.go
@@ -37,7 +37,7 @@ $ c8y tenantoptions create --category "c8y_cli_tests" --key "option1" --value "1
 Create a tenant option
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenantoptions/delete/delete.auto.go
+++ b/pkg/cmd/tenantoptions/delete/delete.auto.go
@@ -37,7 +37,7 @@ $ c8y tenantoptions delete --category "c8y_cli_tests" --key "option3"
 Get a tenant option
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenantoptions/update/update.auto.go
+++ b/pkg/cmd/tenantoptions/update/update.auto.go
@@ -37,7 +37,7 @@ $ c8y tenantoptions update --category "c8y_cli_tests" --key "option4" --value "0
 Update a tenant option
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenantoptions/updatebulk/updateBulk.auto.go
+++ b/pkg/cmd/tenantoptions/updatebulk/updateBulk.auto.go
@@ -37,7 +37,7 @@ $ c8y tenantoptions updateBulk --category "c8y_cli_tests" --data "{\"option5\":0
 Update multiple tenant options
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenantoptions/updateedit/updateEdit.auto.go
+++ b/pkg/cmd/tenantoptions/updateedit/updateEdit.auto.go
@@ -39,7 +39,7 @@ $ c8y tenantoptions updateEdit --category "c8y_cli_tests" --key "option8" --edit
 Update editable property for an existing tenant option
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/applications/disable/disable.auto.go
+++ b/pkg/cmd/tenants/applications/disable/disable.auto.go
@@ -38,7 +38,7 @@ $ c8y tenants applications disable --tenant "t12345" --application "myMicroservi
 Disable an application of a tenant by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/applications/enable/enable.auto.go
+++ b/pkg/cmd/tenants/applications/enable/enable.auto.go
@@ -38,7 +38,7 @@ $ c8y tenants applications enable --tenant "t12345" --application "myMicroservic
 Enable an application of a tenant by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/create/create.auto.go
+++ b/pkg/cmd/tenants/create/create.auto.go
@@ -40,7 +40,7 @@ $ c8y tenants create --name "mycompany" --domain "mycompany" --adminEmail "admin
 Create a new tenant and send a password reset email (from the management tenant)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/delete/delete.auto.go
+++ b/pkg/cmd/tenants/delete/delete.auto.go
@@ -37,7 +37,7 @@ $ c8y tenants delete --id "mycompany"
 Delete a tenant by name (from the management tenant)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/disable/disable.auto.go
+++ b/pkg/cmd/tenants/disable/disable.auto.go
@@ -37,7 +37,7 @@ $ c8y tenants disable --id "mycompany"
 Disable a tenant (from the management tenant)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/disableapplication/disableApplication.auto.go
+++ b/pkg/cmd/tenants/disableapplication/disableApplication.auto.go
@@ -40,7 +40,7 @@ $ c8y tenants disableApplication --tenant "t12345" --application "myMicroservice
 Disable an application of a tenant by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/enable/enable.auto.go
+++ b/pkg/cmd/tenants/enable/enable.auto.go
@@ -37,7 +37,7 @@ $ c8y tenants enable --id "mycompany"
 Enable a tenant (from the management tenant)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/enableapplication/enableApplication.auto.go
+++ b/pkg/cmd/tenants/enableapplication/enableApplication.auto.go
@@ -40,7 +40,7 @@ $ c8y tenants enableApplication --tenant "t12345" --application "myMicroservice"
 Enable an application of a tenant by name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/tfa/update/update.auto.go
+++ b/pkg/cmd/tenants/tfa/update/update.auto.go
@@ -40,7 +40,7 @@ $ c8y tenants tfa update --tenant t12345 --strategy TOTP
 Update the Tenant's TFA setting to use time based one-time-password
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/tenants/update/update.auto.go
+++ b/pkg/cmd/tenants/update/update.auto.go
@@ -37,7 +37,7 @@ $ c8y tenants update --id "mycompany" --contactName "John Smith"
 Update a tenant by name (from the management tenant)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/ui/applications/plugins/delete/delete.manual.go
+++ b/pkg/cmd/ui/applications/plugins/delete/delete.manual.go
@@ -33,7 +33,7 @@ func NewCmd(f *cmdutil.Factory) *plugins.PluginCmd {
 			Delete all UI plugins from an application
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 	}
 

--- a/pkg/cmd/ui/applications/plugins/install/install.manual.go
+++ b/pkg/cmd/ui/applications/plugins/install/install.manual.go
@@ -30,7 +30,7 @@ func NewCmd(f *cmdutil.Factory) *plugins.PluginCmd {
 			Install myplugin via a lookup and add manual configuration using templates (for power users only!)
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 	}
 

--- a/pkg/cmd/ui/applications/plugins/replace/replace.manual.go
+++ b/pkg/cmd/ui/applications/plugins/replace/replace.manual.go
@@ -27,7 +27,7 @@ func NewCmd(f *cmdutil.Factory) *plugins.PluginCmd {
 			Replace all existing plugins with a new list of plugins
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 	}
 

--- a/pkg/cmd/ui/applications/plugins/update/update.manual.go
+++ b/pkg/cmd/ui/applications/plugins/update/update.manual.go
@@ -30,7 +30,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *plugins.PluginCmd {
 			Update specific UI plugins in an application 
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 	}
 

--- a/pkg/cmd/ui/plugins/create/create.manual.go
+++ b/pkg/cmd/ui/plugins/create/create.manual.go
@@ -69,7 +69,7 @@ func NewCmdCreate(f *cmdutil.Factory) *CmdCreate {
 			Create/update a ui plugin from a URL
 		`),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/ui/plugins/delete/delete.auto.go
+++ b/pkg/cmd/ui/plugins/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y ui plugins delete --id "my-example-app"
 Remove UI plugin
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/ui/plugins/update/update.auto.go
+++ b/pkg/cmd/ui/plugins/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y ui plugins update --id "my-example-app" --availability SHARED
 Update plugin availability to SHARED
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/ui/plugins/versions/create/create.auto.go
+++ b/pkg/cmd/ui/plugins/versions/create/create.auto.go
@@ -38,7 +38,7 @@ $ c8y ui plugins versions create --plugin 1234 --file "./testdata/myapp.zip" --v
 Create a new version for a plugin
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/ui/plugins/versions/delete/delete.auto.go
+++ b/pkg/cmd/ui/plugins/versions/delete/delete.auto.go
@@ -41,7 +41,7 @@ $ c8y ui plugins versions delete --plugin 1234 --version 1.0
 Delete plugin version by version name
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/ui/plugins/versions/update/update.auto.go
+++ b/pkg/cmd/ui/plugins/versions/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y ui plugins versions update --plugin 1234 --version 1.0 --tag tag1,latest
 Replace tags assigned to a version of a plugin
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/usergroups/create/create.auto.go
+++ b/pkg/cmd/usergroups/create/create.auto.go
@@ -37,7 +37,7 @@ $ c8y usergroups create --name customGroup1
 Create a user group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/usergroups/delete/delete.auto.go
+++ b/pkg/cmd/usergroups/delete/delete.auto.go
@@ -38,7 +38,7 @@ $ c8y usergroups delete --id 12345
 Delete a user group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/usergroups/update/update.auto.go
+++ b/pkg/cmd/usergroups/update/update.auto.go
@@ -41,7 +41,7 @@ $ c8y usergroups update --id 12345 --name "customGroup2" --template "{example: '
 Update a user group with custom properties
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/userreferences/addusertogroup/addUserToGroup.auto.go
+++ b/pkg/cmd/userreferences/addusertogroup/addUserToGroup.auto.go
@@ -44,7 +44,7 @@ $ c8y users list | c8y userreferences addUserToGroup --group business | c8y user
 Add a list of users to business and admins group (using pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/userreferences/deleteuserfromgroup/deleteUserFromGroup.auto.go
+++ b/pkg/cmd/userreferences/deleteuserfromgroup/deleteUserFromGroup.auto.go
@@ -41,7 +41,7 @@ $ c8y users get --id peterpi@example.com | c8y userreferences deleteUserFromGrou
 Delete a user from a user group (using pipeline)
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/userroles/addroletogroup/addRoleToGroup.auto.go
+++ b/pkg/cmd/userroles/addroletogroup/addRoleToGroup.auto.go
@@ -38,7 +38,7 @@ $ c8y userroles addRoleToGroup --group "12345" --role "*ALARM*"
 Add a role to the admin group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/userroles/addroletouser/addRoleToUser.auto.go
+++ b/pkg/cmd/userroles/addroletouser/addRoleToUser.auto.go
@@ -38,7 +38,7 @@ $ c8y userroles addRoleToUser --user "peterpi@example.com" --role "ROLE_ALARM_RE
 Add a role (ROLE_ALARM_READ) to a user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/userroles/deleterolefromgroup/deleteRoleFromGroup.auto.go
+++ b/pkg/cmd/userroles/deleterolefromgroup/deleteRoleFromGroup.auto.go
@@ -38,7 +38,7 @@ $ c8y userroles deleteRoleFromGroup --group 12345 --role "ROLE_MEASUREMENT_READ"
 Remove a role from the given user group
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/userroles/deleterolefromuser/deleteRoleFromUser.auto.go
+++ b/pkg/cmd/userroles/deleterolefromuser/deleteRoleFromUser.auto.go
@@ -38,7 +38,7 @@ $ c8y userroles deleteRoleFromUser --user "peterpi@example.com" --role "ROLE_MEA
 Remove a role from the given user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/users/create/create.auto.go
+++ b/pkg/cmd/users/create/create.auto.go
@@ -40,7 +40,7 @@ $ c8y users create --template "{email: 'test@me.com', userName: $.email, firstNa
 Create a user using a template
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/users/delete/delete.auto.go
+++ b/pkg/cmd/users/delete/delete.auto.go
@@ -40,7 +40,7 @@ $ c8y users delete --id "myuser"
 Delete a user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/users/resetuserpassword/resetUserPassword.auto.go
+++ b/pkg/cmd/users/resetuserpassword/resetUserPassword.auto.go
@@ -41,7 +41,7 @@ $ c8y users resetUserPassword --id "myuser"
 Update a user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/users/revoketotpsecret/revokeTOTPSecret.auto.go
+++ b/pkg/cmd/users/revoketotpsecret/revokeTOTPSecret.auto.go
@@ -41,7 +41,7 @@ $ c8y users revokeTOTPSecret --id "myuser"
 Revoke a user's TOTP (TFA) secret
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmd/users/update/update.auto.go
+++ b/pkg/cmd/users/update/update.auto.go
@@ -38,7 +38,7 @@ $ c8y users update --id "myuser" --firstName "Simon"
 Update a user
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		},
 		RunE: ccmd.RunE,
 	}

--- a/pkg/cmdparser/runtime_command.go
+++ b/pkg/cmdparser/runtime_command.go
@@ -34,11 +34,11 @@ func NewRuntimeCmd(f *cmdutil.Factory, options *CmdOptions) *RuntimeCmd {
 		// Mode checks
 		switch options.Spec.GetMethod() {
 		case "POST":
-			return f.CreateModeEnabled()
+			return f.CreateModeEnabled(cmd)
 		case "PUT":
-			return f.UpdateModeEnabled()
+			return f.UpdateModeEnabled(cmd)
 		case "DELETE":
-			return f.DeleteModeEnabled()
+			return f.DeleteModeEnabled(cmd)
 		}
 		return nil
 	}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -7,11 +7,16 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/fatih/color"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/activitylogger"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/clio"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/console"
@@ -27,6 +32,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/mapbuilder"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/mode"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/pathresolver"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/prompt"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/request"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -68,8 +74,74 @@ func (f *Factory) SetCommand(cmd *cobra.Command) *Factory {
 	return f
 }
 
+// confirmModeMismatch prompt the user for manual confirmation when a command that is not
+// enabled by default is used, and give the user a chance to confirm it.
+func confirmModeMismatch(cfg *config.Config, expectedMode string, command string) error {
+	if !clio.IsTerminal(os.Stderr) {
+		return fmt.Errorf("user did not confirm")
+	}
+
+	// add small delay so that other commands within the pipeline
+	// to try to avoid messages being mixed into the prompt
+	time.Sleep(100 * time.Millisecond)
+
+	bold := color.New(color.Bold, color.FgRed, color.Underline)
+	fmt.Fprint(os.Stderr, heredoc.Docf(`
+
+		%s This command (%s) is disabled in the session
+		
+		Check the following session information and then confirm the type of action.
+
+		`,
+		bold.Sprint("Session Mode Mismatch"),
+		command,
+	))
+
+	c8ysession.PrintSessionInfo(os.Stderr, nil, cfg, c8ysession.CumulocitySession{
+		SessionUri: cfg.GetSessionFile(),
+		Mode:       cfg.SessionMode().String(),
+		Host:       cfg.GetHost(),
+		Tenant:     cfg.GetTenant(),
+		Username:   cfg.GetUsername(),
+		Version:    cfg.GetCumulocityVersion(),
+	})
+
+	boldGreen := color.New(color.Bold, color.FgGreen)
+	fmt.Fprint(os.Stderr, heredoc.Docf(`
+		%s You can permanently change the session mode by using either:
+		  * set-session --mode dev (set the mode when selecting the session)
+		  * c8y settings update mode dev (set the default mode for the current session (requires reloading the session))
+		  * %s --sessionMode dev (set mode for a single command)
+
+		`,
+		boldGreen.Sprint("Tip"),
+		command,
+	))
+
+	mode, err := prompt.Select("Confirm the action to continue", []string{
+		"cancel",
+		expectedMode,
+	}, "cancel")
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("user did not confirm")
+		}
+		return err
+	}
+	if mode == expectedMode {
+		return nil
+	}
+	if mode == "cancel" {
+		return fmt.Errorf("user cancelled the command")
+	}
+	if mode != expectedMode {
+		return fmt.Errorf("user did not confirm")
+	}
+	return nil
+}
+
 // CreateModeEnabled create mode is enabled
-func (f *Factory) CreateModeEnabled() error {
+func (f *Factory) CreateModeEnabled(cmd *cobra.Command) error {
 	cfg, err := f.Config()
 	if err != nil {
 		return err
@@ -84,11 +156,23 @@ func (f *Factory) CreateModeEnabled() error {
 	if cfg.DryRun() {
 		return nil
 	}
-	return mode.ValidateCreateMode(cfg)
+
+	modeErr := mode.ValidateCreateMode(cfg)
+	if modeErr == nil {
+		return nil
+	}
+	if !clio.IsLastInPipeline() {
+		return modeErr
+	}
+
+	if err := confirmModeMismatch(cfg, "create", cmd.CommandPath()); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ValidateUpdateMode update mode is enabled
-func (f *Factory) UpdateModeEnabled() error {
+func (f *Factory) UpdateModeEnabled(cmd *cobra.Command) error {
 	cfg, err := f.Config()
 	if err != nil {
 		return err
@@ -103,11 +187,23 @@ func (f *Factory) UpdateModeEnabled() error {
 	if cfg.DryRun() {
 		return nil
 	}
-	return mode.ValidateUpdateMode(cfg)
+
+	modeErr := mode.ValidateUpdateMode(cfg)
+	if modeErr == nil {
+		return nil
+	}
+	if !clio.IsLastInPipeline() {
+		return modeErr
+	}
+
+	if err := confirmModeMismatch(cfg, "update", cmd.CommandPath()); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ValidateDeleteMode delete mode is enabled
-func (f *Factory) DeleteModeEnabled() error {
+func (f *Factory) DeleteModeEnabled(cmd *cobra.Command) error {
 	cfg, err := f.Config()
 	if err != nil {
 		return err
@@ -122,7 +218,19 @@ func (f *Factory) DeleteModeEnabled() error {
 	if cfg.DryRun() {
 		return nil
 	}
-	return mode.ValidateDeleteMode(cfg)
+
+	modeErr := mode.ValidateDeleteMode(cfg)
+	if modeErr == nil {
+		return nil
+	}
+	if !clio.IsLastInPipeline() {
+		return modeErr
+	}
+
+	if err := confirmModeMismatch(cfg, "delete", cmd.CommandPath()); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (f *Factory) GetRequestHandler() (*request.RequestHandler, error) {

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -41,6 +41,9 @@ var (
 	// EnvPassphraseText passphrase text environment variable name
 	EnvPassphraseText = "C8Y_PASSPHRASE_TEXT"
 
+	// EnvSessionMode session mode (short alias)
+	EnvSessionMode = "C8Y_MODE"
+
 	// PrefixEncrypted prefix used in encrypted string fields to identify when a string is encrypted or not
 	PrefixEncrypted = "{encrypted}"
 
@@ -530,7 +533,7 @@ func (c *Config) bindSettings() {
 		WithBoolEnvOverride(SettingsModeCI, "CI"),
 
 		// Support overriding the settings.session.mode value with the C8Y_MODE env variable
-		WithStringEnvOverride(SettingsMode, "C8Y_MODE"),
+		WithStringEnvOverride(SettingsMode, EnvSessionMode),
 
 		WithBindEnv(SettingsConfigPath, ""),
 		WithBindEnv(SettingsViewsCommonPaths, ""),

--- a/scripts/build-cli/New-C8yApiGoCommand.ps1
+++ b/scripts/build-cli/New-C8yApiGoCommand.ps1
@@ -536,9 +536,9 @@
     }
 
     $PreRunFunction = switch ($FunctionalMethod) {
-        "POST" { "f.CreateModeEnabled()" }
-        "PUT" { "f.UpdateModeEnabled()" }
-        "DELETE" { "f.DeleteModeEnabled()" }
+        "POST" { "f.CreateModeEnabled(cmd)" }
+        "PUT" { "f.UpdateModeEnabled(cmd)" }
+        "DELETE" { "f.DeleteModeEnabled(cmd)" }
         default { "nil" }
     }
 

--- a/tests/manual/common/disable_commands/disable_commands.yaml
+++ b/tests/manual/common/disable_commands/disable_commands.yaml
@@ -8,7 +8,6 @@ config:
     C8Y_SETTINGS_CI: false
     CI: ""
     C8Y_MODE: "prod"
-    C8Y_SETTINGS_SESSION_MODE: ""
 
 tests:
   It disables create commands:

--- a/tools/PSc8y/Tests/DisableCommands.manual.Tests.ps1
+++ b/tools/PSc8y/Tests/DisableCommands.manual.Tests.ps1
@@ -5,14 +5,14 @@ Describe -Name "Disable create/update/delete commands" {
         $backupEnvSettings = @{
             CI = $env:CI
             C8Y_SETTINGS_CI = $env:C8Y_SETTINGS_CI
-            C8Y_SETTINGS_SESSION_MODE = $env:C8Y_SETTINGS_SESSION_MODE
+            C8Y_MODE = $env:C8Y_MODE
         }
     }
 
     BeforeEach {
         $env:CI = "false"
         $env:C8Y_SETTINGS_CI = "false"
-        $env:C8Y_SETTINGS_SESSION_MODE = "prod"
+        $env:C8Y_MODE = "prod"
 
         $items = New-Object System.Collections.ArrayList
     }

--- a/tools/shell/c8y.plugin.fish
+++ b/tools/shell/c8y.plugin.fish
@@ -52,17 +52,6 @@ function clear-session --description "Clear all cumulocity session variables"
     c8y sessions clear | source
 end
 
-# -----------
-# clear-c8ypassphrase
-# -----------
-# Description: Clear the encryption passphrase environment variables
-# Usage:
-#   clear-c8ypassphrase
-#
-function clear-c8ypassphrase --description "Clear the encryption passphrase environment variables"
-    set -u C8Y_PASSPHRASE
-    set -u C8Y_PASSPHRASE_TEXT
-end
 
 # -----------
 # set-c8ymode-xxxx

--- a/tools/shell/c8y.plugin.fish
+++ b/tools/shell/c8y.plugin.fish
@@ -52,33 +52,6 @@ function clear-session --description "Clear all cumulocity session variables"
     c8y sessions clear | source
 end
 
-
-# -----------
-# set-c8ymode-xxxx
-# -----------
-# Description: Set temporary mode by setting the environment variables
-# Usage:
-#   set-c8ymode-dev     (enable PUT, POST and DELETE)
-#   set-c8ymode-qual    (enable PUT, POST)
-#   set-c8ymode-prod    (disable PUT, POST and DELETE)
-#
-function set-c8ymode --description "Enable a c8y temporary mode by setting the environment variables"
-    c8y settings update --shell auto mode $argv[1] | source
-    echo (set_color green)"Enabled "$argv[1]" mode (temporarily)"(set_color normal)
-end
-
-function set-c8ymode-dev --description "Enable dev mode (All enabled)"
-    set-c8ymode dev
-end
-
-function set-c8ymode-qual --description "Enable qual mode (DELETE disabled)"
-    set-c8ymode qual
-end
-
-function set-c8ymode-prod --description "Enable prod mode (POST/PUT/DELETE disabled)"
-    set-c8ymode prod
-end
-
 # ----------
 # c8y-update
 # ----------

--- a/tools/shell/c8y.plugin.ps1
+++ b/tools/shell/c8y.plugin.ps1
@@ -52,31 +52,3 @@ Clear session variables
     Param()
     c8y sessions clear | Out-String | Invoke-Expression
 }
-
-Function set-c8ymode {
-<#
-.SYNOPSIS
-Enable a c8y temporary mode by setting the environment variables
-
-.EXAMPLE
-set-c8ymode dev
-
-Enable dev mode (enables POST, PUT and DELETE commands)
-#>
-    [cmdletbinding()]
-    Param(
-        # Mode
-        [Parameter(
-            Mandatory = $true,
-            Position = 0
-        )]
-        [ValidateSet("dev", "qual", "prod")]
-        [string]
-        $Mode,
-
-        [parameter(ValueFromRemainingArguments=$true)]
-        $Options
-    )
-    c8y settings update --shell auto mode $Mode $Options | Out-String | Invoke-Expression
-    Write-Host "Enabled "$Mode" mode (temporarily)" -ForegroundColor Green
-}

--- a/tools/shell/c8y.plugin.ps1
+++ b/tools/shell/c8y.plugin.ps1
@@ -53,22 +53,6 @@ Clear session variables
     c8y sessions clear | Out-String | Invoke-Expression
 }
 
-Function clear-c8ypassphrase {
-<#
-.SYNOPSIS
-Clear the encryption passphrase environment variables
-
-.EXAMPLE
-clear-c8ypassphrase
-
-Clear encryption passphrase variables
-#>
-    [cmdletbinding()]
-    Param()
-    $env:C8Y_PASSPHRASE = $null
-    $env:C8Y_PASSPHRASE_TEXT = $null
-}
-
 Function set-c8ymode {
 <#
 .SYNOPSIS

--- a/tools/shell/c8y.plugin.sh
+++ b/tools/shell/c8y.plugin.sh
@@ -71,17 +71,6 @@ clear-session () {
     source <(c8y sessions clear)
 }
 
-# -----------
-# clear-c8ypassphrase
-# -----------
-# Description: Clear the encryption passphrase environment variables
-# Usage:
-#   clear-c8ypassphrase
-#
-clear-c8ypassphrase () {
-    unset C8Y_PASSPHRASE
-    unset C8Y_PASSPHRASE_TEXT
-}
 
 # -----------
 # set-c8ymode-xxxx

--- a/tools/shell/c8y.plugin.sh
+++ b/tools/shell/c8y.plugin.sh
@@ -38,9 +38,7 @@ fi
 # Usage:
 #   session
 #
-session() {
-    c8y sessions get "$@"
-}
+alias session='c8y sessions get'
 
 # -----------
 # set-session
@@ -70,24 +68,6 @@ set-session () {
 clear-session () {
     source <(c8y sessions clear)
 }
-
-
-# -----------
-# set-c8ymode-xxxx
-# -----------
-# Description: Set temporary mode by setting the environment variables
-# Usage:
-#   set-c8ymode-dev     (enable PUT, POST and DELETE)
-#   set-c8ymode-qual    (enable PUT, POST)
-#   set-c8ymode-prod    (disable PUT, POST and DELETE)
-#
-set-c8ymode () {
-    source <(c8y settings update --shell auto mode $1);
-    echo -e "\e[32mEnabled $1 mode (temporarily)\e[0m";
-}
-set-c8ymode-dev () { set-c8ymode dev; }
-set-c8ymode-qual () { set-c8ymode qual; }
-set-c8ymode-prod () { set-c8ymode prod; }
 
 # ----------
 # c8y-update

--- a/tools/shell/c8y.plugin.zsh
+++ b/tools/shell/c8y.plugin.zsh
@@ -99,18 +99,6 @@ clear-session () {
 }
 
 # -----------
-# clear-c8ypassphrase
-# -----------
-# Description: Clear the encryption passphrase environment variables
-# Usage:
-#   clear-c8ypassphrase
-#
-clear-c8ypassphrase () {
-    unset C8Y_PASSPHRASE
-    unset C8Y_PASSPHRASE_TEXT
-}
-
-# -----------
 # set-c8ymode-xxxx
 # -----------
 # Description: Set temporary mode by setting the environment variables

--- a/tools/shell/c8y.plugin.zsh
+++ b/tools/shell/c8y.plugin.zsh
@@ -65,9 +65,7 @@ init-c8y
 # Usage:
 #   session
 #
-session() {
-    c8y sessions get "$@"
-}
+alias session='c8y sessions get'
 
 # -----------
 # set-session
@@ -97,24 +95,6 @@ set-session () {
 clear-session () {
     source <(c8y sessions clear)
 }
-
-# -----------
-# set-c8ymode-xxxx
-# -----------
-# Description: Set temporary mode by setting the environment variables
-# Usage:
-#   set-c8ymode-dev     (enable PUT, POST and DELETE)
-#   set-c8ymode-qual    (enable PUT, POST)
-#   set-c8ymode-prod    (disable PUT, POST and DELETE)
-#
-set-c8ymode () {
-    source <(c8y settings update --shell auto mode $1);
-    echo -e "\e[32mEnabled $1 mode (temporarily)\e[0m";
-}
-set-c8ymode-dev () { set-c8ymode dev; }
-set-c8ymode-qual () { set-c8ymode qual; }
-set-c8ymode-prod () { set-c8ymode prod; }
-
 
 # ----------
 # c8y-update


### PR DESCRIPTION
Improve the UX around sessions by prompting the when a sesion mode mismatch, and getting the user to confirm that this is intended or not.

Previously the user would have to use one of the shell helpers like `set-c8ymode-dev` to change the mode, and then repeat the command. Having the user prompts makes for a more streamlined approach by preventing context switching, whilst still having the protection against accidental data loss due to being in the wrong session.

Below shows an example of the prompt that is presented to the user.


```
c8y inventory create

Session Mode Mismatch This command (c8y inventory create) is disabled in the session

Check the following session information and then confirm the type of action.

---------------------  Cumulocity Session  ---------------------

    source: /Users/example/.cumulocity/example.c8y.io-example.json


mode         : prod (allowed commands: read)
host         : example.c8y.io
tenant       : t1234
version      : 2025.198.0
username     : example

Tip You can permanently change the session mode by using either:
  * set-session --mode dev (set the mode when selecting the session)
  * c8y settings update mode dev (set the default mode for the current session (requires reloading the session))
  * c8y inventory create --sessionMode dev (set mode for a single command)

? Confirm the action to continue  [Use arrows to move, type to filter]
> cancel
  create
```