### PR TITLE
feat: auto detect more ci environments like Jenkins, TeamCity, TaskCluster and dsari

### DIFF
--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -369,7 +369,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 			n.Provider = config.ProviderTypeEnv
 		} else if n.Exec != "" {
 			n.Provider = config.ProviderTypeExternal
-		} else if os.Getenv("CI") != "" {
+		} else if cfg.IsCIMode() {
 			// CI environment and generally env variables are used here
 			n.Provider = config.ProviderTypeEnv
 		} else if n.factory.IOStreams.HasStdin() {

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -477,6 +477,20 @@ func WithBoolEnvOverride(name string, envName string) func(*Config) error {
 	}
 }
 
+// WithBoolEnvOverrides sets the configuration if the given env variable function returns true and no error
+func WithBoolEnvOverrides(name string, valueFunc func(k, v string) (bool, error), envNames ...string) func(*Config) error {
+	return func(c *Config) error {
+		for _, envName := range envNames {
+			if valueFunc != nil {
+				if v, err := valueFunc(envName, os.Getenv(envName)); v && err == nil {
+					c.viper.Set(name, v)
+				}
+			}
+		}
+		return nil
+	}
+}
+
 // WithStringEnvOverride supports optional overriding a string value from another env variable
 func WithStringEnvOverride(name string, envName string) func(*Config) error {
 	return func(c *Config) error {
@@ -527,10 +541,27 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsTemplatePath, ""),
 		WithBindEnv(SettingsMode, SessionModeProduction.String()),
 
-		// Support CI env variable as it is commonly used in CI/CD environments
-		// The env variable "CI" is preferred if present/valid
 		WithBindEnv(SettingsModeCI, false),
-		WithBoolEnvOverride(SettingsModeCI, "CI"),
+		// Determines if the current execution context is within a known CI/CD system.
+		// This is based on https://github.com/watson/ci-info/blob/HEAD/index.js.
+		WithBoolEnvOverrides(
+			SettingsModeCI,
+			func(k, v string) (bool, error) {
+				if k == "CI" {
+					return v != "false" && v != "", nil
+				}
+				return v != "", nil
+			},
+			"CI",                     // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari, Cloudflare Pages
+			"BUILD_ID",               // Jenkins, TeamCity
+			"BUILD_NUMBER",           // Jenkins, TeamCity
+			"RUN_ID",                 // TaskCluster, dsari
+			"CI_APP_ID",              // Appflow
+			"CI_BUILD_ID",            // Appflow
+			"CI_BUILD_NUMBER",        // Appflow
+			"CI_NAME",                // Codeship and others
+			"CONTINUOUS_INTEGRATION", // Travis CI, Cirrus CI
+		),
 
 		// Support overriding the settings.session.mode value with the C8Y_MODE env variable
 		WithStringEnvOverride(SettingsMode, EnvSessionMode),

--- a/tests/manual/settings/settings_ci.yaml
+++ b/tests/manual/settings/settings_ci.yaml
@@ -3,9 +3,13 @@ tests:
   It supports CI env:
     config:
       inherit-env: false
+      env:
+        CI: ""
+        C8Y_SETTINGS_CI: false
     command: |
       CI=true C8Y_SETTINGS_CI=false c8y settings list --select ci --output csv
       CI=true C8Y_SETTINGS_CI=true c8y settings list --select ci --output csv
+
       CI=false C8Y_SETTINGS_CI=false c8y settings list --select ci --output csv
       CI=false C8Y_SETTINGS_CI=true c8y settings list --select ci --output csv
 
@@ -17,6 +21,66 @@ tests:
         true
         true
         false
-        false
+        true
         false
         true
+
+  It supports Jenkins/TeamCity env:
+    config:
+      inherit-env: false
+      env:
+        CI: ""
+        C8Y_SETTINGS_CI: false
+    command: |
+      BUILD_NUMBER=1 C8Y_SETTINGS_CI=false c8y settings list --select ci --output csv
+    exit-code: 0
+    stdout:
+      exactly: |
+        true
+
+  It supports TaskCluster/dsari env:
+    config:
+      inherit-env: false
+      env:
+        CI: ""
+        C8Y_SETTINGS_CI: false
+    command: |
+      RUN_ID=1234 C8Y_SETTINGS_CI=false c8y settings list --select ci --output csv
+    exit-code: 0
+    stdout:
+      exactly: |
+        true
+
+  It supports Appflow:
+    config:
+      inherit-env: false
+      env:
+        CI: ""
+        C8Y_SETTINGS_CI: false
+    command: |
+      CI_APP_ID=1 c8y settings list --select ci --output csv
+      CI_BUILD_ID=1 c8y settings list --select ci --output csv
+      CI_BUILD_NUMBER=1 c8y settings list --select ci --output csv
+      c8y settings list --select ci --output csv
+    exit-code: 0
+    stdout:
+      exactly: |
+        true
+        true
+        true
+        false
+
+  It supports Travis CI / Cirrus CI:
+    config:
+      inherit-env: false
+      env:
+        CI: ""
+        C8Y_SETTINGS_CI: false
+    command: |
+      CONTINUOUS_INTEGRATION=1 c8y settings list --select ci --output csv
+      CONTINUOUS_INTEGRATION= c8y settings list --select ci --output csv
+    exit-code: 0
+    stdout:
+      exactly: |
+        true
+        false


### PR DESCRIPTION
Auto detect more CI environments out of the box. When a CI is detected, the session mode is disabled as CI environments are non-interactive and would.

Below shows the env variables used and the corresponding services:

```
"CI",                     // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari, Cloudflare Pages
"BUILD_ID",               // Jenkins, TeamCity
"BUILD_NUMBER",           // Jenkins, TeamCity
"RUN_ID",                 // TaskCluster, dsari
"CI_APP_ID",              // Appflow
"CI_BUILD_ID",            // Appflow
"CI_BUILD_NUMBER",        // Appflow
"CI_NAME",                // Codeship and others
"CONTINUOUS_INTEGRATION", // Travis CI, Cirrus CI
```