### PR TITLE
refactor: move shell types to a common package

### DIFF
--- a/pkg/cmd/cli/install/install.manual.go
+++ b/pkg/cmd/cli/install/install.manual.go
@@ -16,14 +16,15 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
 var ErrInstallFailed = errors.New("failed to install one or more profiles")
-var validShells = []string{"bash", "fish", "powershell", "zsh", "sh"}
+var validShells = shell.SupportedShells()
 
 // Skip sh when installing all shells as it generally does not have a profile defined
-var defaultShells = []string{"bash", "fish", "powershell", "zsh"}
+var defaultShells = []string{shell.ShellBash, shell.ShellFish, shell.ShellPowershell, shell.ShellZsh}
 
 type CmdInstall struct {
 	*subcommand.SubCommand
@@ -81,11 +82,11 @@ func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	shells := map[string]Shell{
-		"bash":       {Name: "bash", Binary: "bash"},
-		"zsh":        {Name: "zsh", Binary: "zsh"},
-		"sh":         {Name: "sh", Binary: "sh"},
-		"powershell": {Name: "powershell", Binary: "pwsh"},
-		"fish":       {Name: "fish", Binary: "fish"},
+		shell.ShellBash:       {Name: "bash", Binary: "bash"},
+		shell.ShellZsh:        {Name: "zsh", Binary: "zsh"},
+		shell.ShellPosixShell: {Name: "sh", Binary: "sh"},
+		shell.ShellPowershell: {Name: "powershell", Binary: "pwsh"},
+		shell.ShellFish:       {Name: "fish", Binary: "fish"},
 	}
 
 	var Errs []error
@@ -150,7 +151,7 @@ func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 	return summaryErr
 }
 
-func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
+func (n *CmdInstall) InstallProfile(shellType string) (bool, error) {
 	changed := false
 	cfg, err := n.factory.Config()
 	if err != nil {
@@ -159,8 +160,8 @@ func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
 	profilePath := ""
 	profileSnippet := ""
 
-	switch shell {
-	case "sh":
+	switch shellType {
+	case shell.ShellPosixShell:
 		// sh/ash uses a special env variable called 'ENV' which controls whether a profile is auto loaded or not
 		profilePath = os.Getenv("ENV")
 		profileSnippet = `eval "$(c8y cli profile --shell sh)"`
@@ -176,17 +177,17 @@ func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
 			return false, cmderrors.NewSilentError()
 		}
 
-	case "zsh":
+	case shell.ShellZsh:
 		profilePath = "~/.zshrc"
 		profileSnippet = "source <(c8y cli profile --shell zsh)"
-	case "bash":
+	case shell.ShellBash:
 		// use eval over source as process substitution was only added in bash >= v4
 		profilePath = "~/.bashrc"
 		profileSnippet = `eval "$(c8y cli profile --shell bash)"`
-	case "fish":
+	case shell.ShellFish:
 		profilePath = "~/.config/fish/config.fish"
 		profileSnippet = "c8y cli profile --shell fish | source"
-	case "powershell":
+	case shell.ShellPowershell:
 		profilePath = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
 		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
 	}
@@ -230,7 +231,7 @@ func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
 	message := ""
 
 	if appendToProfile {
-		message = fmt.Sprintf("Added snippet to %s profile. path: %s", shell, expandedV)
+		message = fmt.Sprintf("Added snippet to %s profile. path: %s", shellType, expandedV)
 		cfg.Logger.Debugf("Adding snippet to %s", expandedV)
 		err = AppendToFile(expandedV, profileSnippet)
 		if err != nil {
@@ -239,7 +240,7 @@ func (n *CmdInstall) InstallProfile(shell string) (bool, error) {
 		changed = true
 	} else {
 		cfg.Logger.Debugf("Snippet already found in profile. path=%s", expandedV)
-		message = fmt.Sprintf("Already added snippet to %s profile. path: %s", shell, expandedV)
+		message = fmt.Sprintf("Already added snippet to %s profile. path: %s", shellType, expandedV)
 	}
 
 	_, bErr := fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s %s\n", cs.SuccessIconWithColor(cs.Green), message)

--- a/pkg/cmd/cli/profile/profile.manual.go
+++ b/pkg/cmd/cli/profile/profile.manual.go
@@ -7,6 +7,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +77,7 @@ func NewCmdProfile(f *cmdutil.Factory) *CmdProfile {
 
 	completion.WithOptions(
 		cmd,
-		completion.WithValidateSet("shell", "bash", "zsh", "powershell", "fish", "sh"),
+		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
 	)
 
 	cmdutil.DisableAuthCheck(cmd)
@@ -88,7 +89,7 @@ func NewCmdProfile(f *cmdutil.Factory) *CmdProfile {
 func (n *CmdProfile) RunE(cmd *cobra.Command, args []string) error {
 	activeShell := n.shell
 	if activeShell == "" {
-		activeShell = "sh"
+		activeShell = shell.ShellPosixShell
 	}
 	var script *string
 
@@ -101,7 +102,7 @@ func (n *CmdProfile) RunE(cmd *cobra.Command, args []string) error {
 	// the real shell type has been determined.
 	// This does not work for fish, or powershell as the syntax is too different
 	switch activeShell {
-	case "zsh", "bash", "sh", "auto":
+	case shell.ShellZsh, shell.ShellBash, shell.ShellPosixShell, shell.ShellAuto:
 		// generic entry point which will find the correct shell
 		script = &scriptLinuxAuto
 	case "__zsh":
@@ -110,9 +111,9 @@ func (n *CmdProfile) RunE(cmd *cobra.Command, args []string) error {
 		script = &scriptBash
 	case "__sh":
 		script = &scriptPosixShell
-	case "fish":
+	case shell.ShellFish:
 		script = &scriptFish
-	case "powershell":
+	case shell.ShellPowershell:
 		script = &scriptPowerShell
 	}
 

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -1,12 +1,14 @@
 package completion
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/shell"
 	"github.com/spf13/cobra"
 )
 
@@ -79,19 +81,21 @@ func NewCmdCompletion() *CmdCompletion {
 		Short:                 "Generate completion script",
 		Long:                  descriptionLong,
 		DisableFlagsInUseLine: true,
-		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		ValidArgs:             shell.SupportTabCompletionShells(),
 		Args:                  flags.ExactArgsOrExample(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			switch args[0] {
-			case "bash":
+			case shell.ShellBash:
 				err = cmd.Root().GenBashCompletionV2(os.Stdout, true)
-			case "zsh":
+			case shell.ShellZsh:
 				err = cmd.Root().GenZshCompletion(os.Stdout)
-			case "fish":
+			case shell.ShellFish:
 				err = cmd.Root().GenFishCompletion(os.Stdout, true)
-			case "powershell":
+			case shell.ShellPowershell:
 				err = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			case shell.ShellPosixShell:
+				err = fmt.Errorf("posix shell (sh) does not support tab completion")
 			}
 			return err
 		},

--- a/pkg/cmd/sessions/clear/clear.manual.go
+++ b/pkg/cmd/sessions/clear/clear.manual.go
@@ -47,11 +47,11 @@ $ c8y sessions clear | source
 	cmdutil.DisableEncryptionCheck(cmd)
 
 	cmd.SilenceUsage = true
-	cmd.Flags().StringVar(&ccmd.Shell, "shell", "auto", "Shell type. Defaults to auto if not printing to terminal")
+	cmd.Flags().StringVar(&ccmd.Shell, "shell", shell.ShellAuto, "Shell type. Defaults to auto if not printing to terminal")
 
 	completion.WithOptions(
 		cmd,
-		completion.WithValidateSet("shell", "auto", "bash", "zsh", "fish", "powershell"),
+		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
 	)
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
@@ -60,8 +60,8 @@ $ c8y sessions clear | source
 
 func (n *CmdClearSession) RunE(cmd *cobra.Command, args []string) error {
 	shellType := utilities.ShellBash
-	if strings.EqualFold(n.Shell, "auto") {
-		n.Shell = shell.DetectShell("bash")
+	if strings.EqualFold(n.Shell, shell.ShellAuto) {
+		n.Shell = shell.DetectShell(shell.ShellBash)
 	}
 	c8ysession.ClearEnvironmentVariables(shellType.FromString(n.Shell))
 	return nil

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -98,7 +98,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 
 	completion.WithOptions(
 		cmd,
-		completion.WithValidateSet("shell", "auto", "bash", "zsh", "fish", "powershell"),
+		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
 		completion.WithValidateSet("output-format", "json", "dotenv"),
 		completion.WithValidateSet("provider", config.ProviderTypeFile, config.ProviderTypeStdin, config.ProviderTypeEnv, config.ProviderTypeExternal, config.ProviderTypeAuto),
 		completion.WithValidateSet("format", "json", "yaml", "toml", "dotenv"),
@@ -463,10 +463,10 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 	outputFormat := n.OutputFormat
 	if outputFormat == "" {
 		if n.Shell == "" && !n.factory.IOStreams.IsStdoutTTY() {
-			n.Shell = "auto"
+			n.Shell = shell.ShellAuto
 		}
-		if strings.EqualFold(n.Shell, "auto") {
-			n.Shell = shell.DetectShell("bash")
+		if strings.EqualFold(n.Shell, shell.ShellAuto) {
+			n.Shell = shell.DetectShell(shell.ShellBash)
 		}
 		outputFormat = n.Shell
 	}

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -64,7 +64,7 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 
 	defaultShell := ""
 	if !f.IOStreams.IsStdoutTTY() {
-		defaultShell = "auto"
+		defaultShell = shell.ShellAuto
 	}
 
 	cmd.Flags().StringVar(&ccmd.sessionFilter, "sessionFilter", "", "Filter to be applied to the list of sessions even before the values can be selected")
@@ -76,7 +76,7 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 
 	completion.WithOptions(
 		cmd,
-		completion.WithValidateSet("shell", "auto", "bash", "zsh", "fish", "powershell"),
+		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
 		completion.WithValidateSet("loginType", c8y.AuthMethodOAuth2Internal, c8y.AuthMethodBasic, c8y.AuthMethodNone),
 	)
 	// Disable the encryption check, as the login handler will take care
@@ -300,10 +300,10 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 
 	if outputFormat == config.OutputUnknown.String() {
 		if n.Shell == "" && !n.factory.IOStreams.IsStdoutTTY() {
-			n.Shell = "auto"
+			n.Shell = shell.ShellAuto
 		}
-		if strings.EqualFold(n.Shell, "auto") {
-			n.Shell = shell.DetectShell("bash")
+		if strings.EqualFold(n.Shell, shell.ShellAuto) {
+			n.Shell = shell.DetectShell(shell.ShellBash)
 		}
 		outputFormat = n.Shell
 	} else if outputFormat != config.OutputJSON.String() {

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -498,7 +498,7 @@ func NewCmdUpdate(f *cmdutil.Factory) *UpdateSettingsCmd {
 
 	completion.WithOptions(
 		cmd,
-		completion.WithValidateSet("shell", "auto", "bash", "fish", "powershell", "zsh"),
+		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
 	)
 
 	cmd.SilenceUsage = true
@@ -528,8 +528,8 @@ func (n *UpdateSettingsCmd) RunE(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else if n.shell != "" {
-		if strings.EqualFold(n.shell, "auto") {
-			n.shell = shell.DetectShell("bash")
+		if strings.EqualFold(n.shell, shell.ShellAuto) {
+			n.shell = shell.DetectShell(shell.ShellBash)
 		}
 		v = viper.New()
 		writeToFile = false

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -1,6 +1,9 @@
 package shell
 
-import "os"
+import (
+	"os"
+	"slices"
+)
 
 // DetectShell detect the shell type, i.e. fish, bash, zsh or powershell
 func DetectShell(defaultValue string) string {
@@ -17,4 +20,33 @@ func DetectShell(defaultValue string) string {
 		return "powershell"
 	}
 	return defaultValue
+}
+
+var (
+	ShellFish       = "fish"
+	ShellBash       = "bash"
+	ShellZsh        = "zsh"
+	ShellPowershell = "powershell"
+	ShellPosixShell = "sh"
+	ShellAuto       = "auto"
+)
+
+func SupportedShells(additional ...string) []string {
+	values := []string{ShellFish, ShellBash, ShellZsh, ShellPosixShell, ShellPowershell}
+	for _, v := range additional {
+		if !slices.Contains(values, v) {
+			values = append(values, v)
+		}
+	}
+	return values
+}
+
+func SupportTabCompletionShells(additional ...string) []string {
+	values := []string{ShellFish, ShellBash, ShellZsh, ShellPowershell}
+	for _, v := range additional {
+		if !slices.Contains(values, v) {
+			values = append(values, v)
+		}
+	}
+	return values
 }

--- a/pkg/utilities/utilities.go
+++ b/pkg/utilities/utilities.go
@@ -41,6 +41,7 @@ func (t ShellType) FromString(name string) ShellType {
 		"bash":       ShellBash,
 		"zsh":        ShellZSH,
 		"fish":       ShellFish,
+		"sh":         ShellPosixShell,
 	}
 
 	if v, ok := values[strings.ToLower(name)]; ok {
@@ -55,6 +56,7 @@ func (t ShellType) Parse(name string) (ShellType, bool) {
 		"bash":       ShellBash,
 		"zsh":        ShellZSH,
 		"fish":       ShellFish,
+		"sh":         ShellPosixShell,
 	}
 
 	v, ok := values[strings.ToLower(name)]
@@ -73,6 +75,9 @@ const (
 
 	// ShellFish fish
 	ShellFish
+
+	// ShellPosixShell sh
+	ShellPosixShell
 )
 
 func WriteShellVariables(w io.Writer, cfg map[string]interface{}, shell ShellType) {


### PR DESCRIPTION
Code refactoring to move the different shell types to a common package so it is easier for commands to refer to the same set of shells