### PR TITLE
feat: prompt user for session mode if given an invalid value

### DIFF
--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -438,7 +438,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		session.Mode = n.Mode
 	}
 
-	if session.Mode == "" {
+	if session.Mode == "" || !config.IsSessionModeValid(session.Mode, cfg.IsCIMode()) {
 		// prompt the user for a value
 		modeOptions := config.GetSessionModeCompletionHelp()
 		mode, selectErr := prompt.Select("Select session mode", modeOptions, modeOptions[0])

--- a/pkg/config/mode.go
+++ b/pkg/config/mode.go
@@ -33,6 +33,11 @@ const (
 	SessionModeUnset
 )
 
+// IsSessionModeValid check if given mode name is valid
+func IsSessionModeValid(name string, ci bool) bool {
+	return SessionModeUnset.FromString(name, ci) != SessionModeUnset
+}
+
 func (f SessionMode) String() string {
 	values := map[SessionMode]string{
 		SessionModeProduction: "prod",


### PR DESCRIPTION
If the user provides a non-existent session mode value, then the user will be prompted for a value from the selected list:

```sh
set-session --mode somethingUnknown
```