### PR TITLE
fix: c8y sessions login compatibility with previous set-session

### DIFF
--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_login.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_login.md
@@ -35,6 +35,7 @@ Set a session from an external command, where the external commands returns the 
 ### Options
 
 ```
+      --clear                  Clear any existing tokens
       --format string          External command format, e.g. json, yaml, toml
       --from-cmd string        External command to execute to get the log in details
       --from-env               Read from environment variables
@@ -48,6 +49,7 @@ Set a session from an external command, where the external commands returns the 
       --provider string        Session provider which returns the session to use
       --secrets strings        List of secrets to include as env variables when running an external command. Only valid with from-cmd
       --shell string           Shell type to return the environment variables
+      --tfaCode string         Two Factor Authentication code
 ```
 
 ### Options inherited from parent commands

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -7,8 +7,10 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/utilities"
@@ -304,4 +306,50 @@ func IsSessionFilePath(path string) bool {
 	}
 	path = strings.TrimPrefix(path, "file://")
 	return !strings.Contains(path, "://")
+}
+
+func shouldRenewToken(t string, validFor time.Duration) (bool, *time.Time) {
+	claims := jwt.RegisteredClaims{}
+	parser := jwt.NewParser()
+	_, _, err := parser.ParseUnverified(t, &claims)
+
+	if err != nil {
+		// Invalid token
+		return true, nil
+	}
+
+	if claims.ExpiresAt != nil {
+		limit := claims.ExpiresAt.Add(-1 * validFor)
+		expiresSoon := limit.Before(time.Now())
+		return expiresSoon, &claims.ExpiresAt.Time
+	}
+	return true, nil
+}
+
+// ShouldReuseToken checks if the token should be reused or not
+func ShouldReuseToken(cfg *config.Config, log *logger.Logger, token string) bool {
+	if token == "" {
+		return false
+	}
+	reuse := true
+
+	// Check if token is valid for the minimum period
+	shouldBeValidFor := cfg.TokenValidFor()
+	expiresSoon, expiresAt := shouldRenewToken(token, shouldBeValidFor)
+
+	if expiresAt != nil {
+		if time.Now().After(*expiresAt) {
+			log.Infof("Token has expired. tokenExpiresAt=%s", expiresAt.Format(time.RFC3339))
+			reuse = false
+		} else if expiresSoon {
+			log.Warnf("Ignoring existing token as it will expire soon. minimumValidFor=%s, tokenExpiresAt=%s", shouldBeValidFor, expiresAt.Format(time.RFC3339))
+			reuse = false
+		} else {
+			log.Infof("Token expiresAt: %s", expiresAt.Format(time.RFC3339))
+		}
+	} else {
+		log.Infof("Ignoring invalid token")
+		reuse = false
+	}
+	return reuse
 }

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/kballard/go-shellquote"
@@ -39,7 +40,9 @@ type CmdLogin struct {
 	Secrets  []string
 
 	// Login options
-	LoginType string
+	LoginType  string
+	TFACode    string
+	ClearToken bool
 
 	Mode string
 
@@ -89,6 +92,8 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().BoolVar(&ccmd.Env, "from-env", false, "Read from environment variables")
 	cmd.Flags().BoolVar(&ccmd.Stdin, "from-stdin", false, "Read from standard input")
 	cmd.Flags().BoolVar(&ccmd.NoBanner, "no-banner", false, "Don't show the session banner")
+	cmd.Flags().StringVar(&ccmd.TFACode, "tfaCode", "", "Two Factor Authentication code")
+	cmd.Flags().BoolVar(&ccmd.ClearToken, "clear", false, "Clear any existing tokens")
 	cmd.Flags().StringVar(&ccmd.Format, "format", "", "External command format, e.g. json, yaml, toml")
 	cmd.Flags().StringVar(&ccmd.OutputFormat, "output-format", "", "Output format")
 	cmd.Flags().StringVar(&ccmd.Shell, "shell", "", "Shell type to return the environment variables")
@@ -406,7 +411,12 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	client := c8y.NewClient(nil, session.Host, session.Tenant, session.Username, session.Password, true)
-	client.SetToken(session.Token)
+
+	if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, session.Token) {
+		client.SetToken(session.Token)
+	} else {
+		client.SetToken("")
+	}
 
 	c8ysession.ClearProcessEnvironment()
 
@@ -419,6 +429,13 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 	log.Infof("User preference for login type: %s", handler.LoginType)
 	handler.TFACode = session.TOTP
+	if n.TFACode == "" {
+		if code, err := cfg.GetTOTP(time.Now()); err == nil {
+			cfg.Logger.Infof("Setting totp code: %s", code)
+			n.TFACode = code
+		}
+	}
+
 	handler.SetLogger(log)
 	err = handler.Run()
 	if err != nil {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ylogin"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/factory"
@@ -205,29 +204,11 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	cfg.SetLoginType(n.LoginType)
 	client.AuthorizationMethod = n.LoginType
 
-	if n.ClearToken {
-		client.SetToken("")
+	token := cfg.MustGetToken(true)
+	if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, token) {
+		client.SetToken(token)
 	} else {
-		// Check if token is valid for the minimum period
-		if tok := cfg.MustGetToken(true); tok != "" {
-			shouldBeValidFor := cfg.TokenValidFor()
-			expiresSoon, expiresAt := ShouldRenewToken(tok, shouldBeValidFor)
-
-			if expiresAt != nil {
-				if time.Now().After(*expiresAt) {
-					log.Infof("Token has expired. tokenExpiresAt=%s", expiresAt.Format(time.RFC3339))
-					client.SetToken("")
-				} else if expiresSoon {
-					log.Warnf("Ignoring existing token as it will expire soon. minimumValidFor=%s, tokenExpiresAt=%s", shouldBeValidFor, expiresAt.Format(time.RFC3339))
-					client.SetToken("")
-				} else {
-					log.Infof("Token expiresAt: %s", expiresAt.Format(time.RFC3339))
-				}
-			} else {
-				log.Infof("Ignoring invalid token")
-				client.SetToken("")
-			}
-		}
+		client.SetToken("")
 	}
 
 	if n.LoginType != c8y.AuthMethodNone {
@@ -332,22 +313,4 @@ func hasChanged(client *c8y.Client, cfg *config.Config) bool {
 		return true
 	}
 	return false
-}
-
-func ShouldRenewToken(t string, validFor time.Duration) (bool, *time.Time) {
-	claims := jwt.RegisteredClaims{}
-	parser := jwt.NewParser()
-	_, _, err := parser.ParseUnverified(t, &claims)
-
-	if err != nil {
-		// Invalid token
-		return true, nil
-	}
-
-	if claims.ExpiresAt != nil {
-		limit := claims.ExpiresAt.Add(-1 * validFor)
-		expiresSoon := limit.Before(time.Now())
-		return expiresSoon, &claims.ExpiresAt.Time
-	}
-	return true, nil
 }

--- a/tools/PSc8y/Public-manual/Set-Session.ps1
+++ b/tools/PSc8y/Public-manual/Set-Session.ps1
@@ -61,13 +61,12 @@ String
     }
 
     Begin {
-        $c8yargs = New-ClientArgument -Parameters $PSBoundParameters -Command "sessions set"
+        $c8yargs = New-ClientArgument -Parameters $PSBoundParameters -Command "sessions login"
     }
 
     Process {
         if ($SessionFilter -gt 0) {
-            $SearchTerms = $SessionFilter -join " "
-            $null = $c8yargs.AddRange(@("--sessionFilter", "$SearchTerms"))
+            $null = $c8yargs.AddRange($SessionFilter)
         }
 
         $null = $c8yargs.AddRange(@("--shell", "powershell"))


### PR DESCRIPTION
Fix some missing flags to the `c8y sessions login` for compatibility reasons.

This fixes the following common scenario:

```sh
set-session --clear
```