### PR TITLE
feat: add support for logging in via oauth2 device authorization flow

### DIFF
--- a/cmd/tests/common/session/session_test.go
+++ b/cmd/tests/common/session/session_test.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/command"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func Test_SetUsernamePassword(t *testing.T) {
+	tenant := "t12345"
+	username := "example"
+	password := "dummy"
+	stdout, _, err := command.ExecuteCmdWithOutputs(
+		command.NewMockCommand(),
+		fmt.Sprintf(
+			`c8y deviceregistration getCredentials -n --id customdevice --sessionUsername "%s" --sessionPassword "%s" --dry --dryFormat json`,
+			tenant+"/"+username,
+			password,
+		),
+		command.WithStdinTTY(false),
+		command.WithSensitiveLogging(t, false),
+	)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, stdout)
+
+	response := gjson.Parse(stdout)
+	assert.Equal(t, response.Get("headers.Authorization").String(), c8y.NewBasicAuthString(tenant, username, password))
+}

--- a/cmd/tests/sessions/login/login_from-cmd_test.go
+++ b/cmd/tests/sessions/login/login_from-cmd_test.go
@@ -1,0 +1,30 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/command"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/mocksession"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func Test_LoginFromCommand(t *testing.T) {
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		command.NewMockCommand(),
+		`c8y sessions login -n --from-cmd "c8y sessions login --from-env --output-format json --no-banner" --output-format json`,
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, mocksession.GetSessionEnvironmentVariables()),
+		command.WithSessionEncryption(t, false),
+	)
+	assert.Nil(t, cmdErr)
+	session := gjson.Parse(stdout)
+
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("username").String())
+	assert.NotEmpty(t, session.Get("token").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.NotEmpty(t, session.Get("version").String())
+	assert.False(t, session.Get("password").Exists())
+}

--- a/cmd/tests/sessions/login/login_loginType_test.go
+++ b/cmd/tests/sessions/login/login_loginType_test.go
@@ -25,6 +25,51 @@ func createBasicSession(t *testing.T) (string, string) {
 	return tmpDir, filepath.Join(tmpDir, sessionName)
 }
 
+func createBasicWithTokenSession(t *testing.T) (string, string) {
+	session, err := mocksession.CreateSessionWithOAuth2Internal()
+	assert.NoError(t, err)
+	sessionName := "test-simple.json"
+	tmpDir := mocksession.CreateCumulocitySessionDir(
+		t,
+		mocksession.WithSession(sessionName, &c8ysession.CumulocitySession{
+			Host:     session.Host,
+			Username: session.Username,
+			Password: session.Password,
+			Token:    session.Token,
+		}),
+	)
+	return tmpDir, filepath.Join(tmpDir, sessionName)
+}
+
+func Test_LoginSwithFromTokenToBasicWithTokenPresent(t *testing.T) {
+	homeDir, sessionFile := createBasicWithTokenSession(t)
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		command.NewMockCommand(),
+		`c8y sessions set -v --shell bash --loginType BASIC`,
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			config.EnvSessionHome: homeDir,
+		}),
+		command.WithSessionEncryption(t, false),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.Contains(t, outputEnv, "C8Y_PASSWORD")
+	assert.NotContains(t, outputEnv, "C8Y_TOKEN")
+
+	// Session information should be persisted
+	session := mocksession.ParseSession(sessionFile)
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.NotEmpty(t, session.Get("password").String())
+	assert.Empty(t, session.Get("token").String())
+	assert.NotEmpty(t, session.Get("version").String())
+}
+
 func Test_LoginWithUserGivenLoginType_Default(t *testing.T) {
 	homeDir, sessionFile := createBasicSession(t)
 	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
@@ -34,9 +79,9 @@ func Test_LoginWithUserGivenLoginType_Default(t *testing.T) {
 		command.WithStdinTTY(true),
 		command.WithStderrTTY(true),
 		command.WithEnv(t, map[string]string{
-			config.EnvSessionHome:                              homeDir,
-			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+			config.EnvSessionHome: homeDir,
 		}),
+		command.WithSessionEncryption(t, false),
 	)
 	assert.Nil(t, cmdErr)
 	outputEnv := command.ParseShellEnv(stdout)
@@ -64,9 +109,9 @@ func Test_LoginWithUserGivenLoginType_OAuth2Internal(t *testing.T) {
 		command.WithStdinTTY(true),
 		command.WithStderrTTY(true),
 		command.WithEnv(t, map[string]string{
-			config.EnvSessionHome:                              homeDir,
-			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+			config.EnvSessionHome: homeDir,
 		}),
+		command.WithSessionEncryption(t, false),
 	)
 	assert.Nil(t, cmdErr)
 	outputEnv := command.ParseShellEnv(stdout)
@@ -94,9 +139,9 @@ func Test_LoginWithUserGivenLoginTypeBasic(t *testing.T) {
 		command.WithStdinTTY(true),
 		command.WithStderrTTY(true),
 		command.WithEnv(t, map[string]string{
-			config.EnvSessionHome:                              homeDir,
-			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+			config.EnvSessionHome: homeDir,
 		}),
+		command.WithSessionEncryption(t, false),
 	)
 	assert.Nil(t, cmdErr)
 	outputEnv := command.ParseShellEnv(stdout)
@@ -135,13 +180,12 @@ func Test_LoginWithUserGivenLoginTypeNone(t *testing.T) {
 	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
 		command.NewMockCommand(),
 		`c8y sessions set -v --shell bash --loginType NONE`,
-		command.WithStdIn("\n"),
 		command.WithStdinTTY(true),
 		command.WithStderrTTY(true),
 		command.WithEnv(t, map[string]string{
-			config.EnvSessionHome:                              homeDir,
-			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+			config.EnvSessionHome: homeDir,
 		}),
+		command.WithSessionEncryption(t, false),
 	)
 	assert.Nil(t, cmdErr)
 	outputEnv := command.ParseShellEnv(stdout)

--- a/cmd/tests/sessions/login/login_loginType_test.go
+++ b/cmd/tests/sessions/login/login_loginType_test.go
@@ -1,0 +1,161 @@
+package login
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/command"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/mocksession"
+	"github.com/stretchr/testify/assert"
+)
+
+func createBasicSession(t *testing.T) (string, string) {
+	sessionName := "test-simple.json"
+	tmpDir := mocksession.CreateCumulocitySessionDir(
+		t,
+		mocksession.WithSession(sessionName, &c8ysession.CumulocitySession{
+			Host:     os.Getenv("C8Y_HOST"),
+			Username: os.Getenv("C8Y_USER"),
+			Password: os.Getenv("C8Y_PASSWORD"),
+		}),
+	)
+	return tmpDir, filepath.Join(tmpDir, sessionName)
+}
+
+func Test_LoginWithUserGivenLoginType_Default(t *testing.T) {
+	homeDir, sessionFile := createBasicSession(t)
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		command.NewMockCommand(),
+		`c8y sessions set -v --shell bash`,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			config.EnvSessionHome:                              homeDir,
+			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.Contains(t, outputEnv, "C8Y_TOKEN")
+	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
+
+	// Session information should be persisted
+	session := mocksession.ParseSession(sessionFile)
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.NotEmpty(t, session.Get("password").String())
+	assert.NotEmpty(t, session.Get("token").String(), "Token should of been updated after the login process")
+	assert.NotEmpty(t, session.Get("version").String())
+}
+
+func Test_LoginWithUserGivenLoginType_OAuth2Internal(t *testing.T) {
+	homeDir, sessionFile := createBasicSession(t)
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		command.NewMockCommand(),
+		`c8y sessions set -v --shell bash --loginType OAUTH2_INTERNAL`,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			config.EnvSessionHome:                              homeDir,
+			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.Contains(t, outputEnv, "C8Y_TOKEN")
+	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
+
+	// Session information should be persisted
+	session := mocksession.ParseSession(sessionFile)
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.NotEmpty(t, session.Get("password").String())
+	assert.NotEmpty(t, session.Get("token").String(), "Token should of been updated after the login process")
+	assert.NotEmpty(t, session.Get("version").String())
+}
+
+func Test_LoginWithUserGivenLoginTypeBasic(t *testing.T) {
+	homeDir, sessionFile := createBasicSession(t)
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		command.NewMockCommand(),
+		`c8y sessions set -v --shell bash --loginType BASIC`,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			config.EnvSessionHome:                              homeDir,
+			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.NotContains(t, outputEnv, "C8Y_TOKEN")
+	assert.Contains(t, outputEnv, "C8Y_PASSWORD")
+
+	// Session information should be persisted
+	session := mocksession.ParseSession(sessionFile)
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.NotEmpty(t, session.Get("password").String())
+	assert.Empty(t, session.Get("token").String(), "Token should not be present as the user requested to use basic auth")
+	assert.NotEmpty(t, session.Get("version").String())
+}
+
+func Test_LoginWithUserGivenLoginTypeNone(t *testing.T) {
+	tedgeURL := os.Getenv("TEDGE_URL")
+	if tedgeURL == "" {
+		t.Skip("TEDGE_URL not set")
+	}
+
+	sessionName := "test-simple.json"
+	homeDir := mocksession.CreateCumulocitySessionDir(
+		t,
+		mocksession.WithSession(sessionName, &c8ysession.CumulocitySession{
+			Host: os.Getenv("TEDGE_URL"),
+		}),
+	)
+	sessionFile := filepath.Join(homeDir, sessionName)
+
+	//
+	// Login using SSO, the token should be stored in the session
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		command.NewMockCommand(),
+		`c8y sessions set -v --shell bash --loginType NONE`,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			config.EnvSessionHome:                              homeDir,
+			config.GetEnvKey(config.SettingsEncryptionEnabled): "false",
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.NotContains(t, outputEnv, "C8Y_TOKEN")
+	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
+
+	// Session information should be persisted
+	session := mocksession.ParseSession(sessionFile)
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.Empty(t, session.Get("password").String())
+	assert.Empty(t, session.Get("token").String(), "Token should not be present as the user requested to use basic auth")
+	assert.NotEmpty(t, session.Get("version").String())
+}

--- a/cmd/tests/sessions/login/login_sso_test.go
+++ b/cmd/tests/sessions/login/login_sso_test.go
@@ -53,6 +53,7 @@ func Test_SSOLoginFromSessionFile(t *testing.T) {
 	assert.Contains(t, outputEnv, "C8Y_TENANT")
 	assert.Contains(t, outputEnv, "C8Y_VERSION")
 	assert.Contains(t, outputEnv, "C8Y_TOKEN")
+	assert.Contains(t, outputEnv, "C8Y_USER")
 	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
 
 	// Session information should be persisted

--- a/cmd/tests/sessions/login/login_sso_test.go
+++ b/cmd/tests/sessions/login/login_sso_test.go
@@ -1,0 +1,106 @@
+package login
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/command"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/testing/mocksession"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SSOLoginFromSessionFile(t *testing.T) {
+	cumulocityHostWithSSO := os.Getenv("SSO_C8Y_HOST")
+	if cumulocityHostWithSSO == "" {
+		t.Skipf("SSO_C8Y_HOST env variable is not set")
+	}
+	cmd := command.NewMockCommand()
+	False := false
+	sessionName := "test-sso.json"
+	tmpDir := mocksession.CreateCumulocitySessionDir(
+		t,
+		mocksession.WithSession(sessionName, &c8ysession.CumulocitySession{
+			Host: cumulocityHostWithSSO,
+			Settings: &config.CommandSettings{
+				Encryption: &config.EncryptionSettings{
+					Enabled: &False,
+				},
+			},
+		}),
+	)
+	sessionFile := filepath.Join(tmpDir, sessionName)
+
+	//
+	// Login using SSO, the token should be stored in the session
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		cmd,
+		fmt.Sprintf(`c8y sessions set %s --shell bash -v`, sessionName),
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			"C8Y_SESSION_HOME":                tmpDir,
+			"C8Y_SETTINGS_ENCRYPTION_ENABLED": "false",
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.Contains(t, outputEnv, "C8Y_TOKEN")
+	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
+
+	// Session information should be persisted
+	session := mocksession.ParseSession(sessionFile)
+	assert.NotEmpty(t, session.Get("host").String())
+	assert.NotEmpty(t, session.Get("tenant").String())
+	assert.NotEmpty(t, session.Get("token").String())
+	assert.NotEmpty(t, session.Get("version").String())
+
+	//
+	// Reuse the session should use the token instead of having to login again
+	env := command.ParseShellEnv(stdout)
+	env["C8Y_SESSION_HOME"] = tmpDir
+	env["C8Y_SETTINGS_ENCRYPTION_ENABLED"] = "false"
+	stdout, cmdErr = command.ExecuteCmdWithStandardOutput(
+		cmd,
+		fmt.Sprintf(`c8y sessions set %s --shell bash -v`, "test-sso"),
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, env),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv = command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv, "C8Y_HOST")
+	assert.Contains(t, outputEnv, "C8Y_TENANT")
+	assert.Contains(t, outputEnv, "C8Y_VERSION")
+	assert.Contains(t, outputEnv, "C8Y_TOKEN")
+	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
+}
+
+func Test_SSOLoginFromConsole(t *testing.T) {
+	cumulocityHostWithSSO := os.Getenv("SSO_C8Y_HOST")
+	if cumulocityHostWithSSO == "" {
+		t.Skipf("SSO_C8Y_HOST env variable is not set")
+	}
+	cmd := command.NewMockCommand()
+	cmdtext := `c8y sessions login --provider env --shell bash -v`
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		cmd,
+		cmdtext,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			"C8Y_HOST": cumulocityHostWithSSO,
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	assert.Contains(t, stdout, "export C8Y_HOST=")
+}

--- a/cmd/tests/sessions/login/login_sso_test.go
+++ b/cmd/tests/sessions/login/login_sso_test.go
@@ -69,7 +69,7 @@ func Test_SSOLoginFromSessionFile(t *testing.T) {
 	env["C8Y_SETTINGS_ENCRYPTION_ENABLED"] = "false"
 	stdout, cmdErr = command.ExecuteCmdWithStandardOutput(
 		cmd,
-		fmt.Sprintf(`c8y sessions set %s --shell bash -v`, "test-sso"),
+		fmt.Sprintf(`c8y sessions set %s --shell bash -v`, sessionName),
 		command.WithStdIn("\n"),
 		command.WithStdinTTY(true),
 		command.WithStderrTTY(true),
@@ -82,6 +82,25 @@ func Test_SSOLoginFromSessionFile(t *testing.T) {
 	assert.Contains(t, outputEnv, "C8Y_VERSION")
 	assert.Contains(t, outputEnv, "C8Y_TOKEN")
 	assert.NotContains(t, outputEnv, "C8Y_PASSWORD")
+
+	// Manually specify to ignore the token
+	stdout, cmdErr = command.ExecuteCmdWithStandardOutput(
+		cmd,
+		fmt.Sprintf(`c8y sessions set %s --shell bash -v --clear`, sessionName),
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, env),
+	)
+	assert.Nil(t, cmdErr)
+	outputEnv2 := command.ParseShellEnv(stdout)
+	assert.Contains(t, outputEnv2, "C8Y_HOST")
+	assert.Contains(t, outputEnv2, "C8Y_TENANT")
+	assert.Contains(t, outputEnv2, "C8Y_VERSION")
+	assert.Contains(t, outputEnv2, "C8Y_TOKEN")
+	assert.NotContains(t, outputEnv2, "C8Y_PASSWORD")
+
+	assert.NotEqual(t, outputEnv["C8Y_TOKEN"], outputEnv2["C8Y_TOKEN"])
 }
 
 func Test_SSOLoginFromConsole(t *testing.T) {
@@ -100,6 +119,98 @@ func Test_SSOLoginFromConsole(t *testing.T) {
 		command.WithEnv(t, map[string]string{
 			"C8Y_HOST": cumulocityHostWithSSO,
 		}),
+	)
+	assert.Nil(t, cmdErr)
+	assert.Contains(t, stdout, "export C8Y_HOST=")
+}
+
+func Test_SSOLoginWithDiscoveryURL(t *testing.T) {
+	cumulocityHostWithSSO := os.Getenv("SSO_C8Y_HOST")
+	if cumulocityHostWithSSO == "" {
+		t.Skipf("SSO_C8Y_HOST env variable is not set")
+	}
+
+	sessionName := "test-sso.json"
+	tmpDir := mocksession.CreateCumulocitySessionDir(
+		t,
+		mocksession.WithSession(sessionName, &c8ysession.CumulocitySession{
+			Host: cumulocityHostWithSSO,
+			Settings: &config.CommandSettings{
+				SSO: &config.SSOSettings{
+					DiscoveryURL: "https://invalid.com/example",
+				},
+			},
+		}),
+	)
+	// sessionFile := filepath.Join(tmpDir, sessionName)
+
+	cmd := command.NewMockCommand()
+	cmdtext := fmt.Sprintf(`c8y sessions set --shell bash -v %s --clear`, "test-sso")
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		cmd,
+		cmdtext,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			"C8Y_SESSION_HOME":                tmpDir,
+			"C8Y_SETTINGS_ENCRYPTION_ENABLED": "false",
+		}),
+	)
+	assert.Error(t, cmdErr)
+	assert.Contains(t, stdout, "export C8Y_HOST=")
+}
+
+func Test_OAuth2InternalLoginWhenSSOIsActive(t *testing.T) {
+	cumulocityHostWithSSO := os.Getenv("SSO_C8Y_HOST")
+	if cumulocityHostWithSSO == "" {
+		t.Skipf("SSO_C8Y_HOST env variable is not set")
+	}
+	cmd := command.NewMockCommand()
+	cmdtext := fmt.Sprintf(`c8y sessions set --shell bash -v --loginType OAUTH2_INTERNAL %s`, "iot-lat-sso")
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		cmd,
+		cmdtext,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+		command.WithEnv(t, map[string]string{
+			"C8Y_HOST": cumulocityHostWithSSO,
+		}),
+	)
+	assert.Nil(t, cmdErr)
+	assert.Contains(t, stdout, "export C8Y_HOST=")
+}
+
+func Test_SetSessionUsingOAuth2InternalWhenSSOIsActive(t *testing.T) {
+	if cumulocityHostWithSSO := os.Getenv("SSO_C8Y_HOST"); cumulocityHostWithSSO == "" {
+		t.Skipf("SSO_C8Y_HOST env variable is not set")
+	}
+	cmd := command.NewMockCommand()
+	cmdtext := fmt.Sprintf(`c8y sessions set --shell bash -v --loginType OAUTH2_INTERNAL %s`, "iot.latest.stage.c8y.io-reuben.d.miller@gmail.com.json")
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		cmd,
+		cmdtext,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
+	)
+	assert.Nil(t, cmdErr)
+	assert.Contains(t, stdout, "export C8Y_HOST=")
+}
+
+func Test_SetSessionClearSSOToken(t *testing.T) {
+	if cumulocityHostWithSSO := os.Getenv("SSO_C8Y_HOST"); cumulocityHostWithSSO == "" {
+		t.Skipf("SSO_C8Y_HOST env variable is not set")
+	}
+	cmd := command.NewMockCommand()
+	cmdtext := fmt.Sprintf(`c8y sessions set --shell bash -v %s`, "iot-lat-sso")
+	stdout, cmdErr := command.ExecuteCmdWithStandardOutput(
+		cmd,
+		cmdtext,
+		command.WithStdIn("\n"),
+		command.WithStdinTTY(true),
+		command.WithStderrTTY(true),
 	)
 	assert.Nil(t, cmdErr)
 	assert.Contains(t, stdout, "export C8Y_HOST=")

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.1
+	github.com/reubenmiller/go-c8y v0.37.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.3
+	github.com/reubenmiller/go-c8y v0.37.4-0.20250701160323-0a8e2018a6ff
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.4
+	github.com/reubenmiller/go-c8y v0.37.6
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.0
+	github.com/reubenmiller/go-c8y v0.37.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.33.0
+	github.com/reubenmiller/go-c8y v0.37.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.4-0.20250701160628-5635b41c9019
+	github.com/reubenmiller/go-c8y v0.37.4
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.4-0.20250701160323-0a8e2018a6ff
+	github.com/reubenmiller/go-c8y v0.37.4-0.20250701160628-5635b41c9019
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.2
+	github.com/reubenmiller/go-c8y v0.37.3
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.4-0.20250701160628-5635b41c9019 h1:605HTwI/m/2jT2zPj62R692CN7VSNcV27ql2cgLoU04=
-github.com/reubenmiller/go-c8y v0.37.4-0.20250701160628-5635b41c9019/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.4 h1:JRi/PUl5tHn1tFhWbKAApGYE2k83VLmRTSbJbbT1Azs=
+github.com/reubenmiller/go-c8y v0.37.4/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.33.0 h1:U2iY25aewjEy/Ibm+R1W9bv8Y1USMpXn6uoCs3zLksY=
-github.com/reubenmiller/go-c8y v0.33.0/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.0 h1:9QtzGGoLLqlqSdtAU34R+Clm4Pq8+TbzKFK50igD7W0=
+github.com/reubenmiller/go-c8y v0.37.0/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.3 h1:vphygS5CNcGto1j8CaEXvNjxyJBM+RT7dsOybjvIIaU=
-github.com/reubenmiller/go-c8y v0.37.3/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.4-0.20250701160323-0a8e2018a6ff h1:uweMMx7X/lTS2RM8erXhsaZr9Jv392ELT+mtQwZ5gho=
+github.com/reubenmiller/go-c8y v0.37.4-0.20250701160323-0a8e2018a6ff/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.0 h1:9QtzGGoLLqlqSdtAU34R+Clm4Pq8+TbzKFK50igD7W0=
-github.com/reubenmiller/go-c8y v0.37.0/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.1 h1:JH2oApEP+oCE6b6R1C8sDByXlMfo0Wljr+E0cQNZIIc=
+github.com/reubenmiller/go-c8y v0.37.1/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.1 h1:JH2oApEP+oCE6b6R1C8sDByXlMfo0Wljr+E0cQNZIIc=
-github.com/reubenmiller/go-c8y v0.37.1/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.2 h1:nF2UvPbp1sxvZkhi/x107DHwBOMBMmnwDF94X/XdXFo=
+github.com/reubenmiller/go-c8y v0.37.2/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.2 h1:nF2UvPbp1sxvZkhi/x107DHwBOMBMmnwDF94X/XdXFo=
-github.com/reubenmiller/go-c8y v0.37.2/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.3 h1:vphygS5CNcGto1j8CaEXvNjxyJBM+RT7dsOybjvIIaU=
+github.com/reubenmiller/go-c8y v0.37.3/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.4 h1:JRi/PUl5tHn1tFhWbKAApGYE2k83VLmRTSbJbbT1Azs=
-github.com/reubenmiller/go-c8y v0.37.4/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.6 h1:4OLwu9PHLw9sPNMfggQtGuzVh1+gk6U/ZCrIooFUr7g=
+github.com/reubenmiller/go-c8y v0.37.6/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.4-0.20250701160323-0a8e2018a6ff h1:uweMMx7X/lTS2RM8erXhsaZr9Jv392ELT+mtQwZ5gho=
-github.com/reubenmiller/go-c8y v0.37.4-0.20250701160323-0a8e2018a6ff/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
+github.com/reubenmiller/go-c8y v0.37.4-0.20250701160628-5635b41c9019 h1:605HTwI/m/2jT2zPj62R692CN7VSNcV27ql2cgLoU04=
+github.com/reubenmiller/go-c8y v0.37.4-0.20250701160628-5635b41c9019/go.mod h1:63lPvPX6B8xf5GT9PvRrXgM0u5uU5tgZiQRAIfYQDQY=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3/go.mod h1:QidmUT4ebNVwyjKXAQgx9VFHxpOxBKWs32EEXaXnEfE=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -1,6 +1,7 @@
 package c8ylogin
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -10,10 +11,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cli/browser"
+	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/mdp/qrterminal/v3"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/reubenmiller/go-c8y/pkg/oauth/api"
+	"github.com/reubenmiller/go-c8y/pkg/oauth/device"
 )
 
 // LoginState current state of the login flow
@@ -39,6 +45,9 @@ const (
 	// LoginStateTFAConfirm user requires TFA setup to be confirmed
 	LoginStateTFAConfirm
 
+	// LoginStateLogin login (mostly used for OAUTH2 / SSO)
+	LoginStateLogin
+
 	// LoginStateVerify verify authorization state by sending a request to Cumulocity
 	LoginStateVerify
 
@@ -57,9 +66,9 @@ var (
 // LoginHandler handler to process all login / authorization tasks for Cumulocity.
 // Two-Factor authentication, TFA setup, OAUTH etc.
 type LoginHandler struct {
+	IO              *iostreams.IOStreams
 	TFACodeRequired bool
 	Authorized      bool
-	Interactive     bool
 	Err             error
 	TFACode         string
 	C8Yclient       *c8y.Client
@@ -74,13 +83,13 @@ type LoginHandler struct {
 }
 
 // NewLoginHandler creates a new login handler to process the full Cumulocity login process for different login types, i.e. OAUTH2_INTERNAL, BASIC etc.
-func NewLoginHandler(c *c8y.Client, w io.Writer, onSave func()) *LoginHandler {
+func NewLoginHandler(IO *iostreams.IOStreams, c *c8y.Client, w io.Writer, onSave func()) *LoginHandler {
 	h := &LoginHandler{
-		C8Yclient:   c,
-		Interactive: true,
-		Writer:      w,
-		onSave:      onSave,
-		Logger:      logger.NewDummyLogger("c8ylogin"),
+		IO:        IO,
+		C8Yclient: c,
+		Writer:    w,
+		onSave:    onSave,
+		Logger:    logger.NewDummyLogger("c8ylogin"),
 	}
 	h.state = make(chan LoginState, 1)
 	return h
@@ -105,9 +114,9 @@ func (lh *LoginHandler) Clear() {
 	}
 	lh.Authorized = false
 	// lh.TFACodeRequired = false
-	lh.C8Yclient.SetToken("")
+	lh.C8Yclient.ClearToken()
 	lh.onSave()
-	lh.C8Yclient.AuthorizationMethod = c8y.AuthMethodBasic
+	lh.C8Yclient.SetAuthorizationType(c8y.AuthTypeBasic)
 	lh.Err = nil
 }
 
@@ -117,8 +126,23 @@ func (lh *LoginHandler) Run() error {
 	lh.init()
 
 	// Check if any authentication is set
-	if lh.C8Yclient.Token != "" || lh.C8Yclient.Password != "" || lh.LoginType == c8y.AuthMethodNone {
+	if lh.LoginType == c8y.LoginTypeNone {
 		lh.state <- LoginStateVerify
+	} else if lh.LoginType == c8y.LoginTypeOAuth2Internal {
+		if lh.C8Yclient.Token != "" {
+			lh.state <- LoginStateVerify
+		} else {
+			lh.state <- LoginStateLogin
+		}
+	} else if lh.C8Yclient.Token != "" {
+		lh.state <- LoginStateVerify
+	} else if lh.LoginType == c8y.LoginTypeOAuth2 {
+		lh.state <- LoginStateLogin
+	} else if lh.C8Yclient.Password != "" {
+		lh.state <- LoginStateVerify
+	} else if lh.C8Yclient.Username == "" {
+		// OAUTH2 doesn't provide a username
+		lh.state <- LoginStateLogin
 	} else {
 		lh.state <- LoginStatePromptPassword
 	}
@@ -134,6 +158,8 @@ func (lh *LoginHandler) Run() error {
 		} else if c == LoginStateVerify {
 			lh.verify()
 		} else if c == LoginStateTFAConfirm {
+			lh.login()
+		} else if c == LoginStateLogin {
 			lh.login()
 		} else if c == LoginStateNoAuth {
 			lh.Clear()
@@ -168,22 +194,23 @@ func (lh *LoginHandler) sortLoginOptions() {
 	}
 
 	optionOrder := map[string]int{
-		c8y.AuthMethodNone:           3,
-		c8y.AuthMethodBasic:          2,
-		c8y.AuthMethodOAuth2Internal: 1,
+		c8y.LoginTypeNone:           40,
+		c8y.LoginTypeBasic:          30,
+		c8y.LoginTypeOAuth2Internal: 20,
+		c8y.LoginTypeOAuth2:         10,
 	}
 
 	if lh.LoginType != "" {
 		if _, ok := optionOrder[lh.LoginType]; ok {
 			lh.Logger.Infof("Setting preferred login method. %s", lh.LoginType)
-			optionOrder[lh.LoginType] = 0
+			optionOrder[lh.LoginType] = -999 // Try preferred method first
 		} else {
 			lh.Logger.Infof("Unsupported login method. The given option will be ignored. %s", lh.LoginType)
 		}
 	}
 
 	// sort login options
-	sort.SliceStable(lh.LoginOptions.LoginOptions[:], func(i, j int) bool {
+	sort.SliceStable(lh.LoginOptions.LoginOptions, func(i, j int) bool {
 		iWeight := 100
 		jWeight := 200
 
@@ -201,7 +228,7 @@ func (lh *LoginHandler) sortLoginOptions() {
 func (lh *LoginHandler) init() {
 	lh.do(func() error {
 		// Special case where no auth is required
-		if lh.LoginType == c8y.AuthMethodNone {
+		if lh.LoginType == c8y.LoginTypeNone {
 			return nil
 		}
 		loginOptions, _, err := lh.C8Yclient.Tenant.GetLoginOptions(context.Background())
@@ -237,10 +264,10 @@ func (lh *LoginHandler) init() {
 		lh.sortLoginOptions()
 
 		if len(lh.LoginOptions.LoginOptions) > 0 {
-			lh.C8Yclient.AuthorizationMethod = lh.LoginOptions.LoginOptions[0].Type
+			lh.LoginType = lh.LoginOptions.LoginOptions[0].Type
 
 			// Setting preferred login method
-			lh.Logger.Debugf("Preferred login method. type=%s", lh.C8Yclient.AuthorizationMethod)
+			lh.Logger.Debugf("Preferred login method. type=%s", lh.LoginType)
 		}
 		return err
 	})
@@ -258,8 +285,14 @@ func (lh *LoginHandler) promptForPassword() error {
 		return nil
 	}
 
+	if lh.C8Yclient.Username == "" {
+		lh.state <- LoginStateAbort
+		lh.Err = fmt.Errorf("Username is empty")
+		return lh.Err
+	}
+
 	reason := ""
-	label := "Enter c8y password"
+	label := fmt.Sprintf("Enter c8y password for user (%s)", lh.C8Yclient.Username)
 
 	// Provide additional information to user what happened
 	// invalid encryption key? or missing password
@@ -267,7 +300,7 @@ func (lh *LoginHandler) promptForPassword() error {
 		reason = "password is empty"
 	} else {
 		reason = "password is invalid"
-		label = "Re-enter c8y password"
+		label = fmt.Sprintf("Re-enter c8y password for user (%s)", lh.C8Yclient.Username)
 	}
 
 	prompt := promptui.Prompt{
@@ -302,7 +335,7 @@ func (lh *LoginHandler) login() {
 			if lh.Authorized {
 				lh.state <- LoginStateAuth
 			} else {
-				lh.LoginType = c8y.AuthMethodBasic
+				lh.LoginType = c8y.LoginTypeBasic
 				lh.state <- LoginStateVerify
 			}
 			return nil
@@ -313,9 +346,60 @@ func (lh *LoginHandler) login() {
 			return nil
 		}
 
+		order := []string{}
 		for _, option := range lh.LoginOptions.LoginOptions {
+			order = append(order, option.Type)
+		}
+		lh.Logger.Infof("Login type order: %v", order)
+
+		for _, option := range lh.LoginOptions.LoginOptions {
+			lh.Logger.Infof("Trying login option. %s", option.Type)
 			switch option.Type {
-			case c8y.AuthMethodOAuth2Internal:
+			case c8y.LoginTypeOAuth2:
+				// Device Authorization Flow (for external providers)
+				if !lh.IO.CanPromptOnStdErr() {
+					lh.state <- LoginStateAbort
+					lh.Err = fmt.Errorf("OAuth2 device flow requires an interactive console")
+					return lh.Err
+				}
+
+				displayDeviceCode := func(code *device.CodeResponse) error {
+					verificationURI := code.VerificationURIComplete
+
+					lh.writeMessage("\nLogging in using the device flow (OAUTH2)\n\n")
+
+					bold := color.New(color.Bold)
+					bold.EnableColor()
+
+					if verificationURI == "" {
+						verificationURI = code.VerificationURI
+						fmt.Fprintf(os.Stderr, " First copy your one-time code: %s\n", bold.Sprint(code.UserCode))
+					}
+
+					fmt.Fprintf(lh.IO.ErrOut, "%s to open %s in your browser...", bold.Sprintf("Press Enter"), verificationURI)
+					bufio.NewReader(lh.IO.In).ReadBytes('\n')
+
+					if browserErr := browser.OpenURL(code.VerificationURIComplete); browserErr != nil {
+						lh.writeMessage("Failed to open browser, please open the URL in your browser manually")
+					}
+					return nil
+				}
+
+				accessToken, loginErr := lh.C8Yclient.Tenant.AuthorizeWithDeviceFlow(context.Background(), option.InitRequest, api.AuthEndpoints{
+					// TODO: Make URL configurable if the user knows better
+					// OpenIDConfigurationURL: "",
+				}, displayDeviceCode)
+				if loginErr != nil {
+					lh.state <- LoginStateAbort
+					lh.Err = fmt.Errorf("OAuth2 device authorization flow failed")
+					return lh.Err
+				}
+
+				lh.Logger.Infof("Received access token via device flow. type=%s, scope=%s", accessToken.Type, accessToken.Scope)
+				lh.onSave()
+				lh.state <- LoginStateVerify
+				return nil
+			case c8y.LoginTypeOAuth2Internal:
 
 				if lh.TFACodeRequired && option.TFAStrategy == "TOTP" {
 					os.Stderr.WriteString(fmt.Sprintf("Session details:\nHost=%s, username=%s\n", lh.C8Yclient.BaseURL.Host, lh.C8Yclient.Username))
@@ -360,7 +444,18 @@ func (lh *LoginHandler) login() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(Timeout)*time.Millisecond)
 					defer cancel()
 
-					lh.Logger.Debugf("Logging in using %s", c8y.AuthMethodOAuth2Internal)
+					lh.Logger.Debugf("Logging in using %s", c8y.LoginTypeOAuth2Internal)
+
+					// Check if username/password are provided
+					if lh.C8Yclient.Username == "" {
+						lh.Logger.Warnf("Skipping login type (%s) as a username is empty", option.Type)
+						continue
+					}
+					if lh.C8Yclient.Password == "" {
+						lh.Logger.Warnf("Skipping login type (%s) as password is empty", option.Type)
+						continue
+					}
+
 					if err := lh.C8Yclient.LoginUsingOAuth2(ctx, option.InitRequest); err != nil {
 						lh.Attempts++
 
@@ -394,8 +489,13 @@ func (lh *LoginHandler) login() {
 				lh.onSave()
 				lh.state <- LoginStateVerify
 
-			case c8y.AuthMethodBasic:
-				// do nothing
+			case c8y.LoginTypeBasic:
+				if lh.C8Yclient.Username == "" && lh.C8Yclient.Password == "" {
+					lh.Logger.Warnf("Skipping login type (%s) as a username and password are not defined", option.Type)
+					continue
+				}
+				lh.state <- LoginStateVerify
+				return nil
 			}
 		}
 		return nil
@@ -425,20 +525,20 @@ func (lh *LoginHandler) verify() {
 				} else if lh.errorContains(v.Message, "User has been logged out") {
 					lh.Logger.Warning("User had been logged out. Clearing token and trying again")
 					lh.state <- LoginStateNoAuth
-					lh.C8Yclient.SetToken("")
+					lh.C8Yclient.ClearToken()
 					lh.onSave()
 				} else if lh.errorContains(v.Message, "Tenant has no access from outside the platform") {
 					// Decide what to do here
-					lh.LoginType = c8y.AuthMethodBasic
+					lh.LoginType = c8y.LoginTypeBasic
 					lh.state <- LoginStateVerify
 				} else if lh.errorContains(v.Message, "Bad credentials") || lh.errorContains(v.Message, "Invalid credentials") {
-					lh.Logger.Infof("Bad credentials, using auth method: %s", lh.C8Yclient.AuthorizationMethod)
+					lh.Logger.Infof("Bad credentials, using auth method: %s", lh.C8Yclient.AuthorizationType)
 
 					// try resetting the tenant (in case if it is incorrect)
 					lh.C8Yclient.TenantName = ""
 
-					if lh.C8Yclient.AuthorizationMethod != c8y.AuthMethodOAuth2Internal {
-						if lh.Interactive {
+					if lh.C8Yclient.AuthorizationType != c8y.AuthTypeBearer {
+						if lh.IO.CanPromptOnStdErr() {
 							lh.state <- LoginStatePromptPassword
 						} else {
 							lh.state <- LoginStateAbort
@@ -486,13 +586,17 @@ func (lh LoginHandler) writeMessageF(format string, a interface{}) {
 func (lh *LoginHandler) setupTFA() error {
 
 	// Request TFA secret
-	backupAuthMethod := lh.C8Yclient.AuthorizationMethod
-	lh.C8Yclient.AuthorizationMethod = c8y.AuthMethodBasic
+	authFunc := c8y.WithTenantUsernamePassword(
+		lh.C8Yclient.TenantName,
+		lh.C8Yclient.Username,
+		lh.C8Yclient.Password,
+	)
 	resp, err := lh.C8Yclient.SendRequest(
 		context.Background(),
 		c8y.RequestOptions{
-			Method: http.MethodPost,
-			Path:   "/user/currentUser/totpSecret",
+			Method:   http.MethodPost,
+			Path:     "/user/currentUser/totpSecret",
+			AuthFunc: authFunc,
 		})
 
 	if err != nil {
@@ -544,9 +648,10 @@ func (lh *LoginHandler) setupTFA() error {
 	_, err = lh.C8Yclient.SendRequest(
 		context.Background(),
 		c8y.RequestOptions{
-			Method: http.MethodPost,
-			Path:   "/user/currentUser/totpSecret/activity",
-			Body:   map[string]interface{}{"isActive": true},
+			Method:   http.MethodPost,
+			Path:     "/user/currentUser/totpSecret/activity",
+			Body:     map[string]interface{}{"isActive": true},
+			AuthFunc: authFunc,
 		},
 	)
 
@@ -555,8 +660,6 @@ func (lh *LoginHandler) setupTFA() error {
 	}
 
 	time.Sleep(1000 * time.Millisecond)
-
-	lh.C8Yclient.AuthorizationMethod = backupAuthMethod
 	return nil
 }
 

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mdp/qrterminal/v3"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/prompt"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/reubenmiller/go-c8y/pkg/oauth/api"
 	"github.com/reubenmiller/go-c8y/pkg/oauth/device"
@@ -310,9 +311,14 @@ func (lh *LoginHandler) promptForPassword() error {
 	}
 
 	if lh.C8Yclient.Username == "" {
-		lh.state <- LoginStateAbort
-		lh.Err = fmt.Errorf("Username is empty")
-		return lh.Err
+		prompter := prompt.NewPrompt(lh.Logger)
+		username, err := prompter.Username("Enter username", " ")
+		if err != nil {
+			lh.state <- LoginStateAbort
+			lh.Err = fmt.Errorf("user cancelled prompt")
+			return lh.Err
+		}
+		lh.C8Yclient.Username = username
 	}
 
 	reason := ""
@@ -458,7 +464,7 @@ func (lh *LoginHandler) login() {
 						} else {
 							lh.state <- LoginStateAbort
 							lh.Err = fmt.Errorf("User cancelled login")
-							return nil
+							return lh.Err
 						}
 					}
 					lh.C8Yclient.TFACode = lh.TFACode
@@ -481,8 +487,6 @@ func (lh *LoginHandler) login() {
 					}
 
 					if err := lh.C8Yclient.LoginUsingOAuth2(ctx, option.InitRequest); err != nil {
-						lh.Attempts++
-
 						if v, ok := err.(*c8y.ErrorResponse); ok {
 							lh.Logger.Errorf("OAuth2 failed. %s", v.Message)
 						} else {
@@ -492,12 +496,6 @@ func (lh *LoginHandler) login() {
 						if strings.Contains(err.Error(), "There was a change in authentication strategy for your tenant or user account") {
 							// trigger unknown to recheck if TFA is required or not
 							lh.state <- LoginStateUnknown
-							return nil
-						}
-
-						if lh.Attempts > 2 {
-							lh.Err = fmt.Errorf("Max log attempts reached: %w", err)
-							lh.state <- LoginStateAbort
 							return nil
 						}
 
@@ -514,15 +512,25 @@ func (lh *LoginHandler) login() {
 				lh.state <- LoginStateVerify
 
 			case c8y.LoginTypeBasic:
-				if lh.C8Yclient.Username == "" && lh.C8Yclient.Password == "" {
-					lh.Logger.Warnf("Skipping login type (%s) as a username and password are not defined", option.Type)
-					continue
+				if lh.C8Yclient.Username == "" || lh.C8Yclient.Password == "" {
+					if lh.IO.CanPromptOnStdErr() {
+						lh.state <- LoginStatePromptPassword
+						return nil
+					} else {
+						lh.Err = fmt.Errorf("username or password is empty and the interactive prompt is disabled")
+						lh.state <- LoginStateAbort
+						return lh.Err
+					}
 				}
 				lh.state <- LoginStateVerify
 				return nil
 			}
 		}
-		return nil
+
+		// return an error by default
+		lh.state <- LoginStateAbort
+		lh.Err = fmt.Errorf("no valid login type found")
+		return lh.Err
 	})
 }
 
@@ -532,6 +540,14 @@ func (lh *LoginHandler) errorContains(message, pattern string) bool {
 
 func (lh *LoginHandler) verify() {
 	lh.do(func() error {
+		lh.Attempts++
+
+		if lh.Attempts > 2 {
+			lh.Err = fmt.Errorf("max log attempts reached")
+			lh.state <- LoginStateAbort
+			return lh.Err
+		}
+
 		tenant, resp, err := lh.C8Yclient.Tenant.GetCurrentTenant(context.Background())
 
 		if resp != nil && resp.StatusCode() == http.StatusUnauthorized {

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -100,6 +100,9 @@ type LoginHandler struct {
 	Logger          *logger.Logger
 	LoginType       string
 
+	// SSO specific settings
+	SSODiscoveryURL string
+
 	onSave func()
 }
 
@@ -407,12 +410,12 @@ func (lh *LoginHandler) login() {
 				}
 
 				accessToken, loginErr := lh.C8Yclient.Tenant.AuthorizeWithDeviceFlow(context.Background(), option.InitRequest, api.AuthEndpoints{
-					// TODO: Make URL configurable if the user knows better
-					// OpenIDConfigurationURL: "",
+					// Allow users to provide their own discovery URL
+					OpenIDConfigurationURL: lh.SSODiscoveryURL,
 				}, displayDeviceCode)
 				if loginErr != nil {
 					lh.state <- LoginStateAbort
-					lh.Err = fmt.Errorf("OAuth2 device authorization flow failed")
+					lh.Err = fmt.Errorf("OAuth2 device authorization flow failed. %w", loginErr)
 					return lh.Err
 				}
 

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/mdp/qrterminal/v3"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/prompt"
@@ -105,9 +106,7 @@ type LoginHandler struct {
 	LoginAttempted  bool
 
 	// SSO specific settings
-	SSODiscoveryURL string
-	SSOAudience     string
-	SSOScopes       []string
+	SSO config.SSOSettings
 
 	onSave func()
 }
@@ -120,6 +119,7 @@ func NewLoginHandler(IO *iostreams.IOStreams, c *c8y.Client, w io.Writer, onSave
 		Writer:    w,
 		onSave:    onSave,
 		Logger:    logger.NewDummyLogger("c8ylogin"),
+		SSO:       config.SSOSettings{},
 	}
 	h.state = make(chan LoginState, 1)
 	return h
@@ -440,9 +440,11 @@ func (lh *LoginHandler) login() {
 
 				accessToken, loginErr := lh.C8Yclient.Tenant.AuthorizeWithDeviceFlow(context.Background(), option.InitRequest, api.AuthEndpoints{
 					// Allow users to provide their own discovery URL and scopes
-					OpenIDConfigurationURL: lh.SSODiscoveryURL,
-					Scopes:                 lh.SSOScopes,
-					Audience:               lh.SSOAudience,
+					OpenIDConfigurationURL: lh.SSO.DiscoveryURL,
+					Scopes:                 lh.SSO.Scopes,
+					AuthRequestOptions: []api.AuthRequestEditorFn{
+						api.WithAudience(lh.SSO.Audience),
+					},
 				}, displayDeviceCode)
 				if loginErr != nil {
 					// Ignore SSO if invalid configuration is found

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -26,7 +26,28 @@ import (
 type LoginState int
 
 func (l LoginState) String() string {
-	return [...]string{"Unknown", "Authorized", "NotAuthorized", "TFASetup", "TFAConfirm", "Verify", "Abort", "PromptForPassword"}[l]
+	switch l {
+	case LoginStateAuth:
+		return "Authorized"
+	case LoginStateNoAuth:
+		return "NotAuthorized"
+	case LoginStateTFASetup:
+		return "TFASetup"
+	case LoginStateTFAConfirm:
+		return "TFAConfirm"
+	case LoginStateLogin:
+		return "Login"
+	case LoginStateVerify:
+		return "Verify"
+	case LoginStateAbort:
+		return "Abort"
+	case LoginStatePromptPassword:
+		return "PromptForPassword"
+	case LoginStateUnknown:
+		fallthrough
+	default:
+		return "Unknown"
+	}
 }
 
 const (

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -457,7 +457,7 @@ func (lh *LoginHandler) login() {
 					return lh.Err
 				}
 
-				lh.Logger.Infof("Received access token via device flow. type=%s, scope=%s", accessToken.Type, accessToken.Scope)
+				lh.Logger.Infof("Received access token via device flow. type=%s, scope=%s, tokenPresent=%v, refreshTokenPresent=%v", accessToken.Type, accessToken.Scope, accessToken.Token != "", accessToken.RefreshToken != "")
 				lh.onSave()
 				lh.state <- LoginStateVerify
 				return nil

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -103,6 +103,7 @@ type LoginHandler struct {
 
 	// SSO specific settings
 	SSODiscoveryURL string
+	SSOScopes       []string
 
 	onSave func()
 }
@@ -409,15 +410,16 @@ func (lh *LoginHandler) login() {
 					fmt.Fprintf(lh.IO.ErrOut, "%s to open %s in your browser...", bold.Sprintf("Press Enter"), verificationURI)
 					bufio.NewReader(lh.IO.In).ReadBytes('\n')
 
-					if browserErr := browser.OpenURL(code.VerificationURIComplete); browserErr != nil {
+					if browserErr := browser.OpenURL(verificationURI); browserErr != nil {
 						lh.writeMessage("Failed to open browser, please open the URL in your browser manually")
 					}
 					return nil
 				}
 
 				accessToken, loginErr := lh.C8Yclient.Tenant.AuthorizeWithDeviceFlow(context.Background(), option.InitRequest, api.AuthEndpoints{
-					// Allow users to provide their own discovery URL
+					// Allow users to provide their own discovery URL and scopes
 					OpenIDConfigurationURL: lh.SSODiscoveryURL,
+					Scopes:                 lh.SSOScopes,
 				}, displayDeviceCode)
 				if loginErr != nil {
 					lh.state <- LoginStateAbort

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -106,6 +106,7 @@ type LoginHandler struct {
 
 	// SSO specific settings
 	SSODiscoveryURL string
+	SSOAudience     string
 	SSOScopes       []string
 
 	onSave func()
@@ -441,6 +442,7 @@ func (lh *LoginHandler) login() {
 					// Allow users to provide their own discovery URL and scopes
 					OpenIDConfigurationURL: lh.SSODiscoveryURL,
 					Scopes:                 lh.SSOScopes,
+					Audience:               lh.SSOAudience,
 				}, displayDeviceCode)
 				if loginErr != nil {
 					// Ignore SSO if invalid configuration is found

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -590,6 +590,18 @@ func (lh *LoginHandler) verify() {
 					lh.Logger.Warnf("Could not get Cumulocity System version. %s", err)
 				}
 			}
+
+			// Get user information if not set (e.g. external SSO tokens don't generally include the username in a known field)
+			if lh.C8Yclient.Username == "" {
+				lh.Logger.Infof("Getting the current user's information as the username is not set")
+				currentUser, _, err := lh.C8Yclient.User.GetCurrentUser(context.Background())
+				if err != nil {
+					lh.Logger.Warnf("Could not get username. %s", err)
+				} else {
+					lh.Logger.Infof("Found current username. %s", currentUser.Username)
+					lh.C8Yclient.Username = currentUser.Username
+				}
+			}
 		}
 		return err
 	})

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -3,6 +3,7 @@ package c8ylogin
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/mdp/qrterminal/v3"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/prompt"
@@ -100,6 +102,7 @@ type LoginHandler struct {
 	Writer          io.Writer
 	Logger          *logger.Logger
 	LoginType       string
+	LoginAttempted  bool
 
 	// SSO specific settings
 	SSODiscoveryURL string
@@ -209,6 +212,22 @@ func (lh *LoginHandler) Run() error {
 		}
 
 		time.Sleep(500 * time.Millisecond)
+	}
+
+	//
+	// When reusing an existing token, the default login type might be wrong so
+	// try and detect the type by parsing the token
+	if !lh.LoginAttempted {
+		if lh.C8Yclient.Token != "" {
+			if subject, err := c8ysession.GetTokenSubject(lh.C8Yclient.Token); err == nil {
+				// with c8y issued tokens, the subject is the username
+				if lh.C8Yclient.Username == subject {
+					lh.LoginType = c8y.LoginTypeOAuth2Internal
+				} else {
+					lh.LoginType = c8y.LoginTypeOAuth2
+				}
+			}
+		}
 	}
 
 	return lh.Err
@@ -377,6 +396,8 @@ func (lh *LoginHandler) login() {
 			return nil
 		}
 
+		lh.LoginAttempted = true
+
 		order := []string{}
 		for _, option := range lh.LoginOptions.LoginOptions {
 			order = append(order, option.Type)
@@ -422,6 +443,15 @@ func (lh *LoginHandler) login() {
 					Scopes:                 lh.SSOScopes,
 				}, displayDeviceCode)
 				if loginErr != nil {
+					// Ignore SSO if invalid configuration is found
+					if errors.Is(loginErr, c8y.ErrSSOInvalidConfiguration) {
+						lh.Logger.Warnf("Skipping login type (%s) as SSO configuration is invalid. err=%s", option.Type, loginErr)
+						continue
+					}
+
+					// Check error type, and if the configuration can't be found, then skip SSO
+					// add a new formal type to cover this scenario
+					// could not get OpenID Connect configuration
 					lh.state <- LoginStateAbort
 					lh.Err = fmt.Errorf("OAuth2 device authorization flow failed. %w", loginErr)
 					return lh.Err

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -254,6 +254,10 @@ func GetVariablesFromSession(session *CumulocitySession, cfg *config.Config, cli
 		"C8Y_HEADER":               authHeader,
 	}
 
+	if session.LoginType != "" {
+		output["C8Y_SETTINGS_LOGIN_TYPE"] = session.LoginType
+	}
+
 	if mode != "" {
 		output[config.EnvSessionMode] = mode
 	}
@@ -302,6 +306,7 @@ func GetSessionEnvKeys() []string {
 		"C8Y_SESSION",
 		"C8Y_HEADER",
 		"C8Y_HEADER_AUTHORIZATION",
+		"C8Y_SETTINGS_LOGIN_TYPE",
 		config.EnvSessionMode,
 	}
 	return keys

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -171,7 +171,13 @@ func PrintSessionInfo(w io.Writer, client *c8y.Client, cfg *config.Config, sessi
 		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "username")), value(maybeHideMessage(client, session.Username)))
 	}
 	if client != nil {
-		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "authType")), value(client.AuthorizationType.String()))
+		var authTypeLogin string
+		if session.LoginType != "" {
+			authTypeLogin = fmt.Sprintf("%s (loginType=%s)", client.AuthorizationType.String(), session.LoginType)
+		} else {
+			authTypeLogin = client.AuthorizationType.String()
+		}
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "authType")), value(authTypeLogin))
 	}
 	fmt.Fprintf(w, "\n")
 }
@@ -359,7 +365,10 @@ func shouldRenewToken(log *logger.Logger, t string, validFor time.Duration) (boo
 }
 
 // ShouldReuseToken checks if the token should be reused or not
-func ShouldReuseToken(cfg *config.Config, log *logger.Logger, token string) bool {
+func ShouldReuseToken(cfg *config.Config, log *logger.Logger, token string, loginType string) bool {
+	if loginType != "" && !LoginTypeRequiresToken(loginType) {
+		return false
+	}
 	if token == "" {
 		return false
 	}
@@ -384,4 +393,9 @@ func ShouldReuseToken(cfg *config.Config, log *logger.Logger, token string) bool
 		reuse = false
 	}
 	return reuse
+}
+
+// LoginTypeRequiresToken check if the given loginType requires a token for authorization
+func LoginTypeRequiresToken(loginType string) bool {
+	return strings.EqualFold(loginType, c8y.LoginTypeOAuth2) || strings.EqualFold(loginType, c8y.LoginTypeOAuth2Internal)
 }

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -25,17 +25,21 @@ type CumulocitySessions struct {
 type CumulocitySession struct {
 	Schema string `json:"$schema,omitempty"`
 
+	// authorized
+	Authorized *bool `json:"authorized,omitempty"`
+
 	// ID          string `json:"id"`
-	Host            string `json:"host"`
-	Tenant          string `json:"tenant"`
-	Version         string `json:"version"`
-	Username        string `json:"username"`
-	Password        string `json:"password"`
+	Host            string `json:"host,omitempty"`
+	Tenant          string `json:"tenant,omitempty"`
+	Version         string `json:"version,omitempty"`
+	Username        string `json:"username,omitempty"`
+	Password        string `json:"password,omitempty"`
 	Mode            string `json:"mode,omitempty"`
-	TOTP            string `json:"totp"`
-	Token           string `json:"token"`
-	Description     string `json:"description"`
+	TOTP            string `json:"totp,omitempty"`
+	Token           string `json:"token,omitempty"`
+	Description     string `json:"description,omitempty"`
 	UseTenantPrefix bool   `json:"useTenantPrefix"`
+	LoginType       string `json:"loginType,omitempty"`
 
 	Settings *config.CommandSettings `json:"settings,omitempty"`
 
@@ -47,7 +51,7 @@ type CumulocitySession struct {
 	Name      string `json:"-"`
 
 	// How to identify the session
-	SessionUri string `json:"sessionUri"`
+	SessionUri string `json:"sessionUri,omitempty"`
 
 	Logger *logger.Logger `json:"-"`
 	Config *config.Config `json:"-"`
@@ -67,6 +71,14 @@ func (s *CumulocitySession) SetToken(token string) {
 
 func (s *CumulocitySession) SetHost(host string) {
 	s.Host = FormatHost(host)
+}
+
+func (s *CumulocitySession) SetAuthorized(v bool) {
+	s.Authorized = &v
+}
+
+func (s CumulocitySession) IsAuthorized() bool {
+	return s.Authorized != nil && *s.Authorized
 }
 
 func FormatHost(host string) string {
@@ -159,7 +171,7 @@ func PrintSessionInfo(w io.Writer, client *c8y.Client, cfg *config.Config, sessi
 		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "username")), value(maybeHideMessage(client, session.Username)))
 	}
 	if client != nil {
-		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "loginType")), value(client.AuthorizationMethod))
+		fmt.Fprintf(w, "%s : %s\n", label(fmt.Sprintf("%-12s", "authType")), value(client.AuthorizationType.String()))
 	}
 	fmt.Fprintf(w, "\n")
 }
@@ -209,7 +221,7 @@ func GetVariablesFromSession(session *CumulocitySession, cfg *config.Config, cli
 	token := session.Token
 	authHeaderValue := ""
 	authHeader := ""
-	loginType := client.AuthorizationMethod
+	loginType := session.LoginType
 
 	if dummyReq, err := client.NewRequest("GET", "/", "", nil); err == nil {
 		authHeaderValue = dummyReq.Header.Get("Authorization")
@@ -253,7 +265,7 @@ func GetVariablesFromSession(session *CumulocitySession, cfg *config.Config, cli
 		}
 	}
 
-	if loginType != c8y.AuthMethodOAuth2Internal {
+	if client.AuthorizationType != c8y.AuthTypeBearer {
 		output["C8Y_TOKEN"] = ""
 	}
 
@@ -308,7 +320,7 @@ func IsSessionFilePath(path string) bool {
 	return !strings.Contains(path, "://")
 }
 
-func shouldRenewToken(t string, validFor time.Duration) (bool, *time.Time) {
+func shouldRenewToken(log *logger.Logger, t string, validFor time.Duration) (bool, *time.Time) {
 	claims := jwt.RegisteredClaims{}
 	parser := jwt.NewParser()
 	_, _, err := parser.ParseUnverified(t, &claims)
@@ -316,6 +328,16 @@ func shouldRenewToken(t string, validFor time.Duration) (bool, *time.Time) {
 	if err != nil {
 		// Invalid token
 		return true, nil
+	}
+
+	// Recently issued, so don't renew it
+	// Check if the token's validity period is too short
+	if claims.ExpiresAt != nil && claims.IssuedAt != nil {
+		tokenValidityPeriod := claims.ExpiresAt.Sub(claims.IssuedAt.Time)
+		if tokenValidityPeriod < validFor {
+			log.Warnf("SSO token validity period is less than the given token validFor, so the token will be used regardless. minimumValidFor=%v, tokenValidity=%v", validFor, tokenValidityPeriod)
+			return false, nil
+		}
 	}
 
 	if claims.ExpiresAt != nil {
@@ -335,7 +357,7 @@ func ShouldReuseToken(cfg *config.Config, log *logger.Logger, token string) bool
 
 	// Check if token is valid for the minimum period
 	shouldBeValidFor := cfg.TokenValidFor()
-	expiresSoon, expiresAt := shouldRenewToken(token, shouldBeValidFor)
+	expiresSoon, expiresAt := shouldRenewToken(log, token, shouldBeValidFor)
 
 	if expiresAt != nil {
 		if time.Now().After(*expiresAt) {

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -191,7 +191,7 @@ func WriteOutput(w io.Writer, client *c8y.Client, cfg *config.Config, session *C
 
 	switch format {
 	case "json":
-		out, err := json.Marshal(session)
+		out, err := MarshalSession(session, cfg)
 		if err != nil {
 			return err
 		}
@@ -302,6 +302,16 @@ func GetSessionEnvKeys() []string {
 		config.EnvSessionMode,
 	}
 	return keys
+}
+
+func MarshalSession(session *CumulocitySession, cfg *config.Config) ([]byte, error) {
+	// Don't include password if a token is provided
+	if !cfg.AlwaysIncludePassword() {
+		if session.Token != "" {
+			session.Password = ""
+		}
+	}
+	return json.Marshal(session)
 }
 
 func ClearEnvironmentVariables(shell utilities.ShellType) {

--- a/pkg/c8ysession/c8ysession.go
+++ b/pkg/c8ysession/c8ysession.go
@@ -227,7 +227,6 @@ func GetVariablesFromSession(session *CumulocitySession, cfg *config.Config, cli
 	token := session.Token
 	authHeaderValue := ""
 	authHeader := ""
-	loginType := session.LoginType
 
 	if dummyReq, err := client.NewRequest("GET", "/", "", nil); err == nil {
 		authHeaderValue = dummyReq.Header.Get("Authorization")
@@ -253,7 +252,6 @@ func GetVariablesFromSession(session *CumulocitySession, cfg *config.Config, cli
 		"C8Y_PASSWORD":             password,
 		"C8Y_HEADER_AUTHORIZATION": authHeaderValue,
 		"C8Y_HEADER":               authHeader,
-		"C8Y_SETTINGS_LOGIN_TYPE":  loginType,
 	}
 
 	if mode != "" {
@@ -304,7 +302,6 @@ func GetSessionEnvKeys() []string {
 		"C8Y_SESSION",
 		"C8Y_HEADER",
 		"C8Y_HEADER_AUTHORIZATION",
-		"C8Y_SETTINGS_LOGIN_TYPE",
 		config.EnvSessionMode,
 	}
 	return keys
@@ -398,4 +395,19 @@ func ShouldReuseToken(cfg *config.Config, log *logger.Logger, token string, logi
 // LoginTypeRequiresToken check if the given loginType requires a token for authorization
 func LoginTypeRequiresToken(loginType string) bool {
 	return strings.EqualFold(loginType, c8y.LoginTypeOAuth2) || strings.EqualFold(loginType, c8y.LoginTypeOAuth2Internal)
+}
+
+func GetTokenSubject(value string) (string, error) {
+	claims := jwt.RegisteredClaims{}
+	parser := jwt.NewParser()
+	token, _, err := parser.ParseUnverified(value, &claims)
+	if err != nil {
+		// Invalid token
+		return "", fmt.Errorf("invalid token")
+	}
+	subject, err := token.Claims.GetSubject()
+	if err != nil {
+		return "", err
+	}
+	return subject, nil
 }

--- a/pkg/cmd/factory/c8yclient.go
+++ b/pkg/cmd/factory/c8yclient.go
@@ -220,7 +220,7 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 			authErrors = nil
 		}
 
-		log.Infof("Using client auth type: %s", client.AuthorizationMethod)
+		log.Infof("Using client auth type: %s", client.AuthorizationType.String())
 
 		if !disableEncryptionCheck && len(authErrors) > 0 {
 			log.Warnf("Could not load authentication. error=%v", authErrors[0])
@@ -244,7 +244,7 @@ func CreateCumulocityClient(f *cmdutil.Factory, sessionFile, username, password 
 		)
 
 		// Set realtime authorization
-		if client.AuthorizationMethod == c8y.AuthMethodOAuth2Internal {
+		if client.AuthorizationType == c8y.AuthTypeBearer {
 			if client.Token != "" {
 				client.Realtime.SetBearerToken(client.Token)
 			} else {
@@ -275,45 +275,46 @@ func loadAuthentication(conf *config.Config, client *c8y.Client) error {
 		token, err := conf.GetToken()
 		if err == nil && token != "" {
 			client.SetToken(token)
-			client.AuthorizationMethod = c8y.AuthMethodOAuth2Internal
 			return nil
 		}
 
 		// password
 		if p, err := conf.GetPassword(); err == nil && p != "" {
-			client.AuthorizationMethod = c8y.AuthMethodBasic
+			client.SetTenantUsernamePassword(conf.GetTenant(), conf.GetUsername(), p)
 			return nil
 		}
 
 		// none
-		client.AuthorizationMethod = c8y.AuthMethodNone
+		client.SetAuthorizationType(c8y.AuthTypeNone)
 		return nil
 	}
 
 	// Force the usage of an auth method regardless if the pre-requisites for
 	// such auth method are available (this allows users to also enforce it)
-	client.AuthorizationMethod = conf.GetLoginTypeWithDefault()
-	if strings.EqualFold(client.AuthorizationMethod, c8y.AuthMethodOAuth2Internal) {
+	loginType = conf.GetLoginTypeWithDefault()
+
+	// OAUTH2 (internal and external)
+	if strings.EqualFold(loginType, c8y.LoginTypeOAuth2Internal) || strings.EqualFold(loginType, c8y.LoginTypeOAuth2) {
 		token, err := conf.GetToken()
 		if err != nil {
 			return err
 		}
 		client.SetToken(token)
-		client.AuthorizationMethod = c8y.AuthMethodOAuth2Internal
 		return nil
 	}
 
-	if strings.EqualFold(client.AuthorizationMethod, c8y.AuthMethodBasic) {
-		// clear token as we want to force basic auth
-		client.SetToken("")
+	if strings.EqualFold(loginType, c8y.LoginTypeBasic) {
+		password, err := conf.GetPassword()
+		if err != nil {
+			return err
+		}
+		client.SetTenantUsernamePassword(conf.GetTenant(), conf.GetUsername(), password)
 		return nil
 	}
 
-	if strings.EqualFold(client.AuthorizationMethod, c8y.AuthMethodNone) {
+	if strings.EqualFold(loginType, c8y.LoginTypeNone) {
 		// clear token as we want to force basic auth
-		client.SetToken("")
-		client.Username = ""
-		client.Password = ""
+		client.SetAuthorizationType(c8y.AuthTypeNone)
 		return nil
 	}
 	return nil

--- a/pkg/cmd/root/command.go
+++ b/pkg/cmd/root/command.go
@@ -85,6 +85,11 @@ func getOutputHeaders(c *console.Console, cfg *config.Config, input []string) (h
 	return append(bytes.Join(columns, []byte(",")), []byte("\n")...)
 }
 
+func ShouldIgnoreSessionFile(args []string) bool {
+	cmdStr := strings.Join(args, " ")
+	return strings.Contains(cmdStr, "c8y sessions login") || strings.Contains(cmdStr, "c8y sessions set")
+}
+
 // Initialize initializes the configuration manager and c8y client
 func NewCommand(buildVersion, buildBranch string) (*CmdRoot, error) {
 	if buildVersion == "" {
@@ -104,7 +109,8 @@ func NewCommand(buildVersion, buildBranch string) (*CmdRoot, error) {
 	// init logger
 	logHandler = logger.NewLogger(module, GetInitLoggerOptions(os.Args))
 
-	if _, err := configHandler.ReadConfigFiles(nil); err != nil {
+	// Note: Loading of the session should be deferred until the commands are loaded
+	if _, err := configHandler.ReadConfigFiles(nil, ShouldIgnoreSessionFile(os.Args)); err != nil {
 		logHandler.Infof("Failed to read configuration. Trying to proceed anyway. %s", err)
 	}
 

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -819,7 +819,7 @@ func (c *CmdRoot) Configure(disableEncryptionCheck, forceVerbose, forceDebug boo
 		client, err := factory.CreateCumulocityClient(c.Factory, c.SessionFile, c.SessionUsername, c.SessionPassword, disableEncryptionCheck)()
 		if client != nil {
 			if c.SessionUsername != "" || c.SessionPassword != "" {
-				client.AuthorizationMethod = c8y.AuthMethodBasic
+				client.SetUsernamePassword(c.SessionUsername, c.SessionPassword)
 				c.log.Debug("Forcing basic authentication as user provided username/password")
 			}
 		}

--- a/pkg/cmd/sessions/create/create.manual.go
+++ b/pkg/cmd/sessions/create/create.manual.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -143,9 +144,10 @@ $ c8y sessions create --type prod --host "https://localhost:443" --insecure
 		),
 		completion.WithValidateSet(
 			"loginType",
-			c8y.AuthMethodBasic,
-			c8y.AuthMethodOAuth2Internal,
-			c8y.AuthMethodNone,
+			c8y.LoginTypeBasic,
+			c8y.LoginTypeOAuth2Internal,
+			c8y.LoginTypeOAuth2,
+			c8y.LoginTypeNone,
 		),
 	)
 
@@ -183,7 +185,34 @@ func (n *CmdCreate) promptArgs(cmd *cobra.Command, args []string) error {
 		n.host = strings.TrimSpace(v)
 	}
 
-	if !cmd.Flags().Changed("username") && n.loginType != c8y.AuthMethodNone {
+	if !cmd.Flags().Changed("loginType") {
+		localClient := c8y.NewClientFromOptions(nil, c8y.ClientOptions{
+			BaseURL: n.host,
+		})
+		loginOptions, _, loginOptionsErr := localClient.Tenant.GetLoginOptions(context.Background())
+		if loginOptionsErr != nil {
+			return loginOptionsErr
+		}
+
+		loginOptionsForUsers := make([]string, 0, len(loginOptions.LoginOptions))
+		loginOptionsForUsers = append(loginOptionsForUsers, "auto")
+		for _, option := range loginOptions.LoginOptions {
+			loginOptionsForUsers = append(loginOptionsForUsers, option.Type)
+		}
+
+		selectedLoginOption, err := prompt.Select("Select login type", loginOptionsForUsers, loginOptionsForUsers[0])
+		if err != nil {
+			return err
+		}
+		// TODO: Add formal type for auto
+		if selectedLoginOption != "auto" {
+			n.loginType = selectedLoginOption
+		}
+	}
+
+	loginTypeRequiresPasswords := requiresUsername(n.loginType)
+
+	if !cmd.Flags().Changed("username") && loginTypeRequiresPasswords {
 		v, err := prompter.Username("Enter username", " "+cfg.GetDefaultUsername())
 
 		if err != nil {
@@ -192,7 +221,7 @@ func (n *CmdCreate) promptArgs(cmd *cobra.Command, args []string) error {
 		n.username = strings.TrimSpace(v)
 	}
 
-	if !n.noStorage && !cmd.Flags().Changed("password") && n.loginType != c8y.AuthMethodNone {
+	if !n.noStorage && !cmd.Flags().Changed("password") && loginTypeRequiresPasswords {
 		password, err := prompter.Password("Enter c8y password", "")
 		if err != nil {
 			return err
@@ -215,6 +244,10 @@ func (n *CmdCreate) promptArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func requiresUsername(loginType string) bool {
+	return loginType != c8y.LoginTypeNone && loginType != c8y.LoginTypeOAuth2
+}
+
 func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 	// Validate required parameters here as the user could have entered them
 	// via the prompt
@@ -225,7 +258,7 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if n.username == "" && n.loginType != c8y.AuthMethodNone {
+	if n.username == "" && requiresUsername(n.loginType) {
 		return &flags.ParameterError{
 			Name: "username",
 			Err:  flags.ErrParameterMissing,

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -3,12 +3,12 @@ package login
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"slices"
 	"strings"
 	"time"
 
@@ -91,13 +91,14 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().StringVar(&ccmd.Exec, "from-cmd", "", "External command to execute to get the log in details")
 	cmd.Flags().BoolVar(&ccmd.Env, "from-env", false, "Read from environment variables")
 	cmd.Flags().BoolVar(&ccmd.Stdin, "from-stdin", false, "Read from standard input")
+	// cmd.Flags().BoolVar(&ccmd.Console, "from-console", false, "Read from user console")
 	cmd.Flags().BoolVar(&ccmd.NoBanner, "no-banner", false, "Don't show the session banner")
 	cmd.Flags().StringVar(&ccmd.TFACode, "tfaCode", "", "Two Factor Authentication code")
 	cmd.Flags().BoolVar(&ccmd.ClearToken, "clear", false, "Clear any existing tokens")
 	cmd.Flags().StringVar(&ccmd.Format, "format", "", "External command format, e.g. json, yaml, toml")
 	cmd.Flags().StringVar(&ccmd.OutputFormat, "output-format", "", "Output format")
 	cmd.Flags().StringVar(&ccmd.Shell, "shell", "", "Shell type to return the environment variables")
-	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL or BASIC. When set to BASIC, any existing token will be cleared")
+	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL, OAUTH2 (device flow) or BASIC. When set to BASIC, any existing token will be cleared")
 	cmd.Flags().StringVar(&ccmd.Mode, "mode", "", "Session mode which controls which commands are allowed, e.g. dev, qual or prod")
 	cmd.Flags().StringSliceVar(&ccmd.Secrets, "secrets", []string{}, "List of secrets to include as env variables when running an external command. Only valid with from-cmd")
 
@@ -107,7 +108,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 		completion.WithValidateSet("output-format", "json", "dotenv"),
 		completion.WithValidateSet("provider", config.ProviderTypeFile, config.ProviderTypeStdin, config.ProviderTypeEnv, config.ProviderTypeExternal, config.ProviderTypeAuto),
 		completion.WithValidateSet("format", "json", "yaml", "toml", "dotenv"),
-		completion.WithValidateSet("loginType", c8y.AuthMethodOAuth2Internal, c8y.AuthMethodBasic),
+		completion.WithValidateSet("loginType", c8y.LoginTypeOAuth2Internal, c8y.LoginTypeBasic, c8y.LoginTypeNone, c8y.LoginTypeOAuth2),
 		completion.WithValidateSet(
 			"mode",
 			config.GetSessionModeCompletionHelp()...,
@@ -209,13 +210,24 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 	if len(cmdArgs) == 0 {
 		return nil, fmt.Errorf("provider command could not be parsed")
 	}
-	cmdExec := cmdArgs[0]
-	cmd := exec.Command(cmdExec, slices.Concat(cmdArgs[1:], args)...)
+	providerCommand := make([]string, 0, len(cmdArgs))
+	providerCommand = append(providerCommand, cmdArgs...)
+
+	if n.ClearToken {
+		providerCommand = append(providerCommand, "--clear")
+	}
+
+	if n.LoginType != "" {
+		providerCommand = append(providerCommand, fmt.Sprintf("--loginType=%s", n.LoginType))
+	}
+
+	providerCommand = append(providerCommand, args...)
+	cmd := exec.Command(providerCommand[0], providerCommand[1:]...)
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 
-	log.Infof("Executing session provider: %s", providerCmd)
+	log.Infof("Executing session provider: %s", shellquote.Join(providerCommand...))
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -232,7 +244,7 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 		}
 	}
 
-	log.Infof("Parsing session provider output: %s", output)
+	log.Infof("Parsing session provider output: %s, value=%s", output, output)
 	return n.FromReader(bytes.NewReader(output), n.Format)
 }
 
@@ -260,7 +272,10 @@ func (n *CmdLogin) FromViper(v *viper.Viper) (*c8ysession.CumulocitySession, err
 		Token:      getValue("token"),
 		TOTP:       getValue("totp"),
 		Mode:       getValue("mode"),
+		LoginType:  getValue("loginType"),
+		Version:    getValue("version"),
 	}
+	session.SetAuthorized(v.GetBool("authorized"))
 	session.SetHost(getValue("host"))
 	return session, nil
 }
@@ -410,45 +425,73 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		return cmderrors.NewUserError("invalid session. host is empty")
 	}
 
+	if sessionContents, err := json.Marshal(session); err == nil {
+		cfg.Logger.Infof("Received session from external source:\n%s\n", sessionContents)
+	}
+
 	client := c8y.NewClient(nil, session.Host, session.Tenant, session.Username, session.Password, true)
 
-	if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, session.Token) {
+	if session.Token != "" {
 		client.SetToken(session.Token)
-	} else {
-		client.SetToken("")
 	}
 
-	c8ysession.ClearProcessEnvironment()
-
-	handler := c8ylogin.NewLoginHandler(client, cmd.ErrOrStderr(), func() {})
-	handler.Interactive = true
-	handler.LoginType = strings.ToUpper(cfg.GetLoginTypeWithDefault())
-	if n.LoginType != "" {
-		handler.LoginType = strings.ToUpper(n.LoginType)
-	}
-
-	log.Infof("User preference for login type: %s", handler.LoginType)
-	handler.TFACode = session.TOTP
-	if n.TFACode == "" {
-		if code, err := cfg.GetTOTP(time.Now()); err == nil {
-			cfg.Logger.Infof("Setting totp code: %s", code)
-			n.TFACode = code
+	if session.Authorized == nil || !*session.Authorized {
+		loginType := strings.ToUpper(cfg.GetLoginTypeWithDefault())
+		if n.LoginType != "" {
+			loginType = strings.ToUpper(n.LoginType)
 		}
+		log.Infof("User flag login type: %s", loginType)
+
+		// Set default auth mode based on login type
+		switch loginType {
+		case c8y.LoginTypeOAuth2Internal, c8y.LoginTypeOAuth2:
+			client.SetAuthorizationType(c8y.AuthTypeBearer)
+		case c8y.LoginTypeBasic:
+			client.SetAuthorizationType(c8y.AuthTypeBasic)
+		case c8y.LoginTypeNone:
+			client.SetAuthorizationType(c8y.AuthTypeNone)
+		}
+
+		// SSO providers are in control of the token, so it should just be used as is
+		if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, session.Token) {
+			client.SetToken(session.Token)
+		} else {
+			client.ClearToken()
+		}
+
+		c8ysession.ClearProcessEnvironment()
+
+		handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {})
+		handler.LoginType = loginType
+
+		log.Infof("User preference for login type: %s", handler.LoginType)
+		handler.TFACode = session.TOTP
+		if n.TFACode == "" {
+			if code, err := cfg.GetTOTP(time.Now()); err == nil {
+				cfg.Logger.Infof("Setting totp code: %s", code)
+				n.TFACode = code
+			}
+		}
+
+		handler.SetLogger(log)
+		err = handler.Run()
+		if err != nil {
+			return err
+		}
+
+		session.Username = handler.C8Yclient.Username
+		session.Host = handler.C8Yclient.BaseURL.Host
+
+		if client.Version != "" {
+			session.Version = client.Version
+		}
+
+		if client.TenantName != "" {
+			session.Tenant = client.TenantName
+		}
+		session.Token = client.Token
 	}
 
-	handler.SetLogger(log)
-	err = handler.Run()
-	if err != nil {
-		return err
-	}
-
-	session.Token = client.Token
-	if client.TenantName != "" {
-		session.Tenant = client.TenantName
-	}
-	session.Version = client.Version
-	session.Username = handler.C8Yclient.Username
-	session.Host = handler.C8Yclient.BaseURL.Host
 	session.Path = cfg.GetSessionFile()
 
 	if n.Mode != "" {
@@ -470,6 +513,10 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 	if canChangeActiveSession {
 		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
+
+		if session.LoginType != "" {
+			fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is using %s\n", cs.SuccessIcon(), session.LoginType)
+		}
 	} else {
 		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is not active (see previous warning)\n", cs.WarningIcon())
 	}

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -310,7 +310,7 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 		}
 	}
 
-	log.Infof("Parsing session provider output: %s, value=%s", output, output)
+	log.Infof("Parsing session provider output: %s", output)
 	return n.FromReader(bytes.NewReader(output), n.Format)
 }
 
@@ -518,6 +518,9 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 	if !session.IsAuthorized() {
 		loginType := strings.ToUpper(cfg.GetLoginTypeWithDefault())
+		if session.LoginType != "" {
+			loginType = session.LoginType
+		}
 		if n.LoginType != "" {
 			loginType = strings.ToUpper(n.LoginType)
 		}

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -186,10 +186,6 @@ func (n *CmdLogin) FromEnv() (*c8ysession.CumulocitySession, error) {
 }
 
 func (n *CmdLogin) FromInteractive(cmd *cobra.Command) (*c8ysession.CumulocitySession, error) {
-	// cfg, err := n.factory.Config()
-	// if err != nil {
-	// 	return nil, err
-	// }
 	log, err := n.factory.Logger()
 	if err != nil {
 		return nil, err
@@ -228,9 +224,7 @@ func (n *CmdLogin) FromInteractive(cmd *cobra.Command) (*c8ysession.CumulocitySe
 		session.Mode = mode
 	}
 
-	if session.SessionUri == "" {
-		session.SessionUri = "interactive://host"
-	}
+	session.SessionUri = "interactive://host"
 	return session, nil
 }
 
@@ -536,6 +530,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {})
 		handler.LoginType = loginType
 		handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
+		handler.SSOScopes = cfg.SSOScopes()
 
 		log.Infof("User preference for login type: %s", handler.LoginType)
 		handler.TFACode = session.TOTP

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -35,6 +35,7 @@ type CmdLogin struct {
 	Exec     string
 	Stdin    bool
 	Env      bool
+	Prompt   bool
 	Format   string
 	Provider string
 	Secrets  []string
@@ -45,6 +46,7 @@ type CmdLogin struct {
 	ClearToken bool
 
 	Mode string
+	Host string
 
 	// Output options
 	Shell        string
@@ -80,6 +82,8 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 
 			$ eval "$( c8y sessions login --from-cmd "c8y-session-bitwarden list --folder c8y" --secrets BW_SESSION --format json )"
 			Set a session from an external command, where the external commands returns the selected session in json format on stdout
+
+			$ eval "$( c8y sessions login --from-prompt --host example.cumulocity.com)"
 		`),
 		RunE: ccmd.RunE,
 	}
@@ -91,6 +95,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().StringVar(&ccmd.Exec, "from-cmd", "", "External command to execute to get the log in details")
 	cmd.Flags().BoolVar(&ccmd.Env, "from-env", false, "Read from environment variables")
 	cmd.Flags().BoolVar(&ccmd.Stdin, "from-stdin", false, "Read from standard input")
+	cmd.Flags().BoolVar(&ccmd.Prompt, "from-prompt", false, "Read from user prompted input")
 	// cmd.Flags().BoolVar(&ccmd.Console, "from-console", false, "Read from user console")
 	cmd.Flags().BoolVar(&ccmd.NoBanner, "no-banner", false, "Don't show the session banner")
 	cmd.Flags().StringVar(&ccmd.TFACode, "tfaCode", "", "Two Factor Authentication code")
@@ -101,12 +106,21 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL, OAUTH2 (device flow) or BASIC. When set to BASIC, any existing token will be cleared")
 	cmd.Flags().StringVar(&ccmd.Mode, "mode", "", "Session mode which controls which commands are allowed, e.g. dev, qual or prod")
 	cmd.Flags().StringSliceVar(&ccmd.Secrets, "secrets", []string{}, "List of secrets to include as env variables when running an external command. Only valid with from-cmd")
+	cmd.Flags().StringVar(&ccmd.Host, "host", "", "Cumulocity host. Only used with the 'interactive' provider")
 
 	completion.WithOptions(
 		cmd,
 		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
 		completion.WithValidateSet("output-format", "json", "dotenv"),
-		completion.WithValidateSet("provider", config.ProviderTypeFile, config.ProviderTypeStdin, config.ProviderTypeEnv, config.ProviderTypeExternal, config.ProviderTypeAuto),
+		completion.WithValidateSet(
+			"provider",
+			config.ProviderTypeFile,
+			config.ProviderTypeStdin,
+			config.ProviderTypeEnv,
+			config.ProviderTypeExternal,
+			config.ProviderTypeAuto,
+			config.ProviderTypeInteractive,
+		),
 		completion.WithValidateSet("format", "json", "yaml", "toml", "dotenv"),
 		completion.WithValidateSet("loginType", c8y.LoginTypeOAuth2Internal, c8y.LoginTypeBasic, c8y.LoginTypeNone, c8y.LoginTypeOAuth2),
 		completion.WithValidateSet(
@@ -116,7 +130,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	)
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 
-	cmd.MarkFlagsMutuallyExclusive("from-file", "from-cmd", "from-stdin", "from-env")
+	cmd.MarkFlagsMutuallyExclusive("from-file", "from-cmd", "from-stdin", "from-env", "from-prompt")
 	cmd.MarkFlagsMutuallyExclusive("output-format", "shell")
 
 	return ccmd
@@ -168,6 +182,55 @@ func (n *CmdLogin) FromEnv() (*c8ysession.CumulocitySession, error) {
 		session.SessionUri = "env://host"
 	}
 
+	return session, nil
+}
+
+func (n *CmdLogin) FromInteractive(cmd *cobra.Command) (*c8ysession.CumulocitySession, error) {
+	// cfg, err := n.factory.Config()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	log, err := n.factory.Logger()
+	if err != nil {
+		return nil, err
+	}
+
+	prompter := prompt.NewPrompt(log)
+
+	session := &c8ysession.CumulocitySession{
+		Host: n.Host,
+		Mode: n.Mode,
+	}
+	if v, err := cmd.Root().PersistentFlags().GetString("sessionUsername"); err == nil {
+		session.Username = v
+	}
+	if v, err := cmd.Root().PersistentFlags().GetString("sessionPassword"); err == nil {
+		session.Password = v
+	}
+
+	if session.Host == "" {
+		v, err := prompter.Input("Enter host", "", true, false)
+		if err != nil {
+			return nil, err
+		}
+		session.Host = strings.TrimSpace(v)
+	}
+
+	if session.Mode == "" {
+		mode, err := prompt.Select("Select mode", []string{
+			"dev\tDevelopment mode (no restrictions)",
+			"qual\tQA mode (delete disabled)",
+			"prod\tProduction mode (read only)",
+		}, "dev\tDevelopment mode (no restrictions)")
+		if err != nil {
+			return nil, err
+		}
+		session.Mode = mode
+	}
+
+	if session.SessionUri == "" {
+		session.SessionUri = "interactive://host"
+	}
 	return session, nil
 }
 
@@ -359,7 +422,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if !oneHasChanged(cmd, "from-cmd", "from-file", "from-env", "from-stdin") {
+	if !oneHasChanged(cmd, "from-cmd", "from-file", "from-env", "from-stdin", "from-prompt") {
 
 		// Set defaults from config if values from flags aren't provided
 		if !cmd.Flags().Changed("provider") {
@@ -386,7 +449,9 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		//
 		// Try guessing a sensible default
 		//
-		if n.File != "" {
+		if n.Prompt {
+			n.Provider = config.ProviderTypeInteractive
+		} else if n.File != "" {
 			n.Provider = config.ProviderTypeFile
 		} else if n.Stdin {
 			n.Provider = config.ProviderTypeStdin
@@ -405,6 +470,8 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 	var session *c8ysession.CumulocitySession
 
 	switch strings.ToLower(n.Provider) {
+	case config.ProviderTypeInteractive:
+		session, err = n.FromInteractive(cmd)
 	case config.ProviderTypeExternal:
 		session, err = n.FromExternalProvider(args)
 	case config.ProviderTypeEnv:

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -100,7 +100,6 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().BoolVar(&ccmd.Env, "from-env", false, "Read from environment variables")
 	cmd.Flags().BoolVar(&ccmd.Stdin, "from-stdin", false, "Read from standard input")
 	cmd.Flags().BoolVar(&ccmd.Prompt, "from-prompt", false, "Read from user prompted input")
-	// cmd.Flags().BoolVar(&ccmd.Console, "from-console", false, "Read from user console")
 	cmd.Flags().BoolVar(&ccmd.NoBanner, "no-banner", false, "Don't show the session banner")
 	cmd.Flags().StringVar(&ccmd.TFACode, "tfaCode", "", "Two Factor Authentication code")
 	cmd.Flags().BoolVar(&ccmd.ClearToken, "clear", false, "Clear any existing tokens")
@@ -545,15 +544,15 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 		handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {})
 		handler.LoginType = loginType
-		handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
+		handler.SSO.DiscoveryURL = cfg.SSODiscoveryUrl()
 
 		if len(n.SSOScopes) > 0 {
-			handler.SSOScopes = strings.Split(n.SSOScopes, " ")
+			handler.SSO.Scopes = strings.Split(n.SSOScopes, " ")
 		} else {
-			handler.SSOScopes = cfg.SSOScopes()
+			handler.SSO.Scopes = cfg.SSOScopes()
 		}
 
-		handler.SSOAudience = n.SSOAudience
+		handler.SSO.Audience = n.SSOAudience
 
 		log.Infof("User preference for login type: %s", handler.LoginType)
 		handler.TFACode = session.TOTP

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -49,7 +49,8 @@ type CmdLogin struct {
 	Host string
 
 	// SSO options
-	SSOScopes string
+	SSOScopes   string
+	SSOAudience string
 
 	// Output options
 	Shell        string
@@ -111,6 +112,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().StringSliceVar(&ccmd.Secrets, "secrets", []string{}, "List of secrets to include as env variables when running an external command. Only valid with from-cmd")
 	cmd.Flags().StringVar(&ccmd.Host, "host", "", "Cumulocity host. Only used with the 'interactive' provider")
 	cmd.Flags().StringVar(&ccmd.SSOScopes, "sso-scopes", "", "SSO Scopes")
+	cmd.Flags().StringVar(&ccmd.SSOAudience, "sso-audience", "", "SSO Audience")
 
 	completion.WithOptions(
 		cmd,
@@ -550,6 +552,8 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		} else {
 			handler.SSOScopes = cfg.SSOScopes()
 		}
+
+		handler.SSOAudience = n.SSOAudience
 
 		log.Infof("User preference for login type: %s", handler.LoginType)
 		handler.TFACode = session.TOTP

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -463,6 +463,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 		handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {})
 		handler.LoginType = loginType
+		handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
 
 		log.Infof("User preference for login type: %s", handler.LoginType)
 		handler.TFACode = session.TOTP

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -275,7 +275,12 @@ func (n *CmdLogin) FromViper(v *viper.Viper) (*c8ysession.CumulocitySession, err
 		LoginType:  getValue("loginType"),
 		Version:    getValue("version"),
 	}
-	session.SetAuthorized(v.GetBool("authorized"))
+
+	// Get if value is defined before accessing it
+	if v.GetString("authorized") != "" {
+		session.SetAuthorized(v.GetBool("authorized"))
+	}
+
 	session.SetHost(getValue("host"))
 	return session, nil
 }
@@ -435,7 +440,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		client.SetToken(session.Token)
 	}
 
-	if session.Authorized == nil || !*session.Authorized {
+	if !session.IsAuthorized() {
 		loginType := strings.ToUpper(cfg.GetLoginTypeWithDefault())
 		if n.LoginType != "" {
 			loginType = strings.ToUpper(n.LoginType)

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -278,6 +278,10 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 		providerCommand = append(providerCommand, fmt.Sprintf("--loginType=%s", n.LoginType))
 	}
 
+	if cfg.Verbose() {
+		providerCommand = append(providerCommand, "-v")
+	}
+
 	providerCommand = append(providerCommand, args...)
 	cmd := exec.Command(providerCommand[0], providerCommand[1:]...)
 	cmd.Env = env
@@ -495,6 +499,12 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		cfg.Logger.Infof("Received session from external source:\n%s\n", sessionContents)
 	}
 
+	if session.SessionUri != "" {
+		cfg.SetSessionFile(session.SessionUri)
+	} else {
+		cfg.SetSessionFile(session.Path)
+	}
+
 	client := c8y.NewClient(nil, session.Host, session.Tenant, session.Username, session.Password, true)
 
 	if session.Token != "" {
@@ -550,6 +560,9 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		session.Username = handler.C8Yclient.Username
 		session.Host = handler.C8Yclient.BaseURL.Host
 
+		// Use the handler selected login type
+		session.LoginType = handler.LoginType
+
 		if client.Version != "" {
 			session.Version = client.Version
 		}
@@ -559,8 +572,6 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		}
 		session.Token = client.Token
 	}
-
-	session.Path = cfg.GetSessionFile()
 
 	if n.Mode != "" {
 		session.Mode = n.Mode
@@ -581,10 +592,6 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 	if canChangeActiveSession {
 		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is now active\n", cs.SuccessIcon())
-
-		if session.LoginType != "" {
-			fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is using %s\n", cs.SuccessIcon(), session.LoginType)
-		}
 	} else {
 		fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Session is not active (see previous warning)\n", cs.WarningIcon())
 	}

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -48,6 +48,9 @@ type CmdLogin struct {
 	Mode string
 	Host string
 
+	// SSO options
+	SSOScopes string
+
 	// Output options
 	Shell        string
 	OutputFormat string
@@ -107,6 +110,7 @@ func NewCmdLogin(f *cmdutil.Factory) *CmdLogin {
 	cmd.Flags().StringVar(&ccmd.Mode, "mode", "", "Session mode which controls which commands are allowed, e.g. dev, qual or prod")
 	cmd.Flags().StringSliceVar(&ccmd.Secrets, "secrets", []string{}, "List of secrets to include as env variables when running an external command. Only valid with from-cmd")
 	cmd.Flags().StringVar(&ccmd.Host, "host", "", "Cumulocity host. Only used with the 'interactive' provider")
+	cmd.Flags().StringVar(&ccmd.SSOScopes, "sso-scopes", "", "SSO Scopes")
 
 	completion.WithOptions(
 		cmd,
@@ -540,7 +544,12 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {})
 		handler.LoginType = loginType
 		handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
-		handler.SSOScopes = cfg.SSOScopes()
+
+		if len(n.SSOScopes) > 0 {
+			handler.SSOScopes = strings.Split(n.SSOScopes, " ")
+		} else {
+			handler.SSOScopes = cfg.SSOScopes()
+		}
 
 		log.Infof("User preference for login type: %s", handler.LoginType)
 		handler.TFACode = session.TOTP

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -458,7 +458,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		}
 
 		// SSO providers are in control of the token, so it should just be used as is
-		if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, session.Token) {
+		if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, session.Token, loginType) {
 			client.SetToken(session.Token)
 		} else {
 			client.ClearToken()

--- a/pkg/cmd/sessions/selectsession/selectsession.go
+++ b/pkg/cmd/sessions/selectsession/selectsession.go
@@ -141,16 +141,16 @@ func SelectSession(io *iostreams.IOStreams, cfg *config.Config, log *logger.Logg
 	}
 
 	templates := &promptui.SelectTemplates{
-		Active:   `▶ {{ printf "#%02d %4.4s" .Index .Extension | highlight }} {{ printf "%-30.29s" .Name | highlight }} {{ .Host | hide | highlight }} {{ printf "(%s/" .Tenant | hide | highlight }}{{ printf "%s)" .Username | hide | highlight }}`,
-		Inactive: `  {{ printf "#%02d %4.4s" .Index .Extension | faint }} {{ printf "%-30.29s" .Name | cyan }} {{ .Host | hide | magenta }} {{ printf "(%s/" .Tenant | hide | red }}{{ printf "%s)" .Username | hide | red }}`,
+		Active:   `▶ {{ printf "#%02d %4.4s" .Index .Extension | highlight }} {{ printf "%-30.29s" .Name | highlight }} {{ .Host | hide | highlight }} {{ printf "(%s" .Tenant | hide | highlight }}{{ if .Username }}{{ "/" | highlight }}{{ end }}{{ printf "%s)" .Username | hide | highlight }}`,
+		Inactive: `  {{ printf "#%02d %4.4s" .Index .Extension | faint }} {{ printf "%-30.29s" .Name | cyan }} {{ .Host | hide | magenta }} {{ printf "(%s" .Tenant | hide | red }}{{ if .Username }}{{ "/" | red }}{{ end }}{{ printf "%s)" .Username | hide | red }}`,
 		Selected: "{{ .Path | hideUser }}",
 		FuncMap:  funcMap,
 		Details: `
 --------- Details ----------
 {{ printf "%10s" "File:" | faint }}  {{ .Path | hideUser }}
 {{ printf "%10s" "Host:" | faint }}  {{ .Host | hide }}
-{{ printf "%10s" "Tenant:" | faint }}  {{ .Tenant | hide }}
-{{ printf "%10s" "Username:" | faint }}  {{ .Username | hide }}
+{{ if .Tenant }}{{ printf "%10s" "Tenant:" | faint }}  {{ .Tenant | hide }}{{ else }}{{ printf "%10s" "Tenant:" | faint }}  {{ "not set" | faint }}{{ end }}
+{{ if .Username }}{{ printf "%10s" "Username:" | faint }}  {{ .Username | hide }}{{ else }}{{ printf "%10s" "Username:" | faint }}  {{ "not set" | faint }}{{ end }}
 `,
 	}
 	templates.Help = `{{ "Use arrow keys (holding shift) to navigate" | faint }} {{ .NextKey | faint }} ` +

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -69,14 +69,14 @@ func NewCmdSet(f *cmdutil.Factory) *CmdSet {
 	cmd.Flags().StringVar(&ccmd.sessionFilter, "sessionFilter", "", "Filter to be applied to the list of sessions even before the values can be selected")
 	cmd.Flags().StringVar(&ccmd.TFACode, "tfaCode", "", "Two Factor Authentication code")
 	cmd.Flags().StringVar(&ccmd.Shell, "shell", defaultShell, "Shell type to return the environment variables")
-	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL or BASIC. When set to BASIC, any existing token will be cleared")
+	cmd.Flags().StringVar(&ccmd.LoginType, "loginType", "", "Login type preference, e.g. OAUTH2_INTERNAL, OAUTH2 (device flow) or BASIC. When set to BASIC, any existing token will be cleared")
 	cmd.Flags().BoolVar(&ccmd.NoBanner, "no-banner", false, "Don't show the session banner")
 	cmd.Flags().BoolVar(&ccmd.ClearToken, "clear", false, "Clear any existing tokens")
 
 	completion.WithOptions(
 		cmd,
 		completion.WithValidateSet("shell", shell.SupportedShells(shell.ShellAuto)...),
-		completion.WithValidateSet("loginType", c8y.AuthMethodOAuth2Internal, c8y.AuthMethodBasic, c8y.AuthMethodNone),
+		completion.WithValidateSet("loginType", c8y.LoginTypeOAuth2Internal, c8y.LoginTypeBasic, c8y.LoginTypeNone, c8y.LoginTypeOAuth2),
 	)
 	// Disable the encryption check, as the login handler will take care
 	// of checking the encryption
@@ -185,36 +185,41 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	n.factory.Config = func() (*config.Config, error) {
 		return cfg, nil
 	}
-	client, err := factory.CreateCumulocityClient(n.factory, "", "", "", true)()
-
-	if err != nil {
-		return err
-	}
 
 	if n.LoginType == "" {
 		n.LoginType = cfg.GetLoginTypeWithDefault()
 	} else {
-		if v, err := c8y.ParseAuthMethod(n.LoginType); err != nil {
-			n.LoginType = c8y.AuthMethodOAuth2Internal
+		if v, err := c8y.ParseLoginType(n.LoginType); err != nil {
+			log.Warnf("Could not parse auth method: value=%s", err)
 		} else {
 			n.LoginType = v
 		}
 	}
 
-	cfg.SetLoginType(n.LoginType)
-	client.AuthorizationMethod = n.LoginType
-
-	token := cfg.MustGetToken(true)
-	if !n.ClearToken && c8ysession.ShouldReuseToken(cfg, log, token) {
-		client.SetToken(token)
-	} else {
-		client.SetToken("")
+	if n.LoginType != "" {
+		cfg.SetLoginType(n.LoginType)
+	}
+	client, err := factory.CreateCumulocityClient(n.factory, "", "", "", true)()
+	if err != nil {
+		return err
 	}
 
-	if n.LoginType != c8y.AuthMethodNone {
+	if n.LoginType != c8y.LoginTypeNone {
 		if err := utilities.CheckEncryption(n.factory.IOStreams, cfg, client); err != nil {
 			return err
 		}
+	}
+
+	// Note: Decrypt after checking for encryption
+	token := cfg.MustGetToken(true)
+	if n.ClearToken {
+		client.ClearToken()
+		cfg.ClearToken()
+	} else if c8ysession.ShouldReuseToken(cfg, log, token) {
+		client.SetToken(token)
+	} else {
+		client.ClearToken()
+		cfg.ClearToken()
 	}
 
 	// If the password is not encrypted, then save it (which will apply the encryption)
@@ -225,11 +230,15 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	handler := c8ylogin.NewLoginHandler(client, cmd.ErrOrStderr(), func() {
+	handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {
 		n.onSave(client)
 	})
 	handler.LoginType = n.LoginType
-	log.Infof("User preference for login type: %s", handler.LoginType)
+	if handler.LoginType == "" {
+		log.Infof("User preference for login type: %s", "not-set")
+	} else {
+		log.Infof("User preference for login type: %s", handler.LoginType)
+	}
 
 	if n.TFACode == "" {
 		if code, err := cfg.GetTOTP(time.Now()); err == nil {
@@ -263,6 +272,8 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		Username:   handler.C8Yclient.Username,
 		Mode:       cfg.SessionMode(config.SessionModeUnset).String(),
 	}
+	// Don't trigger another login afterwards
+	session.SetAuthorized(true)
 
 	outputFormat := cfg.GetOutputFormatWithDefault(cmd, config.OutputUnknown).String()
 
@@ -293,6 +304,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Write session details to stdout (for machines)
+	cfg.Logger.Infof("c8y sessions set: isAuthorized: %v", session.IsAuthorized())
 	return c8ysession.WriteOutput(n.GetCommand().OutOrStdout(), client, cfg, session, outputFormat)
 }
 

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -234,8 +234,8 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		n.onSave(client)
 	})
 	handler.LoginType = n.LoginType
-	handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
-	handler.SSOScopes = cfg.SSOScopes()
+	handler.SSO.DiscoveryURL = cfg.SSODiscoveryUrl()
+	handler.SSO.Scopes = cfg.SSOScopes()
 	if handler.LoginType == "" {
 		log.Infof("User preference for login type: %s", "not-set")
 	} else {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -325,5 +325,9 @@ func hasChanged(client *c8y.Client, cfg *config.Config) bool {
 	if client.Password != "" && client.Password != cfg.MustGetPassword() && cfg.StorePassword() {
 		return true
 	}
+
+	if client.Username != "" && client.Username != cfg.GetUsername() {
+		return true
+	}
 	return false
 }

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -234,6 +234,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		n.onSave(client)
 	})
 	handler.LoginType = n.LoginType
+	handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
 	if handler.LoginType == "" {
 		log.Infof("User preference for login type: %s", "not-set")
 	} else {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -235,6 +235,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	})
 	handler.LoginType = n.LoginType
 	handler.SSODiscoveryURL = cfg.SSODiscoveryUrl()
+	handler.SSOScopes = cfg.SSOScopes()
 	if handler.LoginType == "" {
 		log.Infof("User preference for login type: %s", "not-set")
 	} else {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -215,7 +215,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	if n.ClearToken {
 		client.ClearToken()
 		cfg.ClearToken()
-	} else if c8ysession.ShouldReuseToken(cfg, log, token) {
+	} else if c8ysession.ShouldReuseToken(cfg, log, token, n.LoginType) {
 		client.SetToken(token)
 	} else {
 		client.ClearToken()
@@ -275,6 +275,9 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 	}
 	// Don't trigger another login afterwards
 	session.SetAuthorized(true)
+
+	// Store the chosen login type for display to the user
+	session.LoginType = handler.LoginType
 
 	outputFormat := cfg.GetOutputFormatWithDefault(cmd, config.OutputUnknown).String()
 

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -273,9 +273,10 @@ var updateSettingsOptions = map[string]argumentHandler{
 
 	// login type
 	"login.type": {"login.type", "string", config.SettingsLoginType, []string{
-		c8y.AuthMethodBasic + "\tBasic Auth (not recommended)",
-		c8y.AuthMethodOAuth2Internal + "\tInternal OAUTH2 (tokens)",
-		c8y.AuthMethodNone + "\tNone",
+		c8y.LoginTypeBasic + "\tBasic Auth (not recommended)",
+		c8y.LoginTypeOAuth2Internal + "\tInternal OAUTH2 (tokens)",
+		c8y.LoginTypeOAuth2 + "\tExternal OAUTH2 (tokens)",
+		c8y.LoginTypeNone + "\tNone",
 		"",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -93,8 +93,8 @@ var updateSettingsOptions = map[string]argumentHandler{
 	// "template.path":        {"template.path", "string", config.SettingsTemplatePath, []string{}, nil, cobra.ShellCompDirectiveFilterDirs},
 	"template.customPaths": {"template.customPaths", "string", config.SettingsTemplateCustomPaths, []string{}, nil, cobra.ShellCompDirectiveFilterDirs},
 
-	// views
-	"views.customPaths": {"views.customPaths", "string", config.SettingsViewsCustomPaths, []string{}, nil, cobra.ShellCompDirectiveFilterDirs},
+	// sso
+	"sso.discoveryUrl": {"sso.discoveryUrl", "string", config.SettingsSSODiscoveryUrl, []string{}, nil, cobra.ShellCompDirectiveNoFileComp},
 
 	// settings path
 	"settings.path": {"settings.path", "string", config.SettingsConfigPath, []string{"json"}, nil, cobra.ShellCompDirectiveFilterFileExt},

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -95,6 +95,7 @@ var updateSettingsOptions = map[string]argumentHandler{
 
 	// sso
 	"sso.discoveryUrl": {"sso.discoveryUrl", "string", config.SettingsSSODiscoveryUrl, []string{}, nil, cobra.ShellCompDirectiveNoFileComp},
+	"sso.scopes":       {"sso.scopes", "string", config.SettingsSSOScopes, []string{}, nil, cobra.ShellCompDirectiveNoFileComp},
 
 	// settings path
 	"settings.path": {"settings.path", "string", config.SettingsConfigPath, []string{"json"}, nil, cobra.ShellCompDirectiveFilterFileExt},

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -362,6 +362,9 @@ const (
 	// SettingsBrowser default browser
 	SettingsBrowser = "settings.browser"
 
+	// SettingsSSODiscoveryUrl Open ID Connect URL aka. Discovery URL
+	SettingsSSODiscoveryUrl = "settings.sso.discoveryUrl"
+
 	//
 	// Remote Access preferences
 	//
@@ -1450,6 +1453,11 @@ func (c *Config) GetTemplatePaths() []string {
 	paths = append(paths, c.GetPathSlice(SettingsTemplateCustomPaths)...)
 	paths = append(paths, c.GetPathSlice(SettingsTemplatePath)...)
 	return paths
+}
+
+// SSODiscoveryUrl SSO discovery URL (OpenID Connect Configuration URL)
+func (c *Config) SSODiscoveryUrl() string {
+	return c.viper.GetString(SettingsSSODiscoveryUrl)
 }
 
 // SetSessionMode set the session mode (it is not persisted)

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1021,6 +1021,11 @@ func (c *Config) GetCumulocityVersion() string {
 	return c.Persistent.GetString("version")
 }
 
+// SetUsername sets the username
+func (c *Config) SetUsername(v string) {
+	c.Persistent.Set("username", v)
+}
+
 // SetPassword sets the password
 func (c *Config) SetPassword(p string) {
 	c.Persistent.Set("password", p)
@@ -1867,6 +1872,10 @@ func (c *Config) SaveClientConfig(client *c8y.Client) error {
 
 		if client.Version != "" {
 			c.SetCumulocityVersion(client.Version)
+		}
+
+		if client.Username != "" {
+			c.SetUsername(client.Username)
 		}
 	}
 	return c.WritePersistentConfig()

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1471,7 +1471,23 @@ func (c *Config) SSODiscoveryUrl() string {
 
 // SSOScopes scopes to use in the device code request when using SSO
 func (c *Config) SSOScopes() []string {
-	return c.viper.GetStringSlice(SettingsSSOScopes)
+	// Be flexible with the format, accept either a "," or " " separator
+	// * "openid offline_access"
+	// * "openid,offline_access"
+	// * "openid,offline_access"
+	// * "openid, offline_access"
+	// * ["openid, "offline_access"]
+	// * ["openid,offline_access"]
+	rawValues := c.viper.GetStringSlice(SettingsSSOScopes)
+	values := make([]string, 0, len(rawValues))
+	for _, value := range rawValues {
+		for _, item := range strings.FieldsFunc(value, func(r rune) bool {
+			return r == ',' || r == ' '
+		}) {
+			values = append(values, strings.TrimSpace(item))
+		}
+	}
+	return values
 }
 
 // SetSessionMode set the session mode (it is not persisted)

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -62,11 +62,12 @@ const (
 )
 
 var (
-	ProviderTypeAuto     = "auto"
-	ProviderTypeFile     = "file"
-	ProviderTypeEnv      = "env"
-	ProviderTypeExternal = "external"
-	ProviderTypeStdin    = "stdin"
+	ProviderTypeAuto        = "auto"
+	ProviderTypeFile        = "file"
+	ProviderTypeEnv         = "env"
+	ProviderTypeExternal    = "external"
+	ProviderTypeStdin       = "stdin"
+	ProviderTypeInteractive = "interactive"
 )
 
 const (

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -848,9 +848,13 @@ func (c Config) DecryptAllProperties() (err error) {
 	return err
 }
 
+func GetEnvKey(key string) string {
+	return "C8Y_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+}
+
 // GetEnvKey returns the environment key value associated
 func (c Config) GetEnvKey(key string) string {
-	return "C8Y_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+	return GetEnvKey(key)
 }
 
 // HasEnvSettingsPrefix check if a given env variable name is a settings variable
@@ -949,7 +953,7 @@ func (c *Config) WritePersistentConfig() error {
 
 // GetPassword returns the decrypted password of the current session
 func (c *Config) GetPassword() (string, error) {
-	value := c.viper.GetString("password")
+	value := c.GetPasswordRaw()
 
 	if value == "" {
 		value = c.Persistent.GetString("password")
@@ -962,16 +966,25 @@ func (c *Config) GetPassword() (string, error) {
 	return decryptedValue, nil
 }
 
+func (c *Config) GetPasswordRaw() string {
+	return c.viper.GetString("password")
+}
+
 // IsPasswordEncrypted return true if the password is encrypted
 // If the password is empty then treat it as encrypted
-func (c *Config) IsPasswordEncrypted() bool {
-	password := c.viper.GetString("password")
-	// return password != "" && c.SecureData.IsEncrypted(password) == 1
+func (c *Config) IsPasswordEncrypted(ignoreEmptyValue ...bool) bool {
+	password := c.GetPasswordRaw()
+	if len(ignoreEmptyValue) > 0 && ignoreEmptyValue[0] {
+		return c.SecureData.IsEncrypted(password) == 1
+	}
 	return password == "" || c.SecureData.IsEncrypted(password) == 1
 }
 
-func (c *Config) IsTokenEncrypted() bool {
+func (c *Config) IsTokenEncrypted(ignoreEmptyValue ...bool) bool {
 	token := c.viper.GetString("token")
+	if len(ignoreEmptyValue) > 0 && ignoreEmptyValue[0] {
+		return c.SecureData.IsEncrypted(token) == 1
+	}
 	return token == "" || c.SecureData.IsEncrypted(token) == 1
 }
 
@@ -1013,6 +1026,12 @@ func (c *Config) SetPassword(p string) {
 // SetToken sets the token used for OAUTH authentication
 func (c *Config) SetToken(p string) {
 	c.Persistent.Set(SettingsToken, p)
+}
+
+// SetToken sets the token used for OAUTH authentication
+func (c *Config) ClearToken() {
+	c.viper.Set(SettingsToken, "")
+	c.Persistent.Set(SettingsToken, "")
 }
 
 // SetTenant sets the tenant name
@@ -1626,9 +1645,9 @@ func (c *Config) GetSilentExit() bool {
 }
 
 func ParseLoginTypeWithDefault(v string) string {
-	value, err := c8y.ParseAuthMethod(v)
+	value, err := c8y.ParseLoginType(v)
 	if err != nil {
-		value = c8y.AuthMethodOAuth2Internal
+		value = ""
 	}
 	return value
 }
@@ -1653,9 +1672,9 @@ func (c *Config) GetLoginTypeRaw() string {
 
 // SetLoginType sets the authorization method, e.g. BASIC, OAUTH2_INTERNAL, NONE
 func (c *Config) SetLoginType(v string) {
-	value, err := c8y.ParseAuthMethod(v)
+	value, err := c8y.ParseLoginType(v)
 	if err != nil {
-		value = c8y.AuthMethodOAuth2Internal
+		value = c8y.LoginTypeOAuth2Internal
 	}
 	c.Set(SettingsLoginType, value)
 }

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1692,19 +1692,13 @@ func ParseLoginTypeWithDefault(v string) string {
 
 // GetLoginTypeWithDefault get the preferred login type
 func (c *Config) GetLoginTypeWithDefault() string {
-	v := c.Persistent.GetString(SettingsLoginType)
-	if v == "" {
-		v = c.viper.GetString(SettingsLoginType)
-	}
+	v := c.viper.GetString(SettingsLoginType)
 	return ParseLoginTypeWithDefault(v)
 }
 
 // GetLoginTypeRaw get the raw value, where it could also be an empty value
 func (c *Config) GetLoginTypeRaw() string {
-	v := c.Persistent.GetString(SettingsLoginType)
-	if v == "" {
-		v = c.viper.GetString(SettingsLoginType)
-	}
+	v := c.viper.GetString(SettingsLoginType)
 	return strings.ToUpper(v)
 }
 

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -366,6 +366,9 @@ const (
 	// SettingsSSODiscoveryUrl Open ID Connect URL aka. Discovery URL
 	SettingsSSODiscoveryUrl = "settings.sso.discoveryUrl"
 
+	// SettingsSSOScopes SSO scopes used to request a device code
+	SettingsSSOScopes = "settings.sso.scopes"
+
 	//
 	// Remote Access preferences
 	//
@@ -1464,6 +1467,11 @@ func (c *Config) GetTemplatePaths() []string {
 // SSODiscoveryUrl SSO discovery URL (OpenID Connect Configuration URL)
 func (c *Config) SSODiscoveryUrl() string {
 	return c.viper.GetString(SettingsSSODiscoveryUrl)
+}
+
+// SSOScopes scopes to use in the device code request when using SSO
+func (c *Config) SSOScopes() []string {
+	return c.viper.GetStringSlice(SettingsSSOScopes)
 }
 
 // SetSessionMode set the session mode (it is not persisted)

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -2092,13 +2092,11 @@ func (c *Config) GetSessionFile(overrideSession ...string) string {
 // 1. load settings (from C8Y_SESSION_HOME path)
 // 2. load session file (by path)
 // 3. load session file (by name)
-func (c *Config) ReadConfigFiles(client *c8y.Client) (path string, err error) {
+func (c *Config) ReadConfigFiles(client *c8y.Client, ignoreSessionFile ...bool) (path string, err error) {
 	c.Logger.Debugf("Reading configuration files")
 	v := c.viper
 	v.AddConfigPath(".")
 	v.AddConfigPath(c.GetHomeDir())
-
-	sessionFile := c.GetSessionFile("")
 
 	// Load (non-session) preferences
 	v.SetConfigName(SettingsGlobalName)
@@ -2109,22 +2107,26 @@ func (c *Config) ReadConfigFiles(client *c8y.Client) (path string, err error) {
 	}
 
 	// Load session
-	if _, err := os.Stat(sessionFile); err == nil {
-		// Load config by file path
-		v.SetConfigFile(sessionFile)
+	if len(ignoreSessionFile) == 0 || !ignoreSessionFile[0] {
+		sessionFile := c.GetSessionFile("")
 
-		if err := c.ReadConfig(sessionFile); err != nil {
-			c.Logger.Warnf("Could not read global settings file. file=%s, err=%s", sessionFile, err)
-		}
-	} else {
-		// Load config by name
-		sessionName := "session"
-		if sessionFile != "" {
-			sessionName = sessionFile
-		}
+		if _, err := os.Stat(sessionFile); err == nil {
+			// Load config by file path
+			v.SetConfigFile(sessionFile)
 
-		if sessionName != "" {
-			v.SetConfigName(sessionName)
+			if err := c.ReadConfig(sessionFile); err != nil {
+				c.Logger.Warnf("Could not read global settings file. file=%s, err=%s", sessionFile, err)
+			}
+		} else {
+			// Load config by name
+			sessionName := "session"
+			if sessionFile != "" {
+				sessionName = sessionFile
+			}
+
+			if sessionName != "" {
+				v.SetConfigName(sessionName)
+			}
 		}
 	}
 

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -2126,7 +2126,9 @@ func (c *Config) HideSensitiveInformation(client *c8y.Client, message string) st
 		message = strings.ReplaceAll(message, client.Token, "{token}")
 	}
 	if client.BaseURL != nil {
-		message = strings.ReplaceAll(message, strings.TrimRight(client.BaseURL.Host, "/"), "{host}")
+		if host := client.BaseURL.Host; host != "" {
+			message = strings.ReplaceAll(message, strings.TrimRight(host, "/"), "{host}")
+		}
 	}
 
 	basicAuthMatcher := regexp.MustCompile(`(Basic)\s+[A-Za-z0-9=]+`)

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -10,6 +10,7 @@ type CommandSettings struct {
 	Template    *TemplateSettings      `json:"template,omitempty"`
 	View        *ViewSettings          `json:"views,omitempty"`
 	Login       *LoginSettings         `json:"login,omitempty"`
+	SSO         *SSOSettings           `json:"sso,omitempty"`
 	Defaults    map[string]interface{} `json:"defaults,omitempty"`
 }
 
@@ -25,6 +26,11 @@ type ActivityLogSettings struct {
 	Enabled      *bool  `json:"enabled,omitempty"`
 	MethodFilter string `json:"methodFilter,omitempty"`
 	Path         string `json:"path,omitempty"`
+}
+
+// SSOSettings SSO settings
+type SSOSettings struct {
+	DiscoveryURL string `json:"discoveryUrl,omitempty"`
 }
 
 // EncryptionSettings encryption settings

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -30,7 +30,9 @@ type ActivityLogSettings struct {
 
 // SSOSettings SSO settings
 type SSOSettings struct {
-	DiscoveryURL string `json:"discoveryUrl,omitempty"`
+	DiscoveryURL string   `json:"discoveryUrl,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	Audience     string   `json:"audience,omitempty"`
 }
 
 // EncryptionSettings encryption settings

--- a/pkg/requestiterator/requestiterator.go
+++ b/pkg/requestiterator/requestiterator.go
@@ -69,7 +69,7 @@ func (r *RequestIterator) GetNext() (*c8y.RequestOptions, interface{}, error) {
 		Accept:                 r.Request.Accept,
 		Header:                 r.Request.Header,
 		ResponseData:           r.Request.ResponseData,
-		NoAuthentication:       r.Request.NoAuthentication,
+		AuthFunc:               r.Request.AuthFunc,
 		IgnoreAccept:           r.Request.IgnoreAccept,
 		DryRun:                 r.Request.DryRun,
 		PrepareRequest:         r.Request.PrepareRequest,

--- a/pkg/testing/command/command.go
+++ b/pkg/testing/command/command.go
@@ -127,12 +127,13 @@ func WithEnv(t *testing.T, env map[string]string) ExecuteOptions {
 	}
 }
 
-// WithSensitiveLogging controls the hiding of sensitive information in the logs and dry run output
-func WithSensitiveLogging(t *testing.T, v bool) ExecuteOptions {
-	return func(cmd *root.CmdRoot) error {
-		key := config.GetEnvKey(config.SettingsLoggerHideSensitive)
+// WithSetting sets a configuration setting of a given key, and translates it to the equivalent environment variable
+// The env variable value is restored at the end of the test
+func WithSetting(t *testing.T, key string, value any) ExecuteOptions {
+	return func(cr *root.CmdRoot) error {
+		key := config.GetEnvKey(key)
 		originalValue, found := os.LookupEnv(key)
-		os.Setenv(key, fmt.Sprintf("%v", v))
+		os.Setenv(key, fmt.Sprintf("%v", value))
 		t.Cleanup(func() {
 			if found {
 				os.Setenv(key, originalValue)
@@ -142,6 +143,16 @@ func WithSensitiveLogging(t *testing.T, v bool) ExecuteOptions {
 		})
 		return nil
 	}
+}
+
+// WithSensitiveLogging controls the hiding of sensitive information in the logs and dry run output
+func WithSensitiveLogging(t *testing.T, v bool) ExecuteOptions {
+	return WithSetting(t, config.SettingsLoggerHideSensitive, v)
+}
+
+// WithSessionEncryption sets whether session data should be encrypted or not
+func WithSessionEncryption(t *testing.T, v bool) ExecuteOptions {
+	return WithSetting(t, config.SettingsEncryptionEnabled, v)
 }
 
 func WithOSStdIn(t *testing.T, v string) ExecuteOptions {

--- a/pkg/testing/command/command.go
+++ b/pkg/testing/command/command.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/root"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/fakestdin"
 )
 
@@ -119,6 +121,23 @@ func WithEnv(t *testing.T, env map[string]string) ExecuteOptions {
 				if k, v, ok := strings.Cut(item, "="); ok {
 					os.Setenv(k, v)
 				}
+			}
+		})
+		return nil
+	}
+}
+
+// WithSensitiveLogging controls the hiding of sensitive information in the logs and dry run output
+func WithSensitiveLogging(t *testing.T, v bool) ExecuteOptions {
+	return func(cmd *root.CmdRoot) error {
+		key := config.GetEnvKey(config.SettingsLoggerHideSensitive)
+		originalValue, found := os.LookupEnv(key)
+		os.Setenv(key, fmt.Sprintf("%v", v))
+		t.Cleanup(func() {
+			if found {
+				os.Setenv(key, originalValue)
+			} else {
+				os.Unsetenv(key)
 			}
 		})
 		return nil

--- a/pkg/testing/mocksession/mocksession.go
+++ b/pkg/testing/mocksession/mocksession.go
@@ -11,6 +11,15 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func getFirstNonEmptyEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 func CreateCumulocitySessionDir(t *testing.T, opts ...SessionFunc) string {
 	tmpDir, err := os.MkdirTemp("", "go-c8y-cli-sessionXXXXXX")
 	assert.Nil(t, err)
@@ -45,4 +54,12 @@ func ParseSession(path string) gjson.Result {
 		panic(err)
 	}
 	return gjson.ParseBytes(b)
+}
+
+func GetSessionEnvironmentVariables() map[string]string {
+	return map[string]string{
+		"C8Y_HOST":     os.Getenv("C8Y_HOST"),
+		"C8Y_USERNAME": getFirstNonEmptyEnv("C8Y_USER", "C8Y_USERNAME"),
+		"C8Y_PASSWORD": os.Getenv("C8Y_PASSWORD"),
+	}
 }

--- a/pkg/testing/mocksession/mocksession.go
+++ b/pkg/testing/mocksession/mocksession.go
@@ -1,12 +1,16 @@
 package mocksession
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ysession"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 )
@@ -58,8 +62,54 @@ func ParseSession(path string) gjson.Result {
 
 func GetSessionEnvironmentVariables() map[string]string {
 	return map[string]string{
-		"C8Y_HOST":     os.Getenv("C8Y_HOST"),
-		"C8Y_USERNAME": getFirstNonEmptyEnv("C8Y_USER", "C8Y_USERNAME"),
-		"C8Y_PASSWORD": os.Getenv("C8Y_PASSWORD"),
+		"C8Y_HOST":     getHost(),
+		"C8Y_USERNAME": getUsername(),
+		"C8Y_PASSWORD": getPassword(),
 	}
+}
+
+func getUsername() string {
+	return getFirstNonEmptyEnv("C8Y_USER", "C8Y_USERNAME")
+}
+
+func getHost() string {
+	return os.Getenv("C8Y_HOST")
+}
+
+func getPassword() string {
+	return os.Getenv("C8Y_PASSWORD")
+}
+
+func CreateSessionWithOAuth2Internal() (*c8ysession.CumulocitySession, error) {
+	client := c8y.NewClientFromOptions(nil, c8y.ClientOptions{
+		BaseURL:  getHost(),
+		Username: getUsername(),
+		Password: getPassword(),
+	})
+	loginOptions, _, err := client.Tenant.GetLoginOptions(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	initRequest := ""
+	for _, option := range loginOptions.LoginOptions {
+		if strings.EqualFold(option.Type, c8y.LoginTypeOAuth2Internal) {
+			initRequest = option.InitRequest
+			break
+		}
+	}
+	if initRequest == "" {
+		return nil, fmt.Errorf("tenant does not have the oauth2_internal login type enabled")
+	}
+
+	if err := client.LoginUsingOAuth2(context.Background(), initRequest); err != nil {
+		return nil, err
+	}
+
+	return &c8ysession.CumulocitySession{
+		Host:     client.BaseURL.String(),
+		Username: client.Username,
+		Password: client.Password,
+		Token:    client.Token,
+	}, nil
 }

--- a/pkg/utilities/utilities.go
+++ b/pkg/utilities/utilities.go
@@ -143,7 +143,7 @@ func CheckEncryption(IO *iostreams.IOStreams, cfg *config.Config, client *c8y.Cl
 		cfg.Logger.Infof("Encryption has been disabled but detected a encrypted session")
 		decryptSession = true
 	}
-	if encryptionEnabled || cfg.IsPasswordEncrypted() {
+	if encryptionEnabled || (cfg.IsPasswordEncrypted(true) || cfg.IsTokenEncrypted(true)) {
 		if err := cfg.ReadKeyFile(); err != nil {
 			return err
 		}

--- a/tools/schema/session.schema.json
+++ b/tools/schema/session.schema.json
@@ -50,6 +50,7 @@
                     "enum": [
                         "BASIC",
                         "OAUTH2_INTERNAL",
+                        "OAUTH2",
                         "NONE"
                     ]
                 }


### PR DESCRIPTION
Add initial support for external OAuth2 providers using the device authorization flow.

Setting up SSO requires a lot of configuration, and you need to have everything configured correctly on both sides (in Cumulocity and in your OAUTH2 Provider). But below is a rough checklist:

* You have an SSO provider, and the "Device Code" grant type is enabled
* Your SSO provider is configured and you've enabled the "external token configuration"
* You've tested that you can log into your tenant using SSO and a browser

If all of the above criteria is met, then you can specify that you wish to use OAUTH2 (device flow) by using the `--loginType OAUTH2` option when setting your session. The access token retrieved from the device flow will be stored encrypted in your session. You can use `--clear` to ignore any existing tokens (useful if you're just wanting to try out the device flow multiple times)

**Example**

```sh
set-session iot.lat
```

*Output*
```
✓ Passphrase OK

Logging in using the device flow (OAUTH2)

Press Enter to open https://dev-example.us.auth0.com/activate?user_code=CFSX-QHWC in your browser...
```

If you press enter, it will try to launch your web-browser, then following the login details (you may need to enter the code yourself if your SSO provider does not provide auto-filling via URL query parameters). After logging in, you can close the browser, then go back to your console:

```
✓ Session is now active
---------------------  Cumulocity Session  ---------------------

    source: file:///home/peter/.cumulocity/example.c8y.io-peter@gmail.com.json


mode         : dev (allowed commands: read, create, update, delete)
host         : example.c8y.io
tenant       : t12345
version      : 2025.198.0
username     : peter@gmail.com
loginType    : OAUTH2
```

### Testing from this PR

Note: The functionality is still be verified across the different SSO providers, however if you wish to check the functionality and provide feedback.

You will need to have golang >= 1.23 installed on your machine before using these instructions.

1. Install go-c8y-cli from this PR's branch (you may want to update the commit to that latest).

    ```sh
    go install github.com/reubenmiller/go-c8y-cli/v2/cmd/c8y@e7451d2feeac1f08c7ffd808321ae37e86e56692
    ```

2. Add the go binary path to your `PATH` environment variable, and refresh the binary hashes

    ```sh
    export PATH="$(go env GOPATH)/bin:$PATH"
    hash -r
    ```

3. Try using it (note tab completion won't work when using the `set-session` helper)

    ```sh
    # Option 1: Just using an explicit host (no session required)
    eval "$(c8y sessions login --from-prompt --host example.cumulocity.com)"
    ```

    To debug the output, you can add the `-v` flag