### PR TITLE
feat(remoteaccess): allow users to control the preferred authentication type

### DIFF
--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -64,6 +64,9 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 			$ c8y remoteaccess connect ssh --device 12345 --user admin
 			Start an interactive SSH session on the device with a given ssh user
 
+			$ c8y remoteaccess connect ssh --device 12345 --user admin --preferred-auth password
+			Start an interactive SSH session on the device with a given ssh user and force password authentication
+
 			$ c8y remoteaccess connect ssh --device 12345 --user admin -L 1883:127.0.0.1:1883
 			Start an interactive SSH session and configure port-forward by mapping the remote's 127.0.0.1:1883 to your machine's port 1883
 

--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -29,6 +29,7 @@ type CmdSSH struct {
 	user           string
 	configuration  string
 	portForwarding string
+	preferredAuth  string
 
 	*subcommand.SubCommand
 
@@ -86,12 +87,14 @@ func NewCmdSSH(f *cmdutil.Factory) *CmdSSH {
 	cmd.Flags().StringVar(&ccmd.listen, "listen", "127.0.0.1:0", "Listener address. unix:///run/example.sock")
 	cmd.Flags().StringVar(&ccmd.user, "user", "", "Default ssh user")
 	cmd.Flags().StringVar(&ccmd.configuration, "configuration", "", "Remote Access Configuration")
+	cmd.Flags().StringVar(&ccmd.preferredAuth, "preferred-auth", "", "Set the preferred authentication for the ssh connection. This will add '-o PreferredAuthentications=<value>' to the ssh command")
 	cmd.Flags().StringVarP(&ccmd.portForwarding, "port-forward", "L", "", "SSH Port-Forwarding option in the format [bind_address:]port:host:hostport. It also accepts a custom short form, <local>[:<remote>]. The value is passed to the ssh -L option, so read the ssh man page for more info")
 
 	completion.WithOptions(
 		cmd,
 		completion.WithDevice("device", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 		completion.WithRemoteAccessPassthroughConfiguration("configuration", "device", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithValidateSet("preferred-auth", "password", "publickey"),
 	)
 
 	flags.WithOptions(
@@ -203,6 +206,10 @@ func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 			"-o", "ServerAliveInterval=120",
 			"-o", "StrictHostKeyChecking=no",
 			"-o", "UserKnownHostsFile=/dev/null",
+		}
+
+		if n.preferredAuth != "" {
+			sshArgs = append(sshArgs, "-o", fmt.Sprintf("PreferredAuthentications=%s", n.preferredAuth))
 		}
 
 		sshTarget := host


### PR DESCRIPTION
Allow users to set the preffered ssh authentication method when using `c8y remoteaccess connect ssh`.

Useful if the device supports username/password authentication but you have a lot of ssh keys in your ssh-agent (on your machine), which would normally result in a `Too many authentication failures` on the ssh client when trying to connect.

**Example**

Prefer connecting to the device using password based authentication for the ssh connection.

```
c8y remoteaccess connect ssh --device 12345 --user admin --preferred-auth password
```