### PR TITLE
fix(csv): don't convert 0-1 integers to boolean

### DIFF
--- a/api/spec/json/userReferences.json
+++ b/api/spec/json/userReferences.json
@@ -37,7 +37,7 @@
             "command": "c8y userreferences addUserToGroup --group 1 --user peterpi@example.com",
             "assertStdOut": {
               "json": {
-                "body.user.self": "r//user/$C8Y_TENANT/users/peterpi@example.com$"
+                "body.user.self": "r//user/$C8Y_TENANT/users/peterpi%40example.com$"
               }
             }
           },

--- a/api/spec/yaml/userReferences.yaml
+++ b/api/spec/yaml/userReferences.yaml
@@ -31,7 +31,8 @@ commands:
           command: c8y userreferences addUserToGroup --group 1 --user peterpi@example.com
           assertStdOut:
             json:
-              body.user.self: r//user/$C8Y_TENANT/users/peterpi@example.com$
+              # Note: the responses are not url escaped
+              body.user.self: r//user/$C8Y_TENANT/users/peterpi%40example.com$
 
         - description: Add a list of users to admins group (using pipeline)
           command: c8y users list | c8y userreferences addUserToGroup --group admins

--- a/pkg/iterator/csv.go
+++ b/pkg/iterator/csv.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -58,6 +59,15 @@ func (i *CSVFileContentsIterator) SetColumns(total int) {
 	i.columns = columns
 }
 
+func parseBool(v string) (bool, error) {
+	if strings.EqualFold(v, "true") {
+		return true, nil
+	} else if strings.EqualFold(v, "false") {
+		return false, nil
+	}
+	return false, fmt.Errorf("value is not a boolean")
+}
+
 // GetNext returns the next line in the buffer
 func (i *CSVFileContentsIterator) GetNext() (line []byte, input interface{}, err error) {
 	i.mu.Lock()
@@ -77,7 +87,7 @@ func (i *CSVFileContentsIterator) GetNext() (line []byte, input interface{}, err
 	for j := len(i.columns) - 1; j >= 0; j-- {
 		if j > lastRecordIdx || records[j] == "null" {
 			i.row[i.columns[j]] = nil
-		} else if v, err := strconv.ParseBool(records[j]); err == nil {
+		} else if v, err := parseBool(records[j]); err == nil {
 			i.row[i.columns[j]] = v
 		} else if v, err := strconv.ParseFloat(records[j], 64); err == nil {
 			i.row[i.columns[j]] = v

--- a/tests/auto/userreferences/tests/userreferences_addUserToGroup.yaml
+++ b/tests/auto/userreferences/tests/userreferences_addUserToGroup.yaml
@@ -19,6 +19,6 @@ tests:
         exit-code: 0
         stdout:
             json:
-                body.user.self: r//user/$C8Y_TENANT/users/peterpi@example.com$
+                body.user.self: r//user/$C8Y_TENANT/users/peterpi%40example.com$
                 method: POST
                 path: /user/$C8Y_TENANT/groups/1/users

--- a/tests/manual/extensions/example/body_cumulocity_tests.yaml
+++ b/tests/manual/extensions/example/body_cumulocity_tests.yaml
@@ -202,7 +202,7 @@ tests:
       c8y kitchensink body_complex userself --user "peterpi@example.com"
     stdout:
       json:
-        body.user: r/^https://.*/user/$C8Y_TENANT/users/peterpi@example.com$
+        body.user: r/^https://.*/user/$C8Y_TENANT/users/peterpi%40example.com$
 
   lookup usergroup:
     command: |

--- a/tests/manual/userreferences/addUsersToGroup/userreferences_addUsersToGroup.yaml
+++ b/tests/manual/userreferences/addUsersToGroup/userreferences_addUsersToGroup.yaml
@@ -14,6 +14,6 @@ tests:
     exit-code: 0
     stdout:
       json:
-        body.user.self: r/https://.+/user/$C8Y_TENANT/users/peterpi@example.com
+        body.user.self: r/https://.+/user/$C8Y_TENANT/users/peterpi%40example.com
         method: POST
         pathEncoded: r//user/$C8Y_TENANT/groups/22222/users

--- a/tests/manual/util/repeatcsv/input_values.csv
+++ b/tests/manual/util/repeatcsv/input_values.csv
@@ -1,0 +1,4 @@
+time,state,active
+1000,0,true
+1000,1,false
+1000,2,other

--- a/tests/manual/util/repeatcsv/util_repeatcsv.yaml
+++ b/tests/manual/util/repeatcsv/util_repeatcsv.yaml
@@ -9,7 +9,7 @@ tests:
                 {"disabled":false,"other":null,"text":"hello \"world","threshold":12.123,"time":1000}
                 {"disabled":false,"other":null,"text":"hello world","threshold":12.123,"time":1000}
                 {"disabled":null,"other":null,"text":"hello world","threshold":null,"time":1000}
-                {"disabled":12.123,"other":null,"text":"hello world false","threshold":null,"time":true}
+                {"disabled":12.123,"other":null,"text":"hello world false","threshold":null,"time":1}
                 {"disabled":null,"other":null,"text":"hello world","threshold":null,"time":2}
                 {"disabled":12.123,"other":null,"text":"hello world false","threshold":null,"time":3}
     
@@ -19,7 +19,7 @@ tests:
         exit-code: 0
         stdout:
             exactly: |
-                {"disabled":12.123,"other":null,"text":"hello world false","threshold":null,"time":true}
+                {"disabled":12.123,"other":null,"text":"hello world false","threshold":null,"time":1}
                 {"disabled":null,"other":null,"text":"hello world","threshold":null,"time":2}
                 {"disabled":12.123,"other":null,"text":"hello world false","threshold":null,"time":3}
 
@@ -41,6 +41,16 @@ tests:
             exactly: |
                 {"disabled":false,"other":null,"text":"hello \"world","threshold":12.123,"time":1000}
                 {"disabled":false,"other":null,"text":"hello world","threshold":12.123,"time":1000}
+
+    It does not convert integers to boolean:
+        command: |
+            c8y util repeatcsv ./manual/util/repeatcsv/input_values.csv
+        exit-code: 0
+        stdout:
+            exactly: |
+                {"active":true,"state":0,"time":1000}
+                {"active":false,"state":1,"time":1000}
+                {"active":"other","state":2,"time":1000}
 
     It iterates over file contents randomly skipping lines:
         command: |


### PR DESCRIPTION
Fix a bug in the CSV parsing where an integer `1` or `0` was being converted to `true` and `false` due to the usage of [strconv.ParseBool](https://pkg.go.dev/strconv#ParseBool) instead of a simple true/false detection.