### PR TITLE
feat: extend jsonnet recurse functions to support user defined predicates and transform functions

### DIFF
--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -521,16 +521,32 @@ func evaluateJsonnet(imports string, snippets ...string) (string, error) {
 					has_(o[ks[0]], ks[1:]);
 			has_(o, std.split(f, '.')),
 		RecurseReplace(any, from, to)::
+			local apply_(maybeFunc, current) = if std.isFunction(maybeFunc) then maybeFunc(current) else maybeFunc;
+			local is_match_(maybeFunc, current) = if std.isFunction(maybeFunc) then maybeFunc(current) else maybeFunc == current;
 			local recurseReplace_(any, from, to) = (
 				{
-				object: function(x) { [k]: recurseReplace_(x[k], from, to) for k in std.objectFields(x) },
-				array: function(x) [recurseReplace_(e, from, to) for e in x],
-				string: function(x) std.native('ReplacePattern')(x, from, to),
-				#string: function(x) std.strReplace(x, from, to),
-				number: function(x) x,
-				boolean: function(x) x,
-				'function': function(x) x,
-				'null': function(x) x,
+					object: function(x) { [k]: recurseReplace_(x[k], from, to) for k in std.objectFields(x) },
+					array: function(x) [recurseReplace_(e, from, to) for e in x],
+					string: function(x) std.native('ReplacePattern')(x, from, to),
+					number: function(x) if is_match_(from, x) then apply_(to, x) else x,
+					boolean: function(x) if is_match_(from, x) then apply_(to, x) else x,
+					'function': function(x) if is_match_(from, x) then apply_(to, x) else x,
+					'null': function(x) if is_match_(from, x) then apply_(to, x) else x,
+				}[std.type(any)](any)
+			);
+			recurseReplace_(any, from, to),
+		Recurse(any, from, to)::
+			local apply_(maybeFunc, current) = if std.isFunction(maybeFunc) then maybeFunc(current) else maybeFunc;
+			local is_match_(maybeFunc, current) = if std.isFunction(maybeFunc) then maybeFunc(current) else maybeFunc == current;
+			local recurseReplace_(any, from, to) = (
+				{
+					object: function(x) { [k]: recurseReplace_(x[k], from, to) for k in std.objectFields(x) },
+					array: function(x) [recurseReplace_(e, from, to) for e in x],
+					string: function(x) if is_match_(from, x) then apply_(to, x) else x,
+					number: function(x) if is_match_(from, x) then apply_(to, x) else x,
+					boolean: function(x) if is_match_(from, x) then apply_(to, x) else x,
+					'function': function(x) if is_match_(from, x) then apply_(to, x) else x,
+					'null': function(x) if is_match_(from, x) then apply_(to, x) else x,
 				}[std.type(any)](any)
 			);
 			recurseReplace_(any, from, to),

--- a/tests/manual/template/template_replace.yml
+++ b/tests/manual/template/template_replace.yml
@@ -16,3 +16,53 @@ tests:
             }
           }
         }
+
+  RecurseReplace replaces null values:
+    command: |
+      c8y template execute --template '{"value":{"item":null}}' |
+        c8y template execute --template "_.RecurseReplace(input.value, null, 0)" -o json -c=false
+    stdout:
+      exactly: |
+        {
+          "value": {
+            "item": 0
+          }
+        }
+
+  RecurseReplace replaces boolean values:
+    command: |
+      c8y template execute --template '{"value":{"item":false}}' |
+        c8y template execute --template "_.RecurseReplace(input.value, false, true)" -o json -c=false
+    stdout:
+      exactly: |
+        {
+          "value": {
+            "item": true
+          }
+        }
+
+  Recurse object and replace values matching a function:
+    command: |
+      c8y template execute --template '{"value":{"item":false,"item2":2}}' |
+        c8y template execute --template "_.Recurse(input.value, std.isBoolean, function(x) if x == true then 1 else 0)" -o json -c=false
+    stdout:
+      exactly: |
+        {
+          "value": {
+            "item": 0,
+            "item2": 2
+          }
+        }
+
+  Recurse object and add 1 to all numbers:
+    command: |
+      c8y template execute --template '{"value":{"item":false,"item2":2}}' |
+        c8y template execute --template "_.Recurse(input.value, std.isNumber, function(x) x + 1)" -o json -c=false
+    stdout:
+      exactly: |
+        {
+          "value": {
+            "item": false,
+            "item2": 3
+          }
+        }


### PR DESCRIPTION
Add some advanced jsonnet helper function to apply a transform (or static value) to all fields which match a given predicate (or static value).

* New jsonnet function, `_.Recurse(obj, predicateFunc, transformFunc)`

**Example: Add 1 to each number field**

```sh
c8y template execute --template '{"value":{"item":false,"item2":2}}' |
        c8y template execute --template "_.Recurse(input.value, std.isNumber, function(x) x + 1)" -o json
```
