### PR TITLE
fix: respect legacy session mode in existing sessions

### DIFF
--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -105,6 +105,9 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Ensure session values from previously read configuration is not transferred
+	cfg.Set("settings.session.mode", nil)
+
 	canChangeActiveSession := true
 	// Warn users if they try to use this command directly
 	if n.factory.IOStreams != nil {
@@ -245,6 +248,13 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	mode := cfg.SessionMode(config.SessionModeUnset).String()
+	// Respect session mode using the legacy format (e.g. set via individual create,update,delete values)
+	if legacyMode, legacyValueExists := config.HasLegacySessionMode(cfg.Persistent); legacyValueExists {
+		mode = legacyMode.String()
+		cfg.Logger.Debugf("Detected legacy mode. mode=%s", mode)
+	}
+
 	if hasChanged(handler.C8Yclient, cfg) {
 		log.Infof("Saving tenant name")
 		n.onSave(handler.C8Yclient)
@@ -261,7 +271,7 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		Tenant:     cfg.GetTenant(),
 		Version:    cfg.GetCumulocityVersion(),
 		Username:   handler.C8Yclient.Username,
-		Mode:       cfg.SessionMode(config.SessionModeUnset).String(),
+		Mode:       mode,
 	}
 
 	outputFormat := cfg.GetOutputFormatWithDefault(cmd, config.OutputUnknown).String()

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1447,6 +1448,33 @@ func (c *Config) SessionMode(defaultMode ...SessionMode) SessionMode {
 	return mode.FromString(c.viper.GetString(SettingsMode), c.IsCIMode())
 }
 
+func HasLegacySessionMode(v *viper.Viper) (SessionMode, bool) {
+	// Prefer newer session value
+	if v.IsSet("settings.session.mode") {
+		return SessionModeUnset, false
+	}
+
+	// Check for legacy settings
+	if !(v.IsSet("settings.mode.enablecreate") || v.IsSet("settings.mode.enableupdate") || v.IsSet("settings.mode.enabledelete")) {
+		return SessionModeUnset, false
+	}
+
+	// Map legacy mode settings to session mode
+	enableCreate := v.GetBool("settings.mode.enablecreate")
+	enableUpdate := v.GetBool("settings.mode.enableupdate")
+	enableDelete := v.GetBool("settings.mode.enabledelete")
+
+	mode := SessionModeUnset
+	if !enableCreate && !enableUpdate && !enableDelete {
+		mode = SessionModeProduction
+	} else if enableCreate && enableUpdate && !enableDelete {
+		mode = SessionModeQual
+	} else if enableCreate && enableUpdate && enableDelete {
+		mode = SessionModeDev
+	}
+	return mode, true
+}
+
 // AllowModeCreate enables create (post) commands
 func (c *Config) AllowModeCreate() bool {
 	return c.SessionMode().CanCreate()
@@ -1824,6 +1852,18 @@ func (c *Config) GetOutputCommonOptions(cmd *cobra.Command) (CommonCommandOption
 // AllSettings get all the settings as a map
 func (c *Config) AllSettings() map[string]interface{} {
 	return c.viper.AllSettings()
+}
+
+// MarshalSettings marshals all of the settings into json for debugging purposes
+func (c *Config) MarshalSettings() ([]byte, error) {
+	values := map[string]any{}
+	if c.Persistent != nil {
+		values["all"] = c.viper.AllSettings()
+	}
+	if c.Persistent != nil {
+		values["persistent"] = c.Persistent.AllSettings()
+	}
+	return json.Marshal(values)
 }
 
 // SaveClientConfig save client settings to the session configuration


### PR DESCRIPTION
Fix support for reading the legacy session mode settings in case. After a change in the session mode data format, it resulted in existing session always being treated as a production session (as that is the default).

Below is the order of preference when detecting the session mode (the first non-empty value is chosen):

1. From user given value (e.g. `set-session --mode dev`)
2. From `settings.session.mode` in the session file
3. From `settings.mode.enable*` in the session file