### PR TITLE
fix: Installation on powershell 5.x on Windows

### DIFF
--- a/docs/go-c8y-cli/docs/installation.md
+++ b/docs/go-c8y-cli/docs/installation.md
@@ -54,14 +54,14 @@ The convenience script can be customized, for example you can choose how it is i
     <TabItem value="wget">
 
     ```bash
-    wget -qO - https://docs-easy-installer--goc8ycli.netlify.app/install.sh | sh -s -- --help
+    wget -qO - https://goc8ycli.netlify.app/install.sh | sh -s -- --help
     ```
 
     </TabItem>
     <TabItem value="curl">
 
     ```bash
-    curl -fsSL https://docs-easy-installer--goc8ycli.netlify.app/install.sh | sh -s -- --help
+    curl -fsSL https://goc8ycli.netlify.app/install.sh | sh -s -- --help
     ```
 
     </TabItem>
@@ -72,7 +72,7 @@ The convenience script can be customized, for example you can choose how it is i
 %%c8y%% can be installed using PowerShell using the following one-liner.
 
 ```bash
-. { Invoke-WebRequest https://docs-easy-installer--goc8ycli.netlify.app/install.ps1 } | Invoke-Expression; install-c8y
+. { Invoke-WebRequest https://goc8ycli.netlify.app/install.ps1 } | Invoke-Expression; install-c8y
 ```
 
 ### Alternative Installation Methods

--- a/pkg/cmd/cli/install/install.manual.go
+++ b/pkg/cmd/cli/install/install.manual.go
@@ -152,6 +152,17 @@ func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 	return summaryErr
 }
 
+func addExecutableBinaryToPowerShellPath(existingSnippet string) (string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return existingSnippet, err
+	}
+	exeDir := filepath.Dir(exePath)
+
+	snippet := fmt.Sprintf("$env:PATH += '%c%s'; ", filepath.ListSeparator, exeDir) + existingSnippet
+	return snippet, nil
+}
+
 func (n *CmdInstall) InstallProfile(shellType string) (bool, error) {
 	changed := false
 	cfg, err := n.factory.Config()
@@ -190,10 +201,18 @@ func (n *CmdInstall) InstallProfile(shellType string) (bool, error) {
 		profileSnippet = "c8y cli profile --shell fish | source"
 	case shell.ShellPowershell:
 		profilePath = "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
-		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
+		if snippet, err := addExecutableBinaryToPowerShellPath("c8y cli profile --shell powershell | Out-String | Invoke-Expression"); err == nil {
+			profileSnippet = snippet
+		} else {
+			cfg.Logger.Warnf("Failed to detect binary path. %s", err)
+		}
 	case shell.ShellPwsh:
 		profilePath = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
-		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
+		if snippet, err := addExecutableBinaryToPowerShellPath("c8y cli profile --shell powershell | Out-String | Invoke-Expression"); err == nil {
+			profileSnippet = snippet
+		} else {
+			cfg.Logger.Warnf("Failed to detect binary path. %s", err)
+		}
 	}
 
 	if profilePath == "" {

--- a/pkg/cmd/cli/install/install.manual.go
+++ b/pkg/cmd/cli/install/install.manual.go
@@ -188,7 +188,10 @@ func (n *CmdInstall) InstallProfile(shellType string) (bool, error) {
 	case shell.ShellFish:
 		profilePath = "~/.config/fish/config.fish"
 		profileSnippet = "c8y cli profile --shell fish | source"
-	case shell.ShellPowershell, shell.ShellPwsh:
+	case shell.ShellPowershell:
+		profilePath = "~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1"
+		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
+	case shell.ShellPwsh:
 		profilePath = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
 		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
 	}

--- a/pkg/cmd/cli/install/install.manual.go
+++ b/pkg/cmd/cli/install/install.manual.go
@@ -24,7 +24,7 @@ var ErrInstallFailed = errors.New("failed to install one or more profiles")
 var validShells = shell.SupportedShells()
 
 // Skip sh when installing all shells as it generally does not have a profile defined
-var defaultShells = []string{shell.ShellBash, shell.ShellFish, shell.ShellPowershell, shell.ShellZsh}
+var defaultShells = []string{shell.ShellBash, shell.ShellFish, shell.ShellPowershell, shell.ShellPwsh, shell.ShellZsh}
 
 type CmdInstall struct {
 	*subcommand.SubCommand
@@ -85,7 +85,8 @@ func (n *CmdInstall) RunE(cmd *cobra.Command, args []string) error {
 		shell.ShellBash:       {Name: "bash", Binary: "bash"},
 		shell.ShellZsh:        {Name: "zsh", Binary: "zsh"},
 		shell.ShellPosixShell: {Name: "sh", Binary: "sh"},
-		shell.ShellPowershell: {Name: "powershell", Binary: "pwsh"},
+		shell.ShellPwsh:       {Name: "pwsh", Binary: "pwsh"},
+		shell.ShellPowershell: {Name: "powershell", Binary: "powershell"},
 		shell.ShellFish:       {Name: "fish", Binary: "fish"},
 	}
 
@@ -187,7 +188,7 @@ func (n *CmdInstall) InstallProfile(shellType string) (bool, error) {
 	case shell.ShellFish:
 		profilePath = "~/.config/fish/config.fish"
 		profileSnippet = "c8y cli profile --shell fish | source"
-	case shell.ShellPowershell:
+	case shell.ShellPowershell, shell.ShellPwsh:
 		profilePath = "~/.config/powershell/Microsoft.PowerShell_profile.ps1"
 		profileSnippet = "c8y cli profile --shell powershell | Out-String | Invoke-Expression"
 	}

--- a/pkg/cmd/cli/profile/profile.manual.go
+++ b/pkg/cmd/cli/profile/profile.manual.go
@@ -113,7 +113,7 @@ func (n *CmdProfile) RunE(cmd *cobra.Command, args []string) error {
 		script = &scriptPosixShell
 	case shell.ShellFish:
 		script = &scriptFish
-	case shell.ShellPowershell:
+	case shell.ShellPowershell, shell.ShellPwsh:
 		script = &scriptPowerShell
 	}
 

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -92,7 +92,7 @@ func NewCmdCompletion() *CmdCompletion {
 				err = cmd.Root().GenZshCompletion(os.Stdout)
 			case shell.ShellFish:
 				err = cmd.Root().GenFishCompletion(os.Stdout, true)
-			case shell.ShellPowershell:
+			case shell.ShellPowershell, shell.ShellPwsh:
 				err = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
 			case shell.ShellPosixShell:
 				err = fmt.Errorf("posix shell (sh) does not support tab completion")

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -27,6 +27,7 @@ var (
 	ShellBash       = "bash"
 	ShellZsh        = "zsh"
 	ShellPowershell = "powershell"
+	ShellPwsh       = "pwsh"
 	ShellPosixShell = "sh"
 	ShellAuto       = "auto"
 )
@@ -42,7 +43,7 @@ func SupportedShells(additional ...string) []string {
 }
 
 func SupportTabCompletionShells(additional ...string) []string {
-	values := []string{ShellFish, ShellBash, ShellZsh, ShellPowershell}
+	values := []string{ShellFish, ShellBash, ShellZsh, ShellPowershell, ShellPwsh}
 	for _, v := range additional {
 		if !slices.Contains(values, v) {
 			values = append(values, v)


### PR DESCRIPTION
Fix handling of the installation of go-c8y-cli on Windows where only the older powershell 5.x is available.

The `c8y cli install` will also now add the modification of the `$env:PATH` variable to also include directory where the binary is located to ensure that it is executable without providing the relative or full path.