### PR TITLE
fix(general): don't print set-session on 403 http status codes

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -178,7 +178,7 @@ func CheckCommandError(cmd *cobra.Command, f *cmdutil.Factory, err error) error 
 	}
 
 	if cErr, ok := err.(cmderrors.CommandError); ok {
-		if cErr.StatusCode == 403 || cErr.StatusCode == 401 {
+		if cErr.StatusCode == 401 {
 			logg.Error(fmt.Sprintf("Authentication failed (statusCode=%d). Try to run set-session again, or check the password", cErr.StatusCode))
 		}
 

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -490,7 +490,7 @@ func (f *Factory) CheckPostCommandError(err error) error {
 	printLogEntries := !cfg.ShowProgress()
 
 	if cErr, ok := err.(cmderrors.CommandError); ok {
-		if cErr.StatusCode == 403 || cErr.StatusCode == 401 {
+		if cErr.StatusCode == 401 {
 			logg.Error(fmt.Sprintf("Authentication failed (statusCode=%d). Try to run set-session again, or check the password", cErr.StatusCode))
 		}
 


### PR DESCRIPTION
Fix an error where a go-c8y-cli user message prompting the user to set their session again when receiving a HTTP 403 status code from Cumulocity. 403 status codes generally indicate a permission denied, and reactivating a session would most likely not have any effect (except for if a user

**Before**

Below shows an example of a command which if the user does not have the correct permissions in the tenant, will return a 403 error, and an incorrect hint is presented to the user to tell them to reactivate a session.

```sh
$ c8y features tenants enable --key certificate-authority --tenant t12345

2025-09-17T15:18:07.943+0200    ERROR    Authentication failed (statusCode=403). Try to run set-session again, or check the password
2025-09-17T15:18:07.943+0200    ERROR    serverError: Access is denied PUT https://example.cumulocity.com/features/certificate-authority/by-tenant/t12345: 403 security/Forbidden Access is denied

Error Response

{
  "error": "security/Forbidden",
  "info": "https://cumulocity.com/api/core/",
  "message": "Access is denied"
}

2025-09-17T15:18:07.943+0200    ERROR    Authentication failed (statusCode=403). Try to run set-session again, or check the password
```

**After**

```sh
$ c8y features tenants enable --key certificate-authority --tenant t12345

2025-09-17T15:51:08.063+0200    ERROR   serverError: Access is denied PUT https://example.cumulocity.com/features/certificate-authority/by-tenant/t12345: 403 security/Forbidden Access is denied

Error Response

{
  "error": "security/Forbidden",
  "info": "https://cumulocity.com/api/core/",
  "message": "Access is denied"
}
```
