### PR TITLE
fix(create-vnc): change default vnc configuration name to webvnc

### DIFF
--- a/pkg/cmd/remoteaccess/configurations/create_vnc/createVnc.auto.go
+++ b/pkg/cmd/remoteaccess/configurations/create_vnc/createVnc.auto.go
@@ -51,7 +51,7 @@ Create a VNC configuration that requires a password
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("device", []string{""}, "Device (accepts pipeline)")
-	cmd.Flags().String("name", "webssh", "Connection name")
+	cmd.Flags().String("name", "webvnc", "Connection name")
 	cmd.Flags().String("hostname", "127.0.0.1", "Hostname")
 	cmd.Flags().Int("port", 5900, "Port")
 	cmd.Flags().String("password", "", "VNC Password")


### PR DESCRIPTION
Change the default name used when creating a Cloud Remote Access configuration entry for vnc to "webvnc".