### PR TITLE
fix(device enrollment): avoid using dot in the one-time password generation

### DIFF
--- a/pkg/cmd/devices/enroll/enroll.manual.go
+++ b/pkg/cmd/devices/enroll/enroll.manual.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"os"
 	"time"
@@ -223,7 +224,8 @@ func (n *DeviceEnrollCmd) RunE(cmd *cobra.Command, args []string) error {
 
 		if oneTimePassword == "" {
 			if v, err := c8yclient.DeviceEnrollment.GenerateOneTimePassword(); err == nil {
-				oneTimePassword = v
+				// URL's with "." may not be clickable on some consoles so avoid it
+				oneTimePassword = strings.ReplaceAll(v, ".", "_")
 			}
 		}
 


### PR DESCRIPTION
In some terminals, a dot (".") won't be recognized as part of the URL, so when the user clicks on it, the dot will be left out, resulting in a mismatch between the client and what is registered on the server