### PR TITLE
feat(outputFileRaw): support referencing id, name and owner info

### DIFF
--- a/docs/go-c8y-cli/docs/concepts/common-parameters.md
+++ b/docs/go-c8y-cli/docs/concepts/common-parameters.md
@@ -790,7 +790,19 @@ Save raw response to file
 
 The raw response (as returned by Cumulocity) can also be written to file in addition to displaying it on the console.
 
-No view logic or select statements on the response will be applied. This can be useful if you want to tee the output
+No view logic or select statements on the response will be applied. This can be useful if you want to tee the output.
+
+This flag will also expand the following variables if they are referenced:
+
+* `{filename}` - Filename found in the Content-Disposition response header
+* `{id}` - An id like value found in the request path (/inventory/binaries/12345 => 12345)
+* `{basename}` - The last path section of the request path (/some/nested/url/withafilename.json => withafilename.json)
+
+For JSON payloads the following additional fields are also available:
+
+* `{name}` - Object name (e.g. `.name`)
+* `{type}` - Object type (e.g. `.type`)
+* `{owner}` - Object owner (e.g. `.owner`)
 
 <CodeExample>
 
@@ -799,6 +811,9 @@ c8y alarms list -p 1 --outputFileRaw test.json
 
 # Or if you don't want any console output, just use redirection, but be sure to use raw!
 c8y alarms list -p 1 --raw > test.json
+
+# Save inventory items in individual files and use the managed object's type and name in the filename.
+c8y inventory list -p 2 | c8y inventory get --outputFileRaw "{type}__{name}.json"
 ```
 
 </CodeExample>

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -798,7 +798,12 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 		if resp.StatusCode() != 0 {
 			// check if it is a dummy response (i.e. no status code)
 			newline := strings.Contains(strings.ToLower(resp.Response.Header.Get("Content-Type")), "json")
-			fullFilePath, err := r.saveResponseToFile(resp, commonOptions.OutputFileRaw, false, newline)
+			fields := make(map[string]string)
+			// Only works if it is json, otherwise these values will be empty
+			fields["name"] = resp.JSON("name").String()
+			fields["type"] = resp.JSON("type").String()
+			fields["owner"] = resp.JSON("owner").String()
+			fullFilePath, err := r.saveResponseToFile(resp, commonOptions.OutputFileRaw, false, newline, fields)
 
 			if err != nil {
 				return 0, cmderrors.NewSystemError("write to file failed", err)
@@ -1068,7 +1073,7 @@ func (r *RequestHandler) guessDataProperty(resp *c8y.Response) string {
 // @filename	filename
 // @directory	output directory. If empty, then a temp directory will be used
 // if filename
-func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string, append bool, newline bool) (string, error) {
+func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string, append bool, newline bool, fields map[string]string) (string, error) {
 
 	// Support simple variable substitution to be able to set the output file name dynamically to download a collection of files
 	if strings.Contains(filename, "{") && strings.Contains(filename, "}") {
@@ -1100,6 +1105,15 @@ func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string,
 				}
 			} else {
 				r.Logger.Infof("Request is nill")
+			}
+		}
+
+		// Replace any additional fields
+		for k, v := range fields {
+			fieldName := fmt.Sprintf("{%s}", k)
+			if strings.Contains(filename, fieldName) {
+				r.Logger.Debugf("Replacing %s with %s", fieldName, v)
+				filename = strings.ReplaceAll(filename, fieldName, v)
 			}
 		}
 	}


### PR DESCRIPTION
Support the following additional template values that can be referenced in the `--outputFileRaw` flag.

* `{name}` - Object name (e.g. `.name`)
* `{type}` - Object type (e.g. `.type`)
* `{owner}` - Object owner (e.g. `.owner`)

**Examples**

```sh
# Get a list of devices and then save each managed object to different files and include the managed object name in the filename
c8y devices list | c8y inventory get --outputFile "example/backup__{name}.json" --workers 5
```