### PR TITLE
fix: encode values used within a URL path

### DIFF
--- a/pkg/cmd/alarms/subscribe/subscribe.manual.go
+++ b/pkg/cmd/alarms/subscribe/subscribe.manual.go
@@ -90,7 +90,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{device}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/devices/assert/factory/factory.manual.go
+++ b/pkg/cmd/devices/assert/factory/factory.manual.go
@@ -75,7 +75,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 
 		// path parameters
 		path := flags.NewStringTemplate("{id}")
-		err = flags.WithPathParameters(
+		err = flags.WithParameters(
 			cmd,
 			path,
 			inputIterators,
@@ -185,7 +185,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 
 		// path parameters
 		path := flags.NewStringTemplate("{device}")
-		err = flags.WithPathParameters(
+		err = flags.WithParameters(
 			cmd,
 			path,
 			inputIterators,

--- a/pkg/cmd/events/subscribe/subscribe.manual.go
+++ b/pkg/cmd/events/subscribe/subscribe.manual.go
@@ -90,7 +90,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{device}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/firmware/patches/create/create.manual.go
+++ b/pkg/cmd/firmware/patches/create/create.manual.go
@@ -161,7 +161,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{firmware}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/firmware/versions/create/create.manual.go
+++ b/pkg/cmd/firmware/versions/create/create.manual.go
@@ -154,7 +154,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{firmware}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/inventory/assert/factory/factory.manual.go
+++ b/pkg/cmd/inventory/assert/factory/factory.manual.go
@@ -74,7 +74,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 
 		// path parameters
 		path := flags.NewStringTemplate("{id}")
-		err = flags.WithPathParameters(
+		err = flags.WithParameters(
 			cmd,
 			path,
 			inputIterators,
@@ -194,7 +194,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 
 		// path parameters
 		path := flags.NewStringTemplate("{device}")
-		err = flags.WithPathParameters(
+		err = flags.WithParameters(
 			cmd,
 			path,
 			inputIterators,

--- a/pkg/cmd/inventory/subscribe/subscribe.manual.go
+++ b/pkg/cmd/inventory/subscribe/subscribe.manual.go
@@ -88,7 +88,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{device}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/inventory/wait/wait.manual.go
+++ b/pkg/cmd/inventory/wait/wait.manual.go
@@ -98,7 +98,7 @@ func (n *CmdWait) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{id}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/measurements/subscribe/subscribe.manual.go
+++ b/pkg/cmd/measurements/subscribe/subscribe.manual.go
@@ -90,7 +90,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{device}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/microservices/serviceuser/get/get.manual.go
+++ b/pkg/cmd/microservices/serviceuser/get/get.manual.go
@@ -85,7 +85,7 @@ func (n *CmdGet) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{id}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/operations/subscribe/subscribe.manual.go
+++ b/pkg/cmd/operations/subscribe/subscribe.manual.go
@@ -88,7 +88,7 @@ func (n *CmdSubscribe) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{device}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/operations/wait/wait.manual.go
+++ b/pkg/cmd/operations/wait/wait.manual.go
@@ -90,7 +90,7 @@ func (n *CmdWait) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{id}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/realtime/subscribeall/subscribeall.manual.go
+++ b/pkg/cmd/realtime/subscribeall/subscribeall.manual.go
@@ -82,7 +82,7 @@ func (n *CmdSubscribeAll) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{device}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmd/software/versions/create/create.manual.go
+++ b/pkg/cmd/software/versions/create/create.manual.go
@@ -154,7 +154,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 
 	// path parameters
 	path := flags.NewStringTemplate("{software}")
-	err = flags.WithPathParameters(
+	err = flags.WithParameters(
 		cmd,
 		path,
 		inputIterators,

--- a/pkg/cmdutil/factory_test.go
+++ b/pkg/cmdutil/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/mapbuilder"
+	testify_assert "github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
 )
 
@@ -139,4 +140,46 @@ func Test_QueryParameters(t *testing.T) {
 	assert.True(t, queryValue.Get("editable") == "true")
 	assert.True(t, queryValue.Get("type") == "myType")
 	assert.True(t, queryValue.Get("typeMapping") == "text/myType")
+}
+
+func Test_PathEscaping(t *testing.T) {
+	cmd := buildDummyCommand()
+
+	cmd.Flags().String("category", "", "String type")
+	cmd.Flags().String("name", "", "String type")
+
+	cases := []struct {
+		Args     []string
+		Expected string
+	}{
+		{
+			Args:     []string{"--category", "foo#bar", "--name", "bar"},
+			Expected: "foo%23bar/bar",
+		},
+		{
+			Args:     []string{"--category", "foo%23bar", "--name", "bar"},
+			Expected: "foo%23bar/bar",
+		},
+	}
+
+	for _, testcase := range cases {
+		cmd.SetArgs(testcase.Args)
+		cmdErr := cmd.Execute()
+		testify_assert.NoError(t, cmdErr)
+
+		inputIterators, _ := NewRequestInputIterators(cmd, nil)
+		path := flags.NewStringTemplate("{category}/{name}")
+		err := flags.WithPathParameters(
+			cmd,
+			path,
+			inputIterators,
+			flags.WithStringValue("category"),
+			flags.WithStringValue("name"),
+		)
+		testify_assert.NoError(t, err)
+
+		pathValue, _, err := path.Execute(false)
+		testify_assert.NoError(t, err)
+		testify_assert.Equal(t, testcase.Expected, pathValue)
+	}
 }

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -96,7 +96,56 @@ func WithPathParameters(cmd *cobra.Command, path *StringTemplate, inputIterators
 			switch v := value.(type) {
 			case []string:
 				if len(v) > 0 {
-					path.SetVariable(name, url.EscapeQueryString(strings.Join(v, ",")))
+					path.SetVariable(name, url.PathEscape(strings.Join(v, ",")))
+				}
+
+			case []int:
+				if len(v) > 0 {
+					path.SetVariable(name, strings.Trim(strings.Join(strings.Fields(fmt.Sprint(v)), ","), "[]"))
+				}
+
+			case iterator.Iterator:
+				v1 := iterator.NewStringIterator(v, func(s string) string {
+					return url.PathEscape(s)
+				})
+				path.SetVariable(name, v1)
+				if v1.IsBound() {
+					totalIterators++
+				}
+
+			default:
+				strValue := fmt.Sprintf("%v", value)
+				if strValue != "" {
+					path.SetVariable(name, url.PathEscape(strValue))
+				}
+			}
+		}
+	}
+
+	if err := path.CheckRequired(); err != nil {
+		return err
+	}
+
+	if totalIterators > 0 {
+		inputIterators.Total += totalIterators
+		inputIterators.Path = path
+	}
+	return
+}
+
+// WithParameters returns a string from command line arguments
+func WithParameters(cmd *cobra.Command, path *StringTemplate, inputIterators *RequestInputIterators, opts ...GetOption) (err error) {
+	totalIterators := 0
+	for _, opt := range opts {
+		name, value, err := opt(cmd, inputIterators)
+		if err != nil {
+			return err
+		}
+		if name != "" {
+			switch v := value.(type) {
+			case []string:
+				if len(v) > 0 {
+					path.SetVariable(name, strings.Join(v, ","))
 				}
 
 			case []int:
@@ -113,7 +162,7 @@ func WithPathParameters(cmd *cobra.Command, path *StringTemplate, inputIterators
 			default:
 				strValue := fmt.Sprintf("%v", value)
 				if strValue != "" {
-					path.SetVariable(name, url.EscapeQueryString(strValue))
+					path.SetVariable(name, strValue)
 				}
 			}
 		}

--- a/pkg/iterator/string_iterator.go
+++ b/pkg/iterator/string_iterator.go
@@ -1,0 +1,37 @@
+package iterator
+
+// NewStringIterator create a new string iterator built from an already existing iterator
+func NewStringIterator(iterator Iterator, formatter func(string) string) *StringIterator {
+	return &StringIterator{
+		iterator: iterator,
+		function: formatter,
+	}
+}
+
+type StringIterator struct {
+	function func(string) string
+	iterator Iterator
+}
+
+// GetNext will count through the values and return them one by one
+func (i *StringIterator) GetNext() (line []byte, input interface{}, err error) {
+
+	nextValue, input, err := i.iterator.GetNext()
+
+	if err != nil {
+		return line, input, err
+	}
+
+	out := i.function(string(nextValue))
+	return []byte(out), input, nil
+}
+
+// IsBound return true if the iterator is bound
+func (i *StringIterator) IsBound() bool {
+	return i.iterator.IsBound()
+}
+
+func (i *StringIterator) GetValueByInput(input []byte) (line []byte, err error) {
+	out := i.function(string(input))
+	return []byte(out), nil
+}

--- a/pkg/requestiterator/requestiterator.go
+++ b/pkg/requestiterator/requestiterator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/logger"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/mapbuilder"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/request"
+	pkgurl "github.com/reubenmiller/go-c8y-cli/v2/pkg/url"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 )
 
@@ -103,7 +104,7 @@ func (r *RequestIterator) GetNext() (*c8y.RequestOptions, interface{}, error) {
 		}
 
 		inputLine = input
-		req.Path = string(path)
+		req.Path = pkgurl.PathEscapePreserveQueryParameters(string(path))
 
 		if u, err := parseUrl(req.Path); err == nil {
 			if u.Host != "" {
@@ -111,7 +112,7 @@ func (r *RequestIterator) GetNext() (*c8y.RequestOptions, interface{}, error) {
 				// TODO: Check if this will break anything else
 				req.Host = u.Scheme + "://" + u.Host
 			}
-			req.Path = u.Path
+			req.Path = pkgurl.PathEscapePreserveQueryParameters(u.Path)
 			if u.RawQuery != "" {
 				queryParts = append(queryParts, u.RawQuery)
 			}

--- a/pkg/requestiterator/requestiterator_test.go
+++ b/pkg/requestiterator/requestiterator_test.go
@@ -34,3 +34,28 @@ func Test_RequestIteratorWithBodyIterator(t *testing.T) {
 	assert.True(t, req.Path == "root/subpath")
 	assert.EqualMarshalJSON(t, req.Body, `{"nested":{"value":"2"}}`)
 }
+
+func Test_RequestIteratorWithEscapedPathVariables(t *testing.T) {
+	var err error
+	pathIter := iterator.NewRepeatIterator("foo#bar/sub#other", 0)
+	valueIter := iterator.NewSliceIterator([]string{"1", "2"})
+	body := mapbuilder.NewInitializedMapBuilder(true)
+	err = body.Set("nested.value", valueIter)
+	assert.OK(t, err)
+	options := &c8y.RequestOptions{
+		Body: body,
+	}
+	requestIter := NewRequestIterator(nil, *options, pathIter, nil, body)
+
+	var req *c8y.RequestOptions
+
+	req, _, err = requestIter.GetNext()
+	assert.OK(t, err)
+	assert.True(t, req.Path == "foo#bar/sub#other")
+	assert.EqualMarshalJSON(t, req.Body, `{"nested":{"value":"1"}}`)
+
+	req, _, err = requestIter.GetNext()
+	assert.OK(t, err)
+	assert.True(t, req.Path == "foo#bar/sub#other")
+	assert.EqualMarshalJSON(t, req.Body, `{"nested":{"value":"2"}}`)
+}

--- a/pkg/url/encode.go
+++ b/pkg/url/encode.go
@@ -1,6 +1,7 @@
 package url
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -24,4 +25,31 @@ func EscapeQueryString(v string) string {
 	v = strings.ReplaceAll(v, "%3A", ":")
 	v = strings.ReplaceAll(v, "+", "%2B")
 	return v
+}
+
+func PathEscape(v string) string {
+	raw, err := url.PathUnescape(v)
+	if err == nil {
+		return url.PathEscape(raw)
+	}
+	return url.PathEscape(v)
+}
+
+func PathEscapePreserveQueryParameters(v string) string {
+	var value string
+	raw, err := url.PathUnescape(v)
+	if err == nil {
+		value = raw
+	} else {
+		value = v
+	}
+
+	// strip query parameters
+	pathValue := url.PathEscape(value)
+	if p1, p2, found := strings.Cut(value, "?"); found {
+		pathValue = fmt.Sprintf("%s?%s", url.PathEscape(p1), p2)
+	}
+	// preserve special characters
+	pathValue = strings.ReplaceAll(pathValue, "%2F", "/")
+	return pathValue
 }

--- a/tests/manual/tenantoptions/tenantoptions_update.yaml
+++ b/tests/manual/tenantoptions/tenantoptions_update.yaml
@@ -22,3 +22,25 @@ tests:
                 {
                   "body": {}
                 }
+
+    It encodes the path using url encoding:
+        command: >
+            c8y tenantoptions update --category measurement.series.latestvalue --key 'M#123.*' --dry --dryFormat json |
+            c8y util show --select pathEncoded -c=false --output json
+        exit-code: 0
+        stdout:
+            exactly: |
+                {
+                  "pathEncoded": "/tenant/options/measurement.series.latestvalue/M%23123.%2A"
+                }
+
+    It accepts url encoded values:
+        command: >
+            c8y tenantoptions update --category measurement.series.latestvalue --key 'M%23123.%2A' --dry --dryFormat json |
+            c8y util show --select pathEncoded -c=false --output json
+        exit-code: 0
+        stdout:
+            exactly: |
+                {
+                  "pathEncoded": "/tenant/options/measurement.series.latestvalue/M%23123.%2A"
+                }


### PR DESCRIPTION
Fix the handling of flag values used in the URL path to ensure it is correctly encoded.

Resolves #566