### PR TITLE
feat(extensions): allow validationSets to use \t to denote the description of an item

### DIFF
--- a/pkg/completion/flags.go
+++ b/pkg/completion/flags.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -22,7 +23,18 @@ func WithOptions(cmd *cobra.Command, opts ...Option) *cobra.Command {
 func WithValidateSet(flagName string, values ...string) Option {
 	return func(cmd *cobra.Command) *cobra.Command {
 		_ = cmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return values, cobra.ShellCompDirectiveDefault
+			formattedValues := make([]string, 0, len(values))
+			// Unescape values such as \t to allow users to provide descriptions
+			// to each of the completion items rather than using a literal tab as this can be
+			// difficult to insert depending on the IDE and the document's tab indentation setting (e.g. spaces vs. tabs)
+			for _, v := range values {
+				if v1, err := strconv.Unquote("\"" + v + "\""); err == nil {
+					formattedValues = append(formattedValues, v1)
+				} else {
+					formattedValues = append(formattedValues, v)
+				}
+			}
+			return formattedValues, cobra.ShellCompDirectiveDefault
 		})
 		return cmd
 	}


### PR DESCRIPTION
Allow validationSets to support setting a description on each of the items with using a `\t` (escaped tab) to denote the separation between the item's value and the item's description (as following the tab completion convention).

**Example**

Snippet of a flag's spec which uses a validationSet to control which values should be presented to the user when using tab completion:

```yaml
validationSet:
  - item1\tDescription of item 1
  - item2\tDescription of item 2
  - item3\tDescription of item 3
```