### PR TITLE
fix(identity): remove confusing description for the name parameter

### DIFF
--- a/api/spec/json/identity.json
+++ b/api/spec/json/identity.json
@@ -110,7 +110,7 @@
           "type": "string",
           "required": true,
           "pipeline": true,
-          "description": "External identity id/name",
+          "description": "External identity name",
           "pipelineAliases": [
             "externalId",
             "name",
@@ -174,7 +174,7 @@
           "type": "string",
           "required": true,
           "pipeline": true,
-          "description": "External identity id/name",
+          "description": "External identity name",
           "pipelineAliases": [
             "externalId",
             "name",

--- a/api/spec/json/remoteAccessConfigurations.json
+++ b/api/spec/json/remoteAccessConfigurations.json
@@ -471,7 +471,7 @@
           "name": "name",
           "type": "string",
           "description": "Connection name",
-          "default": "webssh"
+          "default": "webvnc"
         },
         {
           "name": "hostname",

--- a/api/spec/yaml/identity.yaml
+++ b/api/spec/yaml/identity.yaml
@@ -86,7 +86,7 @@ commands:
         type: string
         required: true
         pipeline: true
-        description: External identity id/name
+        description: External identity name
         pipelineAliases:
           - externalId
           - name
@@ -134,7 +134,7 @@ commands:
         type: string
         required: true
         pipeline: true
-        description: External identity id/name
+        description: External identity name
         pipelineAliases:
           - externalId
           - name

--- a/api/spec/yaml/microservicesLogs.yaml
+++ b/api/spec/yaml/microservicesLogs.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=../schema.json
+---
+
+group:
+  name: microservices/logs
+  description: Cumulocity microservices
+  descriptionLong: 'REST endpoint to interact with Cumulocity microservices'
+  link: https://cumulocity.com/guides/reference/applications/
+
+commands:
+  - name: list
+    # Currently a bug when parsing the output
+    skip: false
+    description: Get microservice logs
+    descriptionLong: |
+      Get logs of a microservice in the current tenant
+    method: GET
+    path: /application/applications/{id}/logs/{instance}
+    addAccept: true
+    accept: text/plain
+    # accept: application/vnd.com.nsn.cumulocity.applicationLogs+json
+    # collectionType: application/vnd.com.nsn.cumulocity.application+json
+    # collectionProperty: logs
+    collectionProperty: '-'
+    alias:
+        go: list
+        powershell: Get-MicroserviceLog
+    examples: 
+      powershell:
+        - description: Get microservice log entries
+          command: Get-MicroserviceLog -Id 1234 -Instance app1-scope-t12345-deployment-54dcf96599-rtn5d
+      go:
+        - description: Get microservice log entries
+          command: c8y microservices logs list --id 1234 --instance app1-scope-t12345-deployment-54dcf96599-rtn5d
+    pathParameters:
+      - name: id
+        type: microservice
+        pipeline: true
+        required: true
+        description: Microservice id
+        pipelineAliases:
+          - application.id
+          - id
+      
+      - name: instance
+        type: microserviceinstance
+        required: true
+        description: Microservice instance
+
+    queryParameters:
+      - name: dateFrom
+        type: datetime
+        default: "-1h"
+        description: Start date or date and time of log entries.
+
+      - name: dateTo
+        type: datetime
+        description: End date or date and time of log entries.

--- a/pkg/cmd/identity/delete/delete.auto.go
+++ b/pkg/cmd/identity/delete/delete.auto.go
@@ -48,7 +48,7 @@ Delete a specific external identity type (via pipeline)
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("type", "c8y_Serial", "External identity type")
-	cmd.Flags().String("name", "", "External identity id/name (required) (accepts pipeline)")
+	cmd.Flags().String("name", "", "External identity name (required) (accepts pipeline)")
 
 	completion.WithOptions(
 		cmd,

--- a/pkg/cmd/identity/get/get.auto.go
+++ b/pkg/cmd/identity/get/get.auto.go
@@ -47,7 +47,7 @@ Get external identity
 	cmd.SilenceUsage = true
 
 	cmd.Flags().String("type", "c8y_Serial", "External identity type")
-	cmd.Flags().String("name", "", "External identity id/name (required) (accepts pipeline)")
+	cmd.Flags().String("name", "", "External identity name (required) (accepts pipeline)")
 
 	completion.WithOptions(
 		cmd,

--- a/pkg/cmdparser/cmdparser.go
+++ b/pkg/cmdparser/cmdparser.go
@@ -531,7 +531,7 @@ func AddPredefinedGroupsFlags(cmd *CmdOptions, factory *cmdutil.Factory, templat
 
 		if identityType := cmd.Spec.Preset.GetOption("value"); identityType != "" {
 			cmd.Spec.Path = fmt.Sprintf("/identity/externalIds/%s/{name}", identityType)
-			cmd.Command.Flags().String("name", "", "External identity id/name (required) (accepts pipeline)")
+			cmd.Command.Flags().String("name", "", "External identity name (required) (accepts pipeline)")
 			cmd.Path.Options = append(
 				cmd.Path.Options,
 				[]flags.GetOption{
@@ -541,7 +541,7 @@ func AddPredefinedGroupsFlags(cmd *CmdOptions, factory *cmdutil.Factory, templat
 		} else {
 			cmd.Spec.Path = "/identity/externalIds/{type}/{name}"
 			cmd.Command.Flags().String("type", "c8y_Serial", "External identity type")
-			cmd.Command.Flags().String("name", "", "External identity id/name (required) (accepts pipeline)")
+			cmd.Command.Flags().String("name", "", "External identity name (required) (accepts pipeline)")
 			cmd.Path.Options = append(
 				cmd.Path.Options,
 				[]flags.GetOption{

--- a/tools/PSc8y/Public/Get-ExternalId.ps1
+++ b/tools/PSc8y/Public/Get-ExternalId.ps1
@@ -28,7 +28,7 @@ Get external identity
         [string]
         $Type,
 
-        # External identity id/name (required)
+        # External identity name (required)
         [Parameter(Mandatory = $true,
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]

--- a/tools/PSc8y/Public/Remove-ExternalId.ps1
+++ b/tools/PSc8y/Public/Remove-ExternalId.ps1
@@ -32,7 +32,7 @@ Delete a specific external identity type (via pipeline)
         [string]
         $Type,
 
-        # External identity id/name (required)
+        # External identity name (required)
         [Parameter(Mandatory = $true,
                    ValueFromPipeline=$true,
                    ValueFromPipelineByPropertyName=$true)]


### PR DESCRIPTION
Fix ambiguous description of the `--name` parameters for the `identity` command.

**Before**

```
--name  -- External identity id/name
```

**After**

```
--name  -- External identity name
```