### PR TITLE
fix(api): support pipeline property mapping on url when using c8y api

### DIFF
--- a/pkg/cmd/api/api.manual.go
+++ b/pkg/cmd/api/api.manual.go
@@ -123,6 +123,13 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Runtime flag options
+	flags.WithOptions(
+		cmd,
+		flags.WithRuntimePipelineProperty(),
+	)
+
 	client, err := n.factory.Client()
 	if err != nil {
 		return err
@@ -188,7 +195,9 @@ func (n *CmdAPI) RunE(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("url") {
 		if v, err := cmd.Flags().GetString("url"); err == nil {
-			urlTemplate = v
+			if !flags.IsRuntimePipelineProperty(v) {
+				urlTemplate = v
+			}
 		}
 	}
 	if !strings.Contains(urlTemplate, "{url}") && strings.Contains(urlTemplate, "%s") {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -149,6 +149,11 @@ func WithExtendedPipelineSupport(name string, property string, required bool, al
 	}
 }
 
+// Check if the given string is using the pipeline syntax, "-" or "-.myProperty"
+func IsRuntimePipelineProperty(v string) bool {
+	return v == "-" || strings.HasPrefix(v, "-.")
+}
+
 func WithRuntimePipelineProperty() Option {
 	return func(cmd *cobra.Command) *cobra.Command {
 		name := ""

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -25,6 +25,15 @@ tests:
         path: /test/12345/endpoint
         body.value: "12345"
 
+  It supports pipeline input references:
+    command: >
+      echo "{\"myUrl\": \"/hello/world\"}" | c8y api GET --url -.myUrl --dry
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        path: /hello/world
+
   It sends a POST request using explicit url parameter:
     command: >
       echo "12345" | c8y api POST --url "/test/{url}/endpoint" --template "{value: input.value}" --dry


### PR DESCRIPTION
Allow users to control the piping of the `--url` flag using the `-.<property>` syntax (which is supported by other commands).

**Example**

Read the url from the piped input but read it from the .myUrl property.

```sh
echo '{"myUrl":"/hello/world"}' | c8y api GET --url -.myUrl --dry
```

```
What If: Sending [GET] request to [https://example-cumulocity.com/hello/world]

### GET /hello/world

| header            | value
|-------------------|---------------------------
| Accept            | application/json 
| Authorization     | Bearer {token}
```