### PR TITLE
feat(measurements): add fragmentType flag to c8y measurements deleteCollection

### DIFF
--- a/api/spec/json/measurements.json
+++ b/api/spec/json/measurements.json
@@ -471,7 +471,7 @@
       "examples": {
         "powershell": [
           {
-            "description": "Delete measurement collection for a device",
+            "description": "Delete measurements for a device",
             "beforeEach": [
               "$Measurement = New-TestDevice | New-Measurement -Template \"test.measurement.jsonnet\""
             ],
@@ -479,12 +479,30 @@
             "afterEach": [
               "PSc8y\\Remove-ManagedObject -Id $Measurement.source.id"
             ]
+          },
+          {
+            "description": "Delete measurements older than 10 days for a device",
+            "command": "Remove-MeasurementCollection -Device $Measurement.source.id -DateTo \"-10d\"",
+            "skipTest": true
+          },
+          {
+            "description": "Delete measurements with a given fragment and older than 10 days for a device",
+            "command": "Remove-MeasurementCollection -Device $Measurement.source.id -DateTo \"-10d\" -FragmentType lmp",
+            "skipTest": true
           }
         ],
         "go": [
           {
-            "description": "Delete measurement collection for a device",
+            "description": "Delete measurements for a device",
             "command": "c8y measurements deleteCollection --device 12345"
+          },
+          {
+            "description": "Delete measurements older than 10 days for a device",
+            "command": "c8y measurements deleteCollection --device 12345 --dateTo \"-10d\""
+          },
+          {
+            "description": "Delete measurements with a given fragment and older than 10 days for a device",
+            "command": "c8y measurements deleteCollection --device 12345 --dateTo \"-10d\" --fragmentType lmp"
           }
         ]
       },
@@ -516,8 +534,7 @@
         {
           "name": "fragmentType",
           "type": "string",
-          "deprecated": true,
-          "description": "Fragment name from measurement (deprecated)."
+          "description": "Fragment name from measurement"
         },
         {
           "name": "dateFrom",

--- a/api/spec/yaml/measurements.yaml
+++ b/api/spec/yaml/measurements.yaml
@@ -355,16 +355,31 @@ commands:
         powershell: Remove-MeasurementCollection
     examples:
       powershell:
-        - description: Delete measurement collection for a device
+        - description: Delete measurements for a device
           beforeEach:
             - $Measurement = New-TestDevice | New-Measurement -Template "test.measurement.jsonnet"
           command: Remove-MeasurementCollection -Device $Measurement.source.id
           afterEach:
             - PSc8y\Remove-ManagedObject -Id $Measurement.source.id
 
+        - description: Delete measurements older than 10 days for a device
+          command: Remove-MeasurementCollection -Device $Measurement.source.id -DateTo "-10d"
+          skipTest: true
+
+        - description: Delete measurements with a given fragment and older than 10 days for a device
+          command: Remove-MeasurementCollection -Device $Measurement.source.id -DateTo "-10d" -FragmentType lmp
+          skipTest: true
+
       go:
-        - description: Delete measurement collection for a device
+        - description: Delete measurements for a device
           command: c8y measurements deleteCollection --device 12345
+
+        - description: Delete measurements older than 10 days for a device
+          command: c8y measurements deleteCollection --device 12345 --dateTo "-10d"
+
+        - description: Delete measurements with a given fragment and older than 10 days for a device
+          command: c8y measurements deleteCollection --device 12345 --dateTo "-10d" --fragmentType lmp
+
     queryParameters:
       - name: device
         type: device[]
@@ -388,8 +403,7 @@ commands:
 
       - name: fragmentType
         type: string
-        deprecated: true
-        description: Fragment name from measurement (deprecated).
+        description: Fragment name from measurement
 
       - name: dateFrom
         type: datetime

--- a/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
+++ b/pkg/cmd/measurements/deletecollection/deleteCollection.auto.go
@@ -35,7 +35,13 @@ func NewDeleteCollectionCmd(f *cmdutil.Factory) *DeleteCollectionCmd {
 		Long:  `Delete measurements using a filter`,
 		Example: heredoc.Doc(`
 $ c8y measurements deleteCollection --device 12345
-Delete measurement collection for a device
+Delete measurements for a device
+
+$ c8y measurements deleteCollection --device 12345 --dateTo "-10d"
+Delete measurements older than 10 days for a device
+
+$ c8y measurements deleteCollection --device 12345 --dateTo "-10d" --fragmentType lmp
+Delete measurements with a given fragment and older than 10 days for a device
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.DeleteModeEnabled(cmd)
@@ -47,7 +53,7 @@ Delete measurement collection for a device
 
 	cmd.Flags().StringSlice("device", []string{""}, "Device ID (accepts pipeline)")
 	cmd.Flags().String("type", "", "Measurement type.")
-	cmd.Flags().String("fragmentType", "", "Fragment name from measurement (deprecated).")
+	cmd.Flags().String("fragmentType", "", "Fragment name from measurement")
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of measurement occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of measurement occurrence.")
 
@@ -67,8 +73,6 @@ Delete measurement collection for a device
 	)
 
 	// Required flags
-
-	flags.MarkDeprecated(cmd, "fragmentType", "")
 
 	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
 

--- a/tests/auto/measurements/tests/measurements_deleteCollection.yaml
+++ b/tests/auto/measurements/tests/measurements_deleteCollection.yaml
@@ -1,5 +1,5 @@
 tests:
-    measurements_deleteCollection_Delete measurement collection for a device:
+    measurements_deleteCollection_Delete measurements for a device:
         command: c8y measurements deleteCollection --device 12345
         exit-code: 0
         stdout:
@@ -8,3 +8,24 @@ tests:
                 path: /measurement/measurements
             contains:
                 - source=12345
+    measurements_deleteCollection_Delete measurements older than 10 days for a device:
+        command: c8y measurements deleteCollection --device 12345 --dateTo "-10d"
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /measurement/measurements
+            contains:
+                - source=12345
+                - dateTo=
+    measurements_deleteCollection_Delete measurements with a given fragment and older than 10 days for a device:
+        command: c8y measurements deleteCollection --device 12345 --dateTo "-10d" --fragmentType lmp
+        exit-code: 0
+        stdout:
+            json:
+                method: DELETE
+                path: /measurement/measurements
+            contains:
+                - source=12345
+                - fragmentType=lmp
+                - dateTo=

--- a/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Remove-MeasurementCollection.ps1
@@ -13,7 +13,17 @@ https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/measurements_deleteCollec
 .EXAMPLE
 PS> Remove-MeasurementCollection -Device $Measurement.source.id
 
-Delete measurement collection for a device
+Delete measurements for a device
+
+.EXAMPLE
+PS> Remove-MeasurementCollection -Device $Measurement.source.id -DateTo "-10d"
+
+Delete measurements older than 10 days for a device
+
+.EXAMPLE
+PS> Remove-MeasurementCollection -Device $Measurement.source.id -DateTo "-10d" -FragmentType lmp
+
+Delete measurements with a given fragment and older than 10 days for a device
 
 
 #>
@@ -32,6 +42,11 @@ Delete measurement collection for a device
         [Parameter()]
         [string]
         $Type,
+
+        # Fragment name from measurement
+        [Parameter()]
+        [string]
+        $FragmentType,
 
         # Start date or date and time of measurement occurrence.
         [Parameter()]

--- a/tools/PSc8y/Tests/Remove-MeasurementCollection.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Remove-MeasurementCollection.auto.Tests.ps1
@@ -6,8 +6,18 @@ Describe -Name "Remove-MeasurementCollection" {
 
     }
 
-    It "Delete measurement collection for a device" {
+    It -Skip "Delete measurements for a device" {
         $Response = PSc8y\Remove-MeasurementCollection -Device $Measurement.source.id
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It -Skip "Delete measurements older than 10 days for a device" {
+        $Response = PSc8y\Remove-MeasurementCollection -Device $Measurement.source.id -DateTo "-10d"
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It -Skip "Delete measurements with a given fragment and older than 10 days for a device" {
+        $Response = PSc8y\Remove-MeasurementCollection -Device $Measurement.source.id -DateTo "-10d" -FragmentType lmp
         $LASTEXITCODE | Should -Be 0
     }
 


### PR DESCRIPTION
Adding `--fragmentType` flag to `c8y measurements deleteCollection`.

**Example**

```sh
c8y measurements deleteCollection --device 12345 --dateTo "-10d" --fragmentType lmp
Delete measurements with a given fragment and older than 10 days for a device
```