### PR TITLE
fix(binaries): add Content-Type headers to binary replacement commands

### DIFF
--- a/api/spec/json/binaries.json
+++ b/api/spec/json/binaries.json
@@ -245,6 +245,7 @@
       "method": "PUT",
       "path": "/inventory/binaries/{id}",
       "accept": "application/vnd.com.nsn.cumulocity.managedObject+json",
+      "contentType": "text/plain",
       "alias": {
         "go": "update",
         "powershell": "Update-Binary"

--- a/api/spec/json/events.json
+++ b/api/spec/json/events.json
@@ -578,6 +578,7 @@
       "method": "PUT",
       "path": "event/events/{id}/binaries",
       "accept": "application/vnd.com.nsn.cumulocity.event+json",
+      "contentType": "application/octet-stream",
       "alias": {
         "go": "updateBinary",
         "powershell": "Update-EventBinary"

--- a/api/spec/yaml/binaries.yaml
+++ b/api/spec/yaml/binaries.yaml
@@ -199,6 +199,7 @@ commands:
     method: PUT
     path: /inventory/binaries/{id}
     accept: application/vnd.com.nsn.cumulocity.managedObject+json
+    contentType: text/plain
     alias:
         go: update
         powershell: Update-Binary

--- a/api/spec/yaml/events.yaml
+++ b/api/spec/yaml/events.yaml
@@ -442,6 +442,7 @@ commands:
     method: PUT
     path: event/events/{id}/binaries
     accept: application/vnd.com.nsn.cumulocity.event+json
+    contentType: application/octet-stream
     alias:
         go: updateBinary
         powershell: Update-EventBinary

--- a/pkg/cmd/binaries/update/update.auto.go
+++ b/pkg/cmd/binaries/update/update.auto.go
@@ -114,6 +114,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		headers,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetHeader(), nil }, "header"),
+		flags.WithStaticStringValue("Content-Type", "text/plain"),
 		flags.WithProcessingModeValue(),
 	)
 	if err != nil {

--- a/pkg/cmd/events/updatebinary/updateBinary.auto.go
+++ b/pkg/cmd/events/updatebinary/updateBinary.auto.go
@@ -114,6 +114,7 @@ func (n *UpdateBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 		headers,
 		inputIterators,
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetHeader(), nil }, "header"),
+		flags.WithStaticStringValue("Content-Type", "application/octet-stream"),
 		flags.WithProcessingModeValue(),
 	)
 	if err != nil {

--- a/tests/manual/configuration/crud.sh
+++ b/tests/manual/configuration/crud.sh
@@ -33,7 +33,7 @@ echo "$CONFIG1" | c8y util show --select description -o csv | grep "My custom co
 #
 # create from file
 #
-package_file="$TEMP_DIR/package-1.json"
+package_file="$TEMP_DIR/package-1.txt"
 echo "dummy file" > "$package_file"
 
 CONFIG2=$( c8y configuration create --name "${NAME}_2" --file "$package_file" --configurationType dummytype --select "id,url" --output csv )
@@ -60,7 +60,7 @@ c8y configuration send --device 1234 --configuration "${NAME}_2" --dry --dryForm
 
 
 # Update configuration binary
-package_file2="$TEMP_DIR/package-2.json"
+package_file2="$TEMP_DIR/package-2.txt"
 echo "dummy file 2" > "$package_file2"
 CONFIG2_ID=$( echo "$CONFIG2" | cut -d, -f1 )
 echo "$CONFIG2" | c8y configuration update --file "$package_file2" --select id --output csv | grep "^$CONFIG2_ID$"


### PR DESCRIPTION
Fix the "Content-Type" headers used for binary updates as the server seems to be stricter and will reject invalid types, e.g. `application/json` when text/plain is provided in the body.

Affected commands:

* c8y binaries update
* c8y events binaries update