### PR TITLE
feat(measurement): add aggregationFunction and aggregationInterval support to getSeries

### DIFF
--- a/api/spec/json/measurements.json
+++ b/api/spec/json/measurements.json
@@ -211,7 +211,7 @@
               "$Device = PSc8y\\New-TestDevice",
               "$Measurement = New-Measurement -Template \"{c8y_Temperature:{T:{value:_.Int(),unit:'°C'}}}\" -Device $Device.id -Type \"TempReading\""
             ],
-            "command": "Get-MeasurementSeries -Device $Device.id -Series \"c8y_Temperature.T\" -DateFrom \"1970-01-01\" -DateTo \"0s\"",
+            "command": "Get-MeasurementSeries -Device $Device.id -Series \"c8y_Temperature.T\" -DateFrom \"1970-01-01\"",
             "afterEach": [
               "PSc8y\\Remove-ManagedObject -Id $Device.id"
             ]
@@ -221,7 +221,7 @@
             "beforeEach": [
               "$Measurement2 = New-Measurement -Template \"{c8y_Temperature:{T:{value:_.Int(),unit:'°C'}}}\" -Device $Device.id -Type \"TempReading\""
             ],
-            "command": "Get-MeasurementSeries -Device $Measurement2.source.id -Series \"c8y_Temperature.T\" -DateFrom \"1970-01-01\" -DateTo \"0s\"",
+            "command": "Get-MeasurementSeries -Device $Measurement2.source.id -Series \"c8y_Temperature.T\" -DateFrom \"1970-01-01\"",
             "afterEach": [
               "PSc8y\\Remove-ManagedObject -Id $Measurement2.source.id"
             ]
@@ -236,12 +236,30 @@
             "afterEach": [
               "PSc8y\\Remove-ManagedObject -Id $Device.id"
             ]
+          },
+          {
+            "description": "Get a list of series and calculate the average and use 1 week intervals",
+            "command": "Get-MeasurementSeries -Device 12345 -Series app_Weather.barometer -AggregationFunction avg -AggregationInterval 1w",
+            "skipTest": true
+          },
+          {
+            "description": "Get a list of series and calculate the average, count and sum and use 1 hour intervals",
+            "command": "Get-MeasurementSeries -Device 12345 -Series app_Weather.temperature -AggregationFunction avg,count,sum -AggregationInterval 1h",
+            "skipTest": true
           }
         ],
         "go": [
           {
             "description": "Get a list of series [app_Weather.temperature] and [app_Weather.barometer] for device 12345",
-            "command": "c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom \"-10min\" --dateTo \"0s\""
+            "command": "c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom \"-10min\""
+          },
+          {
+            "description": "Get a list of series and calculate the average and use 1 week intervals",
+            "command": "c8y measurements getSeries --device 12345 --series app_Weather.barometer --aggregationFunction avg --aggregationInterval 1w"
+          },
+          {
+            "description": "Get a list of series and calculate the average, count and sum and use 1 hour intervals",
+            "command": "c8y measurements getSeries --device 12345 --series app_Weather.temperature --aggregationFunction avg,count,sum --aggregationInterval 1h"
           }
         ]
       },
@@ -257,6 +275,25 @@
           "name": "series",
           "type": "string[]",
           "description": "measurement type and series name, e.g. c8y_AccelerationMeasurement.acceleration"
+        },
+        {
+          "name": "aggregationFunction",
+          "type": "string[]",
+          "description": "(time series only) Selects aggregation functions that are calculated for each selected aggregation interval",
+          "validationSet": [
+            "min",
+            "max",
+            "avg",
+            "sum",
+            "count",
+            "stdDevPop",
+            "stdDevSamp"
+          ]
+        },
+        {
+          "name": "aggregationInterval",
+          "type": "string[]",
+          "description": "(time series only) Fetch results are aggregated using a time interval specified by an integer followed by a unit. Available units of (s)econd, (m)inute, (h)our, (d)ay, week, (M)onth, (q)uarter and (y)ear"
         },
         {
           "name": "aggregationType",

--- a/api/spec/yaml/measurements.yaml
+++ b/api/spec/yaml/measurements.yaml
@@ -162,15 +162,14 @@ commands:
           beforeEach:
             - $Device = PSc8y\New-TestDevice
             - $Measurement = New-Measurement -Template "{c8y_Temperature:{T:{value:_.Int(),unit:'°C'}}}" -Device $Device.id -Type "TempReading"
-
-          command: Get-MeasurementSeries -Device $Device.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01" -DateTo "0s"
+          command: Get-MeasurementSeries -Device $Device.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01"
           afterEach:
             - PSc8y\Remove-ManagedObject -Id $Device.id
 
         - description: Get measurement series c8y_Temperature.T on a device
           beforeEach:
             - $Measurement2 = New-Measurement -Template "{c8y_Temperature:{T:{value:_.Int(),unit:'°C'}}}" -Device $Device.id -Type "TempReading"
-          command: Get-MeasurementSeries -Device $Measurement2.source.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01" -DateTo "0s"
+          command: Get-MeasurementSeries -Device $Measurement2.source.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01"
           afterEach:
             - PSc8y\Remove-ManagedObject -Id $Measurement2.source.id
 
@@ -181,10 +180,24 @@ commands:
           command: Get-DeviceCollection -Name $Device.name | Get-MeasurementSeries -Series "c8y_Temperature.T"
           afterEach:
             - PSc8y\Remove-ManagedObject -Id $Device.id
+        
+        - description: Get a list of series and calculate the average and use 1 week intervals
+          command: Get-MeasurementSeries -Device 12345 -Series app_Weather.barometer -AggregationFunction avg -AggregationInterval 1w
+          skipTest: true
+
+        - description: Get a list of series and calculate the average, count and sum and use 1 hour intervals
+          command: Get-MeasurementSeries -Device 12345 -Series app_Weather.temperature -AggregationFunction avg,count,sum -AggregationInterval 1h
+          skipTest: true
 
       go:
         - description: Get a list of series [app_Weather.temperature] and [app_Weather.barometer] for device 12345
-          command: c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom "-10min" --dateTo "0s"
+          command: c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom "-10min"
+
+        - description: Get a list of series and calculate the average and use 1 week intervals
+          command: c8y measurements getSeries --device 12345 --series app_Weather.barometer --aggregationFunction avg --aggregationInterval 1w
+
+        - description: Get a list of series and calculate the average, count and sum and use 1 hour intervals
+          command: c8y measurements getSeries --device 12345 --series app_Weather.temperature --aggregationFunction avg,count,sum --aggregationInterval 1h
     queryParameters:
       - name: device
         type: device[]
@@ -195,6 +208,16 @@ commands:
       - name: series
         type: string[]
         description: measurement type and series name, e.g. c8y_AccelerationMeasurement.acceleration
+
+      - name: aggregationFunction
+        type: string[]
+        description: (time series only) Selects aggregation functions that are calculated for each selected aggregation interval
+        validationSet: [min, max, avg, sum, count, stdDevPop, stdDevSamp]
+
+      - name: aggregationInterval
+        type: string[]
+        # Full range of values for aggregationInterval parameter is only available when time series persistence is enabled
+        description: (time series only) Fetch results are aggregated using a time interval specified by an integer followed by a unit. Available units of (s)econd, (m)inute, (h)our, (d)ay, week, (M)onth, (q)uarter and (y)ear
 
       - name: aggregationType
         type: string

--- a/pkg/cmd/measurements/getseries/getSeries.auto.go
+++ b/pkg/cmd/measurements/getseries/getSeries.auto.go
@@ -35,8 +35,14 @@ func NewGetSeriesCmd(f *cmdutil.Factory) *GetSeriesCmd {
 		Short: "Get measurement series",
 		Long:  `Get a collection of measurements based on filter parameters`,
 		Example: heredoc.Doc(`
-$ c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom "-10min" --dateTo "0s"
+$ c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom "-10min"
 Get a list of series [app_Weather.temperature] and [app_Weather.barometer] for device 12345
+
+$ c8y measurements getSeries --device 12345 --series app_Weather.barometer --aggregationFunction avg --aggregationInterval 1w
+Get a list of series and calculate the average and use 1 week intervals
+
+$ c8y measurements getSeries --device 12345 --series app_Weather.temperature --aggregationFunction avg,count,sum --aggregationInterval 1h
+Get a list of series and calculate the average, count and sum and use 1 hour intervals
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil
@@ -48,6 +54,8 @@ Get a list of series [app_Weather.temperature] and [app_Weather.barometer] for d
 
 	cmd.Flags().StringSlice("device", []string{""}, "Device ID (accepts pipeline)")
 	cmd.Flags().StringSlice("series", []string{""}, "measurement type and series name, e.g. c8y_AccelerationMeasurement.acceleration")
+	cmd.Flags().StringSlice("aggregationFunction", []string{""}, "(time series only) Selects aggregation functions that are calculated for each selected aggregation interval")
+	cmd.Flags().StringSlice("aggregationInterval", []string{""}, "(time series only) Fetch results are aggregated using a time interval specified by an integer followed by a unit. Available units of (s)econd, (m)inute, (h)our, (d)ay, week, (M)onth, (q)uarter and (y)ear")
 	cmd.Flags().String("aggregationType", "", "Fragment name from measurement.")
 	cmd.Flags().String("dateFrom", "-7d", "Start date or date and time of measurement occurrence. Defaults to last 7 days")
 	cmd.Flags().String("dateTo", "0s", "End date or date and time of measurement occurrence. Defaults to the current time")
@@ -56,6 +64,7 @@ Get a list of series [app_Weather.temperature] and [app_Weather.barometer] for d
 		cmd,
 		completion.WithDevice("device", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 		completion.WithDeviceMeasurementSeries("series", "device", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithValidateSet("aggregationFunction", "min", "max", "avg", "sum", "count", "stdDevPop", "stdDevSamp"),
 		completion.WithValidateSet("aggregationType", "DAILY", "HOURLY", "MINUTELY"),
 	)
 
@@ -106,6 +115,8 @@ func (n *GetSeriesCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithCustomStringSlice(func() ([]string, error) { return cfg.GetQueryParameters(), nil }, "custom"),
 		c8yfetcher.WithDeviceByNameFirstMatch(n.factory, args, "device", "source"),
 		flags.WithStringSliceValues("series", "series", ""),
+		flags.WithStringSliceValues("aggregationFunction", "aggregationFunction", ""),
+		flags.WithStringSliceValues("aggregationInterval", "aggregationInterval", ""),
 		flags.WithStringValue("aggregationType", "aggregationType"),
 		flags.WithEncodedRelativeTimestamp("dateFrom", "dateFrom"),
 		flags.WithEncodedRelativeTimestamp("dateTo", "dateTo"),

--- a/tests/auto/measurements/tests/measurements_getSeries.yaml
+++ b/tests/auto/measurements/tests/measurements_getSeries.yaml
@@ -1,6 +1,6 @@
 tests:
     measurements_getSeries_Get a list of series [app_Weather.temperature] and [app_Weather.barometer] for device 12345:
-        command: c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom "-10min" --dateTo "0s"
+        command: c8y measurements getSeries --device 12345 --series app_Weather.temperature --series app_Weather.barometer --dateFrom "-10min"
         exit-code: 0
         stdout:
             json:
@@ -11,4 +11,29 @@ tests:
                 - series=app_Weather.temperature
                 - series=app_Weather.barometer
                 - dateFrom=
-                - dateTo=
+    measurements_getSeries_Get a list of series and calculate the average and use 1 week intervals:
+        command: c8y measurements getSeries --device 12345 --series app_Weather.barometer --aggregationFunction avg --aggregationInterval 1w
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /measurement/measurements/series
+            contains:
+                - source=12345
+                - series=app_Weather.barometer
+                - aggregationFunction=avg
+                - aggregationInterval=1w
+    measurements_getSeries_Get a list of series and calculate the average, count and sum and use 1 hour intervals:
+        command: c8y measurements getSeries --device 12345 --series app_Weather.temperature --aggregationFunction avg,count,sum --aggregationInterval 1h
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /measurement/measurements/series
+            contains:
+                - source=12345
+                - series=app_Weather.temperature
+                - aggregationFunction=avg
+                - aggregationFunction=count
+                - aggregationFunction=sum
+                - aggregationInterval=1h

--- a/tools/PSc8y/Public/Get-MeasurementSeries.ps1
+++ b/tools/PSc8y/Public/Get-MeasurementSeries.ps1
@@ -11,12 +11,12 @@ Get a collection of measurements based on filter parameters
 https://reubenmiller.github.io/go-c8y-cli/docs/cli/c8y/measurements_getSeries
 
 .EXAMPLE
-PS> Get-MeasurementSeries -Device $Device.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01" -DateTo "0s"
+PS> Get-MeasurementSeries -Device $Device.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01"
 
 Get a list of measurements for a particular device
 
 .EXAMPLE
-PS> Get-MeasurementSeries -Device $Measurement2.source.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01" -DateTo "0s"
+PS> Get-MeasurementSeries -Device $Measurement2.source.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01"
 
 Get measurement series c8y_Temperature.T on a device
 
@@ -24,6 +24,16 @@ Get measurement series c8y_Temperature.T on a device
 PS> Get-DeviceCollection -Name $Device.name | Get-MeasurementSeries -Series "c8y_Temperature.T"
 
 Get measurement series from a device (using pipeline)
+
+.EXAMPLE
+PS> Get-MeasurementSeries -Device 12345 -Series app_Weather.barometer -AggregationFunction avg -AggregationInterval 1w
+
+Get a list of series and calculate the average and use 1 week intervals
+
+.EXAMPLE
+PS> Get-MeasurementSeries -Device 12345 -Series app_Weather.temperature -AggregationFunction avg,count,sum -AggregationInterval 1h
+
+Get a list of series and calculate the average, count and sum and use 1 hour intervals
 
 
 #>
@@ -42,6 +52,17 @@ Get measurement series from a device (using pipeline)
         [Parameter()]
         [string[]]
         $Series,
+
+        # (time series only) Selects aggregation functions that are calculated for each selected aggregation interval
+        [Parameter()]
+        [ValidateSet('min','max','avg','sum','count','stdDevPop','stdDevSamp')]
+        [string[]]
+        $AggregationFunction,
+
+        # (time series only) Fetch results are aggregated using a time interval specified by an integer followed by a unit. Available units of (s)econd, (m)inute, (h)our, (d)ay, week, (M)onth, (q)uarter and (y)ear
+        [Parameter()]
+        [string[]]
+        $AggregationInterval,
 
         # Fragment name from measurement.
         [Parameter()]

--- a/tools/PSc8y/Tests/Get-MeasurementSeries.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Get-MeasurementSeries.auto.Tests.ps1
@@ -8,20 +8,32 @@ Describe -Name "Get-MeasurementSeries" {
 
     }
 
-    It "Get a list of measurements for a particular device" {
-        $Response = PSc8y\Get-MeasurementSeries -Device $Device.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01" -DateTo "0s"
+    It -Skip "Get a list of measurements for a particular device" {
+        $Response = PSc8y\Get-MeasurementSeries -Device $Device.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01"
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }
 
-    It "Get measurement series c8y_Temperature.T on a device" {
-        $Response = PSc8y\Get-MeasurementSeries -Device $Measurement2.source.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01" -DateTo "0s"
+    It -Skip "Get measurement series c8y_Temperature.T on a device" {
+        $Response = PSc8y\Get-MeasurementSeries -Device $Measurement2.source.id -Series "c8y_Temperature.T" -DateFrom "1970-01-01"
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }
 
-    It "Get measurement series from a device (using pipeline)" {
+    It -Skip "Get measurement series from a device (using pipeline)" {
         $Response = PSc8y\Get-DeviceCollection -Name $Device.name | Get-MeasurementSeries -Series "c8y_Temperature.T"
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It -Skip "Get a list of series and calculate the average and use 1 week intervals" {
+        $Response = PSc8y\Get-MeasurementSeries -Device 12345 -Series app_Weather.barometer -AggregationFunction avg -AggregationInterval 1w
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
+    It -Skip "Get a list of series and calculate the average, count and sum and use 1 hour intervals" {
+        $Response = PSc8y\Get-MeasurementSeries -Device 12345 -Series app_Weather.temperature -AggregationFunction avg,count,sum -AggregationInterval 1h
         $LASTEXITCODE | Should -Be 0
         $Response | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
Add support for the new time series aggregation functions. See [Cumulocity API docs](https://cumulocity.com/api/core/#operation/getMeasurementSeriesResource) for more details.

**Note** The aggregation functions requires the time series persistence functionality to be enabled in your tenant. 

```sh
$ c8y measurements getSeries --device 12345 --series app_Weather.barometer --aggregationFunction avg --aggregationInterval 1w
Get a list of series and calculate the average and use 1 week intervals

$ c8y measurements getSeries --device 12345 --series app_Weather.temperature --aggregationFunction avg,count,sum --aggregationInterval 1h
Get a list of series and calculate the average, count and sum and use 1 hour intervals
```

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/589