### PR TITLE
fix: fix incorrect encoding of customQueryParameter values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
         c8y currentuser get --select id --debug
         task test-cli
       shell: bash
-      timeout-minutes: 20
+      timeout-minutes: 60
 
   test-pwsh:
     runs-on: ${{ matrix.os }}

--- a/pkg/flags/getters.go
+++ b/pkg/flags/getters.go
@@ -55,7 +55,7 @@ func WithQueryParameters(cmd *cobra.Command, query *QueryTemplate, inputIterator
 		case map[string]string:
 			for key, val := range v {
 				if val != "" {
-					query.SetVariable(key, url.EscapeQueryString(val))
+					query.SetVariable(key, url.EscapeQueryStringStrict(val))
 				}
 			}
 		case map[string][]string:
@@ -63,7 +63,7 @@ func WithQueryParameters(cmd *cobra.Command, query *QueryTemplate, inputIterator
 			for key, values := range v {
 				encodedValues := make([]string, 0, len(values))
 				for _, value := range values {
-					encodedValues = append(encodedValues, url.EscapeQueryString(value))
+					encodedValues = append(encodedValues, url.EscapeQueryStringStrict(value))
 				}
 				query.SetVariable(key, encodedValues)
 			}

--- a/pkg/url/encode.go
+++ b/pkg/url/encode.go
@@ -27,6 +27,18 @@ func EscapeQueryString(v string) string {
 	return v
 }
 
+func IsURLEncoded(v string) bool {
+	q, _ := url.QueryUnescape(v)
+	return url.QueryEscape(q) == v
+}
+
+func EscapeQueryStringStrict(v string) string {
+	if IsURLEncoded(v) {
+		return v
+	}
+	return url.QueryEscape(v)
+}
+
 func PathEscape(v string) string {
 	raw, err := url.PathUnescape(v)
 	if err == nil {

--- a/pkg/url/encode_test.go
+++ b/pkg/url/encode_test.go
@@ -11,3 +11,18 @@ func Test_Encode_date(t *testing.T) {
 		t.Errorf("Date does not match. got=%s, wanted=%s", value, expected)
 	}
 }
+
+func Test_EncodeStrict_AlreadyEncoded(t *testing.T) {
+	value := EscapeQueryStringStrict("+2022-08-10T14%3A59%3A29.561+02%3A00")
+	expected := "+2022-08-10T14%3A59%3A29.561+02%3A00"
+	if value != expected {
+		t.Errorf("Date does not match. got=%s, wanted=%s", value, expected)
+	}
+}
+func Test_EncodeStrict_Date(t *testing.T) {
+	value := EscapeQueryStringStrict("2022-08-10T14:59:29.561+02:00")
+	expected := "2022-08-10T14%3A59%3A29.561%2B02%3A00"
+	if value != expected {
+		t.Errorf("Date does not match. got=%s, wanted=%s", value, expected)
+	}
+}

--- a/tests/manual/common/flag_customQuery.yaml
+++ b/tests/manual/common/flag_customQuery.yaml
@@ -9,3 +9,12 @@ tests:
       json:
         method: GET
         pathEncoded: /inventory/managedObjects?myValue=1
+
+  It encodes spaces correctly:
+    command: |
+      c8y inventory list --customQueryParam "foo: string with space" --dry --dryFormat json
+    exit-code: 0
+    stdout:
+      json:
+        method: GET
+        pathEncoded: /inventory/managedObjects?foo=string+with+space


### PR DESCRIPTION
Fix incorrect encoding of values when provided by the `--customQueryParam` global flag.

**Example**

When trying to use the `--customQueryParam` on any command and using a value which contains a space, it would be incorrectly encoded as `%2B` due to a double query parameter encoding (` ` -> `+` -> `%2B`).

**Before**

```sh
$ c8y inventory list --customQueryParam "foo=string with space" --dry --dryFormat json | c8y util show --select pathEncoded -o csv
/inventory/managedObjects?foo=string%2Bwith%2Bspace
```

**After**

```sh
$ c8y inventory list --customQueryParam "foo=string with space" --dry --dryFormat json | c8y util show --select pathEncoded -o csv
/inventory/managedObjects?foo=string+with+space
```