### PR TITLE
fix(extensions): disable session check for extension help and examples flags

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -837,6 +838,15 @@ func (c *CmdRoot) Configure(disableEncryptionCheck, forceVerbose, forceDebug boo
 	return nil
 }
 
+// check if an extension (i.e. flag parsing is disabled) is being used
+// and manually check if any of the help related flags are given
+func isExtensionWithHelpFlags(cmd *cobra.Command, args []string) bool {
+	if !cmd.DisableFlagParsing {
+		return false
+	}
+	return slices.Contains(args, "--help") || slices.Contains(args, "-h") || slices.Contains(args, "--examples")
+}
+
 func (c *CmdRoot) checkSessionExists(cmd *cobra.Command, args []string) error {
 	log, err := c.Factory.Logger()
 	if err != nil {
@@ -887,6 +897,12 @@ func (c *CmdRoot) checkSessionExists(cmd *cobra.Command, args []string) error {
 		// mdContent, _ := markdown.Render(examples, style)
 		fmt.Fprint(c.Factory.IOStreams.Out, examples)
 		return cmderrors.ErrHelp
+	}
+
+	if isExtensionWithHelpFlags(cmd, args) {
+		// Extension command - skip session check to allow the script to display the help/usage
+		log.Debugf("Skipping auth check and letting the extension handle the help/example flags")
+		return nil
 	}
 
 	// TODO: Find more efficient/extensible way of ignoring specific commands in the activity log

--- a/tests/manual/extensions/example/commands/extension_script_commands.yaml
+++ b/tests/manual/extensions/example/commands/extension_script_commands.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_DEFAULTS_CACHE: true
+    C8Y_SETTINGS_CACHE_METHODS: GET POST PUT
+    C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
+    C8Y_SETTINGS_DEFAULTS_DRY: true
+    C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
+
+tests:
+  Show help (--help) when no session is loaded:
+    command: |
+      eval $(c8y sessions clear)
+      c8y kitchensink items list --help
+    exit-code: 0
+    stdout:
+      contains:
+        - Example description about what your command does
+
+  Show help (-h) when no session is loaded:
+    command: |
+      eval $(c8y sessions clear)
+      c8y kitchensink items list -h
+    exit-code: 0
+    stdout:
+      contains:
+        - Example description about what your command does
+
+  Show examples when no session is loaded:
+    command: |
+      eval $(c8y sessions clear)
+      c8y kitchensink items list --examples
+    exit-code: 0
+    stdout:
+      contains:
+        - "Examples:"

--- a/tests/testdata/extensions/c8y-kitchensink/commands/items/list
+++ b/tests/testdata/extensions/c8y-kitchensink/commands/items/list
@@ -24,3 +24,17 @@ EOF
 
 # Print log messages on stderr so it does not mix with results which is generally printed on stdout
 echo "Running custom services list command" >&2
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h)
+      help
+      exit 0
+      ;;
+    --examples)
+      examples
+      exit 0
+      ;;
+  esac
+  shift
+done


### PR DESCRIPTION
Allow extensions to display help and examples when a Cumulocity session is not active.

PR is based on #https://github.com/reubenmiller/go-c8y-cli/pull/564

### Example

Previously an extensions help was not viewable when a session was not loaded. Below shows an example of the before and after.

**Before**

```sh
eval $(c8y sessions clear)  
c8y myextension mycommand --help                       
2025-10-30T16:17:09.299+0100    WARN    Check existing session failed. commandError: A c8y session has not been loaded. Please create or activate a session and try again
2025-10-30T16:17:09.299+0100    ERROR   commandError: A c8y session has not been loaded. Please create or activate a session and try again
```

**After**

```sh
c8y myextension mycommand --help
c8y myextension mycommand -h
c8y myextension mycommand --examples
```
