### PR TITLE
fix: avoid showing pretty printed error message multiple times

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -191,7 +191,7 @@ func CheckCommandError(cmd *cobra.Command, f *cmdutil.Factory, err error) error 
 		if !cErr.IsSilent() && !strings.Contains(silentStatusCodes, fmt.Sprintf("%d", cErr.StatusCode)) {
 
 			if !cErr.Processed {
-				logg.Errorf("%s", cErr)
+				logg.Errorf("%s", cErr.ErrorPretty())
 				fmt.Fprintf(w, "%s\n", cErr.JSONString())
 			} else {
 				logg.Debugf("Error has already been logged. %s", cErr)

--- a/pkg/cmderrors/cmderrors.go
+++ b/pkg/cmderrors/cmderrors.go
@@ -87,6 +87,14 @@ func (c CommandError) Unwrap() error {
 }
 
 func (c CommandError) Error() string {
+	return c.formatError(true)
+}
+
+func (c CommandError) ErrorPretty() string {
+	return c.formatError(false)
+}
+
+func (c CommandError) formatError(disableRawMessage bool) string {
 	details := ""
 	if c.StatusCode > 0 {
 		details = fmt.Sprintf(" ::StatusCode=%d", c.StatusCode)
@@ -106,7 +114,7 @@ func (c CommandError) Error() string {
 	}
 
 	// Print raw response as microservices add additional information in the response
-	if c.WithRawMessage && len(c.CumulocityError) > 0 && c.IO != nil {
+	if !disableRawMessage && c.WithRawMessage && len(c.CumulocityError) > 0 && c.IO != nil {
 		message.WriteString(c.IO.ColorScheme().Red("\n\nError Response\n\n"))
 		if json.Valid(c.CumulocityError) {
 			b := pretty.PrettyOptions(c.CumulocityError, &pretty.Options{

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -502,7 +502,7 @@ func (f *Factory) CheckPostCommandError(err error) error {
 		}
 		if !cErr.IsSilent() && !strings.Contains(silentStatusCodes, fmt.Sprintf("%d", cErr.StatusCode)) {
 			if printLogEntries {
-				logg.Errorf("%s", cErr)
+				logg.Errorf("%s", cErr.ErrorPretty())
 			}
 			fmt.Fprintf(w, "%s\n", cErr.JSONString())
 


### PR DESCRIPTION
Fix a bug where the pretty printed error would be shown multiple times when using `--verbose` or `--debug`.