### PR TITLE
fix: fix login issues due to errenous fallback mechanism

### DIFF
--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -702,8 +702,6 @@ func (lh *LoginHandler) setupTFA() error {
 			Level:      qrterminal.M,
 			Writer:     lh.Writer,
 			HalfBlocks: true,
-			BlackChar:  qrterminal.BLACK,
-			WhiteChar:  qrterminal.WHITE,
 			QuietZone:  1,
 		})
 

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -509,7 +509,7 @@ func (lh *LoginHandler) login() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(Timeout)*time.Millisecond)
 					defer cancel()
 
-					lh.Logger.Debugf("Logging in using %s", c8y.LoginTypeOAuth2Internal)
+					lh.Logger.Infof("Logging in using %s", c8y.LoginTypeOAuth2Internal)
 
 					// Check if username/password are provided
 					if lh.C8Yclient.Username == "" {
@@ -600,7 +600,7 @@ func (lh *LoginHandler) verify() {
 					lh.TFACodeRequired = true
 					lh.state <- LoginStateTFASetup
 				} else if lh.errorContains(v.Message, "TFA TOTP code required") {
-					lh.Logger.Debugf("TFA code is required. server response: %s", v.Message)
+					lh.Logger.Infof("TFA code is required. server response: %s", v.Message)
 					lh.TFACodeRequired = true
 					lh.state <- LoginStateNoAuth
 				} else if lh.errorContains(v.Message, "User has been logged out") {

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -520,7 +520,13 @@ func (lh *LoginHandler) login() {
 
 					if err := lh.C8Yclient.LoginUsingOAuth2(ctx, option.InitRequest); err != nil {
 						if v, ok := err.(*c8y.ErrorResponse); ok {
+							// Check for known message that the server responds with
+							// when TFA is required, so don't log it on the ERROR level as it is annoying for users
+							if strings.Contains(v.Message, `For input string: "undefined"`) {
+								lh.Logger.Infof("OAuth2 most likely requires TFA. %s", v.Message)
+							} else {
 							lh.Logger.Errorf("OAuth2 failed. %s", v.Message)
+							}
 						} else {
 							lh.Logger.Errorf("OAuth2 failed. %s", err)
 						}

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -551,6 +551,7 @@ func (lh *LoginHandler) login() {
 				}
 				lh.onSave()
 				lh.state <- LoginStateVerify
+				return nil
 
 			case c8y.LoginTypeBasic:
 				if lh.C8Yclient.Username == "" || lh.C8Yclient.Password == "" {

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -243,7 +243,10 @@ func (lh *LoginHandler) sortLoginOptions() {
 		c8y.LoginTypeNone:           40,
 		c8y.LoginTypeBasic:          30,
 		c8y.LoginTypeOAuth2Internal: 20,
-		c8y.LoginTypeOAuth2:         10,
+
+		// reduce priority due to common misconfiguration and
+		// currently only the OAUTH2 Device Flow works and not many users have this setup correctly
+		c8y.LoginTypeOAuth2: 50,
 	}
 
 	if lh.LoginType != "" {

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -105,6 +105,9 @@ type LoginHandler struct {
 	LoginType       string
 	LoginAttempted  bool
 
+	// User defined list of the allowed login types (from their perspective)
+	AllowedLoginTypes []string
+
 	// SSO specific settings
 	SSO config.SSOSettings
 
@@ -258,6 +261,27 @@ func (lh *LoginHandler) sortLoginOptions() {
 		}
 	}
 
+	// Optionally limit the login types based on user settings
+	if len(lh.AllowedLoginTypes) > 0 {
+		// only include the user-given login type
+		lh.Logger.Debugf("Filtering the login options based on a user-defined list. types=%v", lh.AllowedLoginTypes)
+		allowedLoginOptions := make([]c8y.TenantLoginOption, 0, 1)
+		allLoginTypes := make([]string, 0, len(lh.LoginOptions.LoginOptions))
+		matchingTypes := make([]string, 0)
+		for _, loginOption := range lh.LoginOptions.LoginOptions {
+			for _, allowed := range lh.AllowedLoginTypes {
+				allLoginTypes = append(allLoginTypes, loginOption.Type)
+				if strings.EqualFold(loginOption.Type, strings.TrimSpace(allowed)) {
+					allowedLoginOptions = append(allowedLoginOptions, loginOption)
+					matchingTypes = append(matchingTypes, loginOption.Type)
+				}
+			}
+		}
+
+		lh.LoginOptions.LoginOptions = allowedLoginOptions
+		lh.Logger.Infof("Filtered login types. matches=%v. availableOnTenant=%v", matchingTypes, allLoginTypes)
+	}
+
 	// sort login options
 	sort.SliceStable(lh.LoginOptions.LoginOptions, func(i, j int) bool {
 		iWeight := 100
@@ -272,6 +296,14 @@ func (lh *LoginHandler) sortLoginOptions() {
 		}
 		return iWeight < jWeight
 	})
+
+	// log the preference of login types
+	preferenceLoginTypes := make([]string, len(lh.LoginOptions.LoginOptions))
+	for _, option := range lh.LoginOptions.LoginOptions {
+		preferenceLoginTypes = append(preferenceLoginTypes, option.Type)
+	}
+
+	lh.Logger.Infof("Login type preference: %v", preferenceLoginTypes)
 }
 
 func (lh *LoginHandler) init() {
@@ -528,7 +560,7 @@ func (lh *LoginHandler) login() {
 							if strings.Contains(v.Message, `For input string: "undefined"`) {
 								lh.Logger.Infof("OAuth2 most likely requires TFA. %s", v.Message)
 							} else {
-							lh.Logger.Errorf("OAuth2 failed. %s", v.Message)
+								lh.Logger.Errorf("OAuth2 failed. %s", v.Message)
 							}
 						} else {
 							lh.Logger.Errorf("OAuth2 failed. %s", err)

--- a/pkg/c8ylogin/c8ylogin.go
+++ b/pkg/c8ylogin/c8ylogin.go
@@ -488,7 +488,7 @@ func (lh *LoginHandler) login() {
 						continue
 					}
 
-					lh.Logger.Infof("Skipping login type (%s) as SSO login failed. err=%s", option.Type, loginErr)
+					lh.Logger.Warnf("Skipping login type (%s) as SSO login failed. err=%s", option.Type, loginErr)
 					continue
 				}
 

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -552,6 +552,9 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 
 		handler := c8ylogin.NewLoginHandler(n.factory.IOStreams, client, cmd.ErrOrStderr(), func() {})
 		handler.LoginType = loginType
+		if loginType != "" {
+			handler.AllowedLoginTypes = strings.Split(loginType, ",")
+		}
 		handler.SSO.DiscoveryURL = cfg.SSODiscoveryUrl()
 
 		if len(n.SSOScopes) > 0 {

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -287,6 +287,10 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 		providerCommand = append(providerCommand, "-v")
 	}
 
+	if cfg.Debug() {
+		providerCommand = append(providerCommand, "--debug")
+	}
+
 	providerCommand = append(providerCommand, args...)
 	cmd := exec.Command(providerCommand[0], providerCommand[1:]...)
 	cmd.Env = env

--- a/pkg/cmd/sessions/selectsession/selectsession.go
+++ b/pkg/cmd/sessions/selectsession/selectsession.go
@@ -93,6 +93,20 @@ func SelectSession(io *iostreams.IOStreams, cfg *config.Config, log *logger.Logg
 		if info.IsDir() {
 			return nil
 		}
+
+		// check for nested symlinks and only support nested symlinks to files (not folders)
+		if info.Type()&fs.ModeSymlink != 0 {
+			targetInfo, err := os.Stat(path)
+			if err != nil {
+				log.Infof("Ignoring symlink to non-existent path: %+v", path)
+				return nil
+			}
+			if targetInfo.IsDir() {
+				log.Infof("Ignoring nested symlink to a folder (to prevent potential infinite loops): %+v", path)
+				return nil
+			}
+		}
+
 		// skip settings file
 		if strings.HasPrefix(info.Name(), config.SettingsGlobalName+".") ||
 			strings.HasPrefix(info.Name(), ".") {

--- a/pkg/cmd/sessions/set/set.manual.go
+++ b/pkg/cmd/sessions/set/set.manual.go
@@ -237,6 +237,9 @@ func (n *CmdSet) RunE(cmd *cobra.Command, args []string) error {
 		n.onSave(client)
 	})
 	handler.LoginType = n.LoginType
+	if n.LoginType != "" {
+		handler.AllowedLoginTypes = strings.Split(n.LoginType, ",")
+	}
 	handler.SSO.DiscoveryURL = cfg.SSODiscoveryUrl()
 	handler.SSO.Scopes = cfg.SSOScopes()
 	if handler.LoginType == "" {


### PR DESCRIPTION
Fix problems when using `set-session` which broke for multiple users introduced in release v2.53.0.

* Fix problem regarding the fallback login option when iterating through the available types. This means that `--loginType` wouldn't work as expected.
* When using an explicit e.g. `set-session --loginType OAUTH2_INTERNAL` it will enforce this login type and not fall back to other methods.
* Change the priority of OAUTH2 (e.g. external OAUTH2 / SSO) to as most users don't have Device Flow enabled, or misconfigured which was preventing other login types from working
* Increase log levels of the login process to make it easier to debug
* Suppress a known TFA error message and only log it on the INFO level to improve the UX