### PR TITLE
fix(sessions login): respect hosts that use a http scheme

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -871,7 +871,7 @@ func (c *CmdRoot) checkSessionExists(cmd *cobra.Command, args []string) error {
 			if c8ysession.IsSessionFilePath(sessionFile) {
 				log.Warnf("Failed to verify session file. %s", err)
 			} else {
-				log.Warnf("Given file is not a session file. %s", err)
+				log.Infof("Given file is not a session file. %s", err)
 			}
 		} else {
 			log.Infof("Loaded session: %s", cfg.HideSensitiveInformationIfActive(client, sessionFile))

--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -581,7 +581,7 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 		}
 
 		session.Username = handler.C8Yclient.Username
-		session.Host = handler.C8Yclient.BaseURL.Host
+		session.Host = handler.C8Yclient.BaseURL.String()
 
 		// Use the handler selected login type
 		session.LoginType = handler.LoginType

--- a/tests/manual/sessions/login/session_login.yaml
+++ b/tests/manual/sessions/login/session_login.yaml
@@ -51,6 +51,6 @@ tests:
       contains:
         - "✓ Session is now active"
         - ---------------------  Cumulocity Session (sensitive info is hidden)  ---------------------
-        - "host         : {host}"
+        - "{host}"
         - "tenant       : {tenant}"
         - "username     : {username}"


### PR DESCRIPTION
Allow users to specify a http address when calling `c8y sessions login`.

This allows users to use go-c8y-cli against the thin-edge.io local Cumulocity proxy using a single command:

```sh
eval "$(c8y sessions login --from-prompt --loginType NONE --host http://localhost:8001/c8y --mode dev)"
```