### PR TITLE
fix(requestiterator): preserve query parameters in multipart

### DIFF
--- a/pkg/requestiterator/requestiterator.go
+++ b/pkg/requestiterator/requestiterator.go
@@ -3,6 +3,7 @@ package requestiterator
 import (
 	"bytes"
 	"errors"
+	"net/http"
 	"net/url"
 	"os"
 	"reflect"
@@ -194,7 +195,68 @@ func (r *RequestIterator) GetNext() (*c8y.RequestOptions, interface{}, error) {
 			req.Body = v
 		}
 	}
+
+	ensureMultipartQueryPreserved(req)
+
 	return req, inputLine, nil
+}
+
+func ensureMultipartQueryPreserved(req *c8y.RequestOptions) {
+	if req == nil || len(req.FormData) == 0 {
+		return
+	}
+
+	query, ok := req.Query.(string)
+	if !ok || query == "" {
+		return
+	}
+
+	existingPrepareRequest := req.PrepareRequest
+	req.PrepareRequest = func(httpReq *http.Request) (*http.Request, error) {
+		if existingPrepareRequest != nil {
+			var err error
+			httpReq, err = existingPrepareRequest(httpReq)
+			if err != nil {
+				return httpReq, err
+			}
+		}
+
+		if httpReq == nil || httpReq.URL == nil {
+			return httpReq, nil
+		}
+
+		if httpReq.URL.RawQuery == "" {
+			httpReq.URL.RawQuery = query
+			return httpReq, nil
+		}
+
+		baseValues, baseErr := url.ParseQuery(httpReq.URL.RawQuery)
+		addValues, addErr := url.ParseQuery(query)
+		if baseErr != nil || addErr != nil {
+			httpReq.URL.RawQuery = strings.TrimPrefix(httpReq.URL.RawQuery+"&"+query, "&")
+			return httpReq, nil
+		}
+
+		for key, values := range addValues {
+			for _, value := range values {
+				if !valueExists(baseValues[key], value) {
+					baseValues.Add(key, value)
+				}
+			}
+		}
+
+		httpReq.URL.RawQuery = baseValues.Encode()
+		return httpReq, nil
+	}
+}
+
+func valueExists(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func hasUnresolvedVariables(v []byte) bool {

--- a/pkg/requestiterator/requestiterator_test.go
+++ b/pkg/requestiterator/requestiterator_test.go
@@ -1,6 +1,11 @@
 package requestiterator
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/assert"
@@ -58,4 +63,30 @@ func Test_RequestIteratorWithEscapedPathVariables(t *testing.T) {
 	assert.OK(t, err)
 	assert.True(t, req.Path == "foo#bar/sub#other")
 	assert.EqualMarshalJSON(t, req.Body, `{"nested":{"value":"2"}}`)
+}
+
+func Test_RequestIteratorMultipartPreservesQueryParams(t *testing.T) {
+	options := c8y.RequestOptions{
+		Method: http.MethodPost,
+		Path:   "/inventory/binaries",
+		Query:  "name=my-file.txt&description=upload",
+		FormData: map[string]io.Reader{
+			"file": strings.NewReader("demo"),
+		},
+	}
+
+	pathIter := iterator.NewRepeatIterator(options.Path, 1)
+	requestIter := NewRequestIterator(nil, options, pathIter, nil, nil)
+
+	req, _, err := requestIter.GetNext()
+	assert.OK(t, err)
+
+	httpReq := httptest.NewRequest(http.MethodPost, "https://example.com/inventory/binaries", nil)
+	httpReq, err = req.PrepareRequest(httpReq)
+	assert.OK(t, err)
+
+	queryValues, err := url.ParseQuery(httpReq.URL.RawQuery)
+	assert.OK(t, err)
+	assert.Equal(t, queryValues.Get("name"), "my-file.txt")
+	assert.Equal(t, queryValues.Get("description"), "upload")
 }


### PR DESCRIPTION
There was an issue where query-parameters where stripped when sending multipart requests. This is fixed in this pr.


FIXES: #606 