### PR TITLE
fix(configuration): fix incorrect device type filter property. c8y_Filter.type => deviceType

### DIFF
--- a/api/spec/json/configuration.json
+++ b/api/spec/json/configuration.json
@@ -88,7 +88,7 @@
               "name": "deviceType",
               "type": "string",
               "description": "Filter by deviceType",
-              "format": "(c8y_Filter.type eq '%s')"
+              "format": "(deviceType eq '%s')"
             },
             {
               "name": "description",
@@ -194,8 +194,8 @@
           "description": "Device type filter. Only allow configuration to be applied to devices of this type",
           "pipeline": true,
           "pipelineAliases": [
-            "c8y_Filter.type",
             "deviceType",
+            "c8y_Filter.type",
             "type"
           ]
         },

--- a/api/spec/yaml/configuration.yaml
+++ b/api/spec/yaml/configuration.yaml
@@ -71,7 +71,7 @@ commands:
           - name: deviceType
             type: string
             description: Filter by deviceType
-            format: (c8y_Filter.type eq '%s')
+            format: (deviceType eq '%s')
 
           - name: description
             type: string
@@ -154,8 +154,8 @@ commands:
         description: Device type filter. Only allow configuration to be applied to devices of this type
         pipeline: true
         pipelineAliases:
-          - "c8y_Filter.type"
           - "deviceType"
+          - "c8y_Filter.type"
           - "type"
 
       - name: file

--- a/pkg/cmd/configuration/create/create.auto.go
+++ b/pkg/cmd/configuration/create/create.auto.go
@@ -68,7 +68,7 @@ available for multiple device types
 		flags.WithProcessingMode(),
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
-		flags.WithExtendedPipelineSupport("deviceType", "deviceType", false, "c8y_Filter.type", "deviceType", "type"),
+		flags.WithExtendedPipelineSupport("deviceType", "deviceType", false, "deviceType", "c8y_Filter.type", "type"),
 	)
 
 	// Required flags

--- a/pkg/cmd/configuration/list/list.auto.go
+++ b/pkg/cmd/configuration/list/list.auto.go
@@ -116,7 +116,7 @@ func (n *ListCmd) RunE(cmd *cobra.Command, args []string) error {
 				flags.WithStaticStringValue("configuration", "(type eq 'c8y_ConfigurationDump')"),
 				flags.WithStringValue("configurationType", "configurationType", "(configurationType eq '%s')"),
 				flags.WithStringValue("name", "name", "(name eq '%s')"),
-				flags.WithStringValue("deviceType", "deviceType", "(c8y_Filter.type eq '%s')"),
+				flags.WithStringValue("deviceType", "deviceType", "(deviceType eq '%s')"),
 				flags.WithStringValue("description", "description", "(description eq '%s')"),
 			},
 			"query",


### PR DESCRIPTION
Fix the fragment name used on configuration objects (in the configuration repository) used to only apply the configuration to specific device types.

The fragment was incorrectly using `c8y_Filter.type` instead of `deviceType`.