### PR TITLE
fix: print non-json errors as plain text

### DIFF
--- a/pkg/cmderrors/cmderrors.go
+++ b/pkg/cmderrors/cmderrors.go
@@ -274,9 +274,11 @@ func NewServerError(r *c8y.Response, err error, iostream *iostreams.IOStreams, w
 		if v.Response != nil {
 			if json.Valid(v.Response.Body()) {
 				cmdError.CumulocityError = json.RawMessage(v.Response.Body())
-			} else if b, jsonErr := json.Marshal(v.Response.Body()); jsonErr == nil {
-				// handle non json response
-				cmdError.CumulocityError = json.RawMessage(b)
+			} else if strings.Contains(v.Response.Header().Get("Content-Type"), "text") {
+				cmdError.CumulocityError = json.RawMessage(v.Response.Body())
+			} else {
+				// handle non json/non-text response into base64 (which is the default behaviour of json.Marshal for a []byte)
+				cmdError.CumulocityError = json.RawMessage(v.Response.Body())
 			}
 		}
 		cmdError.Message = v.Message

--- a/tests/manual/api/api.yaml
+++ b/tests/manual/api/api.yaml
@@ -276,3 +276,11 @@ tests:
               method: GET
               path: /service/inventory
               host: https://localhost:8080
+
+  It supports returning errors that aren't in json:
+    command: |
+      c8y api -n GET '/path/to/myapi?id=supercoolid' --accept text/html --dry=false
+    exit-code: 4
+    stderr:
+      contains:
+        - <html>

--- a/tests/manual/sessions/sessions_set.yaml
+++ b/tests/manual/sessions/sessions_set.yaml
@@ -5,6 +5,7 @@ config:
     C8Y_SETTINGS_DEFAULTS_CACHE: true
     C8Y_SETTINGS_DEFAULTS_CACHETTL: 100h
     C8Y_SETTINGS_DEFAULTS_DRYFORMAT: json
+    C8Y_SETTINGS_DEFAULTS_PAGESIZE: ''
 
 tests:
   It clears session even if passphrase is invalid:

--- a/tests/run-auto.sh
+++ b/tests/run-auto.sh
@@ -8,6 +8,9 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 pushd "$SCRIPT_DIR"
 
+# Override any defaults which are set
+export C8Y_SETTINGS_DEFAULTS_PAGESIZE=" "
+
 folder=
 if [ $# -gt 0 ]; then
     folder=$1

--- a/tests/run-manual.sh
+++ b/tests/run-manual.sh
@@ -11,6 +11,9 @@ pushd "$SCRIPT_DIR"
 C8Y_SETTINGS_EXTENSIONS_DATADIR="$(pwd)/testdata"
 export C8Y_SETTINGS_EXTENSIONS_DATADIR
 
+# Override any defaults which are set
+export C8Y_SETTINGS_DEFAULTS_PAGESIZE=" "
+
 folder=
 if [ $# -gt 0 ]; then
     folder=$1


### PR DESCRIPTION
Fix a bug where non-json errors were incorrectly being marshalled into base64 (as this is the default behaviour of the json.Marshal function)

**Before**

```
c8y api -n GET '/path/to/myapi?id=supercoolid' --accept text/html

Error Response

"PGh0bWw+DQo8aGVhZD48dGl0bGU+NDA0IE5vdCBGb3VuZDwvdGl0bGU+PC9oZWFkPg0KPGJvZHk+DQo8Y2VudGVyPjxoMT40MDQgTm90IEZvdW5kPC9oMT48L2NlbnRlcj4NCjxocj48Y2VudGVyPm9wZW5yZXN0eTwvY2VudGVyPg0KPC9ib2R5Pg0KPC9odG1sPg0K"
```

**After**

```sh
c8y api -n GET '/path/to/myapi?id=supercoolid' --accept text/html

Error Response

<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>openresty</center>
</body>
</html>
```
