### PR TITLE
feat: support dates combining a fixed date with relative offset

### DIFF
--- a/pkg/timestamp/timestamp.go
+++ b/pkg/timestamp/timestamp.go
@@ -2,6 +2,7 @@ package timestamp
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,7 +62,136 @@ func DecodeC8yTimestamp(value string) string {
 	return strings.ReplaceAll(value, "%2B", "+")
 }
 
+// normalizeOffset combines an outer sign character ('+' or '-') with a raw
+// duration string (which may itself start with '+' or '-') into a single
+// tparse-compatible offset, applying standard sign arithmetic:
+//
+//	outer='+', inner='-' → '-'   outer='-', inner='-' → '+'
+//
+// Spaces within the duration part are also removed.
+func normalizeOffset(outerSign string, durationPart string) string {
+	durationPart = strings.ReplaceAll(strings.TrimSpace(durationPart), " ", "")
+	if strings.HasPrefix(durationPart, "-") || strings.HasPrefix(durationPart, "+") {
+		innerSign := string(durationPart[0])
+		durationPart = durationPart[1:]
+		if outerSign == innerSign {
+			outerSign = "+"
+		} else {
+			outerSign = "-"
+		}
+	}
+	return outerSign + durationPart
+}
+
+// parseQuotedDateWithOffset parses expressions of the form:
+//
+//	'<date>' [+|-] <duration>
+//
+// The date inside single quotes is parsed as an absolute timestamp and the
+// optional trailing offset (e.g. "- 1h", "+2d") is applied with tparse.
+// Returns an error if the value does not start with a single quote or if
+// parsing fails.
+func parseQuotedDateWithOffset(value string) (*time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "'") {
+		return nil, fmt.Errorf("not a quoted date expression")
+	}
+
+	closeIdx := strings.Index(trimmed[1:], "'")
+	if closeIdx == -1 {
+		return nil, fmt.Errorf("unclosed single quote in date expression")
+	}
+	closeIdx++ // make relative to trimmed
+
+	dateStr := trimmed[1:closeIdx]
+	remainder := strings.TrimSpace(trimmed[closeIdx+1:])
+
+	baseTime, err := dateparse.ParseAny(dateStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid date %q: %w", dateStr, err)
+	}
+
+	if remainder == "" {
+		return &baseTime, nil
+	}
+
+	if !strings.HasPrefix(remainder, "+") && !strings.HasPrefix(remainder, "-") {
+		return nil, fmt.Errorf("expected +/- offset after quoted date, got: %s", remainder)
+	}
+
+	// Normalise "- 1h 30m" / "+ -1d" → tparse-compatible offset
+	offset := normalizeOffset(string(remainder[0]), remainder[1:])
+
+	result, err := GetTimestampUsingOffset(baseTime, offset)
+	if err != nil {
+		return nil, fmt.Errorf("invalid offset %q: %w", offset, err)
+	}
+	return result, nil
+}
+
+// parseUnixTimestampWithOffset parses expressions of the form:
+//
+//	<unix_seconds> +|- <duration>
+//
+// e.g. "1773403680 + 1h", "1773403680 -30m"
+// A bare integer with no offset is intentionally not handled here so that
+// values like YYYYMMDD fall through to dateparse unchanged.
+func parseUnixTimestampWithOffset(value string) (*time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+
+	// Scan leading digits
+	end := 0
+	for end < len(trimmed) && trimmed[end] >= '0' && trimmed[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return nil, fmt.Errorf("not a unix timestamp expression")
+	}
+
+	remainder := strings.TrimSpace(trimmed[end:])
+
+	// Require an explicit +/- offset — bare integers fall through to existing handling
+	if remainder == "" || (!strings.HasPrefix(remainder, "+") && !strings.HasPrefix(remainder, "-")) {
+		return nil, fmt.Errorf("not a unix timestamp with offset expression")
+	}
+
+	unixSec, err := strconv.ParseInt(trimmed[:end], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid unix timestamp %q: %w", trimmed[:end], err)
+	}
+
+	baseTime := time.Unix(unixSec, 0).UTC()
+
+	// Normalise "- 1h 30m" / "+ -1d" → tparse-compatible offset
+	offset := normalizeOffset(string(remainder[0]), remainder[1:])
+
+	result, err := GetTimestampUsingOffset(baseTime, offset)
+	if err != nil {
+		return nil, fmt.Errorf("invalid offset %q: %w", offset, err)
+	}
+	return result, nil
+}
+
 func TryGetTimestamp(value string, encode bool, utc bool) (string, error) {
+	// Try parsing quoted date with optional relative offset, e.g. '2025-03-03T12:00:00+01:00' - 1h
+	if ts, err := parseQuotedDateWithOffset(value); err == nil {
+		if utc {
+			return FormatC8yTimestamp(ts.UTC(), encode), nil
+		}
+		return FormatC8yTimestamp(*ts, encode), nil
+	} else if strings.HasPrefix(strings.TrimSpace(value), "'") {
+		// Value looks like a quoted expression but failed to parse — surface the error
+		return "", err
+	}
+
+	// Try parsing unix timestamp with offset, e.g. 1773403680 + 1h
+	if ts, err := parseUnixTimestampWithOffset(value); err == nil {
+		if utc {
+			return FormatC8yTimestamp(ts.UTC(), encode), nil
+		}
+		return FormatC8yTimestamp(*ts, encode), nil
+	}
+
 	// Try parsing relative timestamp
 	if ts, err := ParseDurationRelativeToNow(value); err == nil {
 		if utc {
@@ -86,6 +216,18 @@ func TryGetTimestamp(value string, encode bool, utc bool) (string, error) {
 }
 
 func TryGetDate(value string, encode bool, layout string) (string, error) {
+	// Try parsing quoted date with optional relative offset
+	if ts, err := parseQuotedDateWithOffset(value); err == nil {
+		return FormatC8yDate(*ts, encode, layout), nil
+	} else if strings.HasPrefix(strings.TrimSpace(value), "'") {
+		return "", err
+	}
+
+	// Try parsing unix timestamp with offset, e.g. 1773403680 + 1h
+	if ts, err := parseUnixTimestampWithOffset(value); err == nil {
+		return FormatC8yDate(*ts, encode, layout), nil
+	}
+
 	// Try parsing relative date
 	if ts, err := ParseDurationRelativeToNow(value); err == nil {
 		return FormatC8yDate(*ts, encode, layout), nil
@@ -105,6 +247,21 @@ func TryGetDate(value string, encode bool, layout string) (string, error) {
 
 // ParseTimestamp parse a time stamp (accepts both relative and full timestamps)
 func ParseTimestamp(value string) (ts time.Time, err error) {
+	// Try parsing quoted date with optional relative offset
+	if result, parseErr := parseQuotedDateWithOffset(value); parseErr == nil {
+		ts = *result
+		return
+	} else if strings.HasPrefix(strings.TrimSpace(value), "'") {
+		err = parseErr
+		return
+	}
+
+	// Try parsing unix timestamp with offset, e.g. 1773403680 + 1h
+	if result, parseErr := parseUnixTimestampWithOffset(value); parseErr == nil {
+		ts = *result
+		return
+	}
+
 	// Try parsing relative timestamp
 	timestamp, err := ParseDurationRelativeToNow(value)
 

--- a/pkg/timestamp/timestamp_test.go
+++ b/pkg/timestamp/timestamp_test.go
@@ -2,6 +2,9 @@ package timestamp
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInvalidDates(t *testing.T) {
@@ -14,5 +17,126 @@ func TestInvalidDates(t *testing.T) {
 
 	if timestamp != nil {
 		t.Errorf("Timestamp should be nil. got=%v", timestamp)
+	}
+}
+
+func TestMixingDatesWithRelativeTimeOffsets(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "subtract 1 hour with spaces around operator",
+			input: "'2025-03-03T12:11:22.675221+01:00' - 1h",
+			want:  "2025-03-03T11:11:22.675221+01:00",
+		},
+		{
+			// date-only input has no timezone, so dateparse treats it as UTC midnight
+			name:  "date-only string subtract 1 hour",
+			input: "'2025-03-03' - 1h",
+			want:  "2025-03-02T23:00:00Z",
+		},
+		{
+			name:  "add 1 hour with spaces around operator",
+			input: "'2025-03-03T12:11:22.675221+01:00' + 1h",
+			want:  "2025-03-03T13:11:22.675221+01:00",
+		},
+		{
+			name:  "subtract 1 hour without spaces",
+			input: "'2025-03-03T12:11:22.675221+01:00' -1h",
+			want:  "2025-03-03T11:11:22.675221+01:00",
+		},
+		{
+			name:  "add 1 hour without spaces",
+			input: "'2025-03-03T12:11:22.675221+01:00' +1h",
+			want:  "2025-03-03T13:11:22.675221+01:00",
+		},
+		{
+			name:  "add 1 day",
+			input: "'2025-03-03T12:11:22.675221+01:00' + 1d",
+			want:  "2025-03-04T12:11:22.675221+01:00",
+		},
+		{
+			name:  "subtract combined duration hours and minutes",
+			input: "'2025-03-03T12:11:22.675221+01:00' - 1h30m",
+			want:  "2025-03-03T10:41:22.675221+01:00",
+		},
+		{
+			name:  "quoted date with no offset",
+			input: "'2025-03-03T12:11:22.675221+01:00'",
+			want:  "2025-03-03T12:11:22.675221+01:00",
+		},
+		{
+			name:  "quoted date with UTC timezone",
+			input: "'2025-06-15T00:00:00Z' + 2h",
+			want:  "2025-06-15T02:00:00Z",
+		},
+		{
+			name:  "quoted date subtract crossing midnight",
+			input: "'2025-03-03T01:00:00+01:00' - 2h",
+			want:  "2025-03-02T23:00:00+01:00",
+		},
+		{
+			name:    "invalid date inside quotes",
+			input:   "'not-a-date' + 1h",
+			wantErr: true,
+		},
+		{
+			name:    "invalid offset after valid date",
+			input:   "'2025-03-03T12:11:22.675221+01:00' * 1h",
+			wantErr: true,
+		},
+		{
+			// Unix timestamp (seconds since epoch) + offset; base is always UTC
+			name:  "unix timestamp add 1 hour",
+			input: "1773403680 + 1h",
+			want:  time.Unix(1773403680, 0).UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		},
+		{
+			name:  "unix timestamp subtract 30 minutes",
+			input: "1773403680 - 30m",
+			want:  time.Unix(1773403680, 0).UTC().Add(-30 * time.Minute).Format(time.RFC3339Nano),
+		},
+		{
+			name:  "unix timestamp add 1 hour no spaces",
+			input: "1773403680+1h",
+			want:  time.Unix(1773403680, 0).UTC().Add(time.Hour).Format(time.RFC3339Nano),
+		},
+		{
+			// "+ -1d" is mathematically equivalent to "- 1d"
+			name:  "unix timestamp plus negative duration",
+			input: "1773403680 + -1d",
+			want:  time.Unix(1773403680, 0).UTC().Add(-24 * time.Hour).Format(time.RFC3339Nano),
+		},
+		{
+			// "- -1d" is mathematically equivalent to "+ 1d"
+			name:  "unix timestamp minus negative duration",
+			input: "1773403680 - -1d",
+			want:  time.Unix(1773403680, 0).UTC().Add(24 * time.Hour).Format(time.RFC3339Nano),
+		},
+		{
+			name:  "quoted date plus negative duration",
+			input: "'2025-03-03T12:00:00Z' + -1h",
+			want:  "2025-03-03T11:00:00Z",
+		},
+		{
+			name:  "quoted date minus negative duration",
+			input: "'2025-03-03T12:00:00Z' - -1h",
+			want:  "2025-03-03T13:00:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := TryGetTimestamp(tt.input, false, false)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Extend the relative date/time parsing to support users providing a fixed timestamp and then apply the offsets to it.

**Examples**

```sh
# minus 10 days before a given data
c8y events list --dateFrom "'2025-02-19T00:00:00' - 10d" --dry

# relative epoch dates
c8y events list --dateFrom "1773417365 - 6h" --dry

# set dateFrom and dateTo (though you can set a unix timestamp or a date string)
TIME="1773417365"
c8y measurements list --dateFrom "'$TIME' - 6h" --dateTo "'$TIME' + 6h" --dry
```

Resolves https://github.com/reubenmiller/go-c8y-cli/issues/622