### PR TITLE
ci: update test-examples job to skip dependabot PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,10 +86,10 @@ jobs:
   test-examples:
     runs-on: ${{ matrix.os }}
     needs: [build]
-    # Skip for fork PRs — those lack secrets access and must use the "/test"
-    # slash command instead (see slash-command-dispatch.yml).
+    # Skip for fork PRs and dependabot PRs — those lack secrets access and must
+    # use the "/test" slash command instead (see slash-command-dispatch.yml).
     # PRs from branches within this repo run normally with secrets.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]')
     env:
       C8Y_HOST: ${{ secrets.C8Y_HOST }}
       C8Y_TENANT: ${{ secrets.C8Y_TENANT }}


### PR DESCRIPTION
Dependabot PRs don't have the permission to access secrets, so the PR based checks should be skipped.