### PR TITLE
docs: update docs for release 2.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,56 @@ See the following installation instructions
 * [PowerShell](https://goc8ycli.netlify.app/docs/installation/powershell-installation)
 
 
+## Testing an unreleased version
+
+These instructions are for testing a version that has not yet been officially released, for example directly from a pull request or a specific commit. Go >= 1.25 must be installed on your machine.
+
+### Install
+
+1. Install `c8y` from a specific commit (replace the commit hash with the one you want to test)
+
+    ```sh
+    go install github.com/reubenmiller/go-c8y-cli/v2/cmd/c8y@<commit-or-branch>
+    ```
+
+    For example, to install from a specific commit:
+
+    ```sh
+    go install github.com/reubenmiller/go-c8y-cli/v2/cmd/c8y@7aace7646dfcb7c2a632da85e869daf99c749b90
+    ```
+
+2. Make sure the Go binary path is on your `PATH` and takes precedence over any existing `c8y` installation
+
+    ```sh
+    export PATH="$(go env GOPATH)/bin:$PATH"
+    hash -r
+    ```
+
+3. Verify the binary is the expected version
+
+    ```sh
+    c8y version
+    ```
+
+4. Try it out (note: tab completion won't work when using the `set-session` helper)
+
+    ```sh
+    # Option 1: Use an explicit host (no session file required)
+    eval "$(c8y sessions login --from-prompt --host example.cumulocity.com)"
+
+    # To enable verbose/debug output, add the -v flag
+    c8y currentuser get -v
+    ```
+
+### Uninstall
+
+To remove the dev binary and restore the previously installed version:
+
+```sh
+rm "$(go env GOPATH)/bin/c8y"
+hash -r
+```
+
 ## Documentation
 
 See the [documentation website](https://goc8ycli.netlify.app/) for instructions on how to install and use it.

--- a/docs/go-c8y-cli/docs/cli/c8y/alarms/assert/c8y_alarms_assert_count.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/alarms/assert/c8y_alarms_assert_count.md
@@ -40,6 +40,7 @@ $ c8y devices list | c8y alarms assert count --maximum 0 --dateFrom -7d
 ### Options
 
 ```
+      --attempts int          Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --dateFrom string       Start date or date and time of alarm occurrence.
       --dateTo string         End date or date and time of alarm occurrence.
       --device strings        The ManagedObject which is the source of this event. (accepts pipeline)
@@ -50,7 +51,6 @@ $ c8y devices list | c8y alarms assert count --maximum 0 --dateFrom -7d
       --maximum int           Maximum alarm count (inclusive). A value of -1 will disable this check (default -1)
       --minimum int           Minimum alarm count (inclusive). A value of -1 will disable this check (default -1)
       --resolved              When set to true only resolved alarms will be removed (the one with status CLEARED), false means alarms with status ACTIVE or ACKNOWLEDGED.
-      --retries int           Number of retries before giving up per id
       --severity string       Alarm severity, for example CRITICAL, MAJOR, MINOR or WARNING.
       --status string         Comma separated alarm statuses, for example ACTIVE,CLEARED.
       --strict                Strict mode, fail if no match is found
@@ -99,6 +99,7 @@ $ c8y devices list | c8y alarms assert count --maximum 0 --dateFrom -7d
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/devices/assert/c8y_devices_assert_exists.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/devices/assert/c8y_devices_assert_exists.md
@@ -42,12 +42,12 @@ $ echo 1 | c8y devices assert exists --strict
 ### Options
 
 ```
+      --attempts int      Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --device strings    The ManagedObject which is the source of this event. (accepts pipeline)
       --duration string   Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
   -h, --help              help for exists
       --interval string   Interval to check on the status, i.e. 10s or 1min (default "5s")
       --not               Negate the match
-      --retries int       Number of retries before giving up per id
       --strict            Strict mode, fail if no match is found
 ```
 
@@ -93,6 +93,7 @@ $ echo 1 | c8y devices assert exists --strict
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/devices/assert/c8y_devices_assert_fragments.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/devices/assert/c8y_devices_assert_fragments.md
@@ -38,12 +38,12 @@ $ c8y devices list --device 1111 | c8y operations fragments --status "FAILED" --
 ### Options
 
 ```
+      --attempts int        Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --device strings      The ManagedObject which is the source of this event. (accepts pipeline)
       --duration string     Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
       --fragments strings   Fragments to fragments for. If multiple values are given, then it will be applied as an OR operation
   -h, --help                help for fragments
       --interval string     Interval to check on the status, i.e. 10s or 1min (default "5s")
-      --retries int         Number of retries before giving up per id
       --strict              Strict mode, fail if no match is found
 ```
 
@@ -89,6 +89,7 @@ $ c8y devices list --device 1111 | c8y operations fragments --status "FAILED" --
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/inventory/assert/c8y_inventory_assert_exists.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/inventory/assert/c8y_inventory_assert_exists.md
@@ -42,12 +42,12 @@ $ echo 1 | c8y inventory assert exists --strict
 ### Options
 
 ```
+      --attempts int      Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --duration string   Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
   -h, --help              help for exists
       --id strings        Inventory id (required) (accepts pipeline)
       --interval string   Interval to check on the status, i.e. 10s or 1min (default "5s")
       --not               Negate the match
-      --retries int       Number of retries before giving up per id
       --strict            Strict mode, fail if no match is found
 ```
 
@@ -93,6 +93,7 @@ $ echo 1 | c8y inventory assert exists --strict
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/inventory/assert/c8y_inventory_assert_fragments.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/inventory/assert/c8y_inventory_assert_fragments.md
@@ -38,12 +38,12 @@ $ c8y inventory list --device 1111 | c8y operations fragments --status "FAILED" 
 ### Options
 
 ```
+      --attempts int        Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --duration string     Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
       --fragments strings   Fragments to fragments for. If multiple values are given, then it will be applied as an OR operation
   -h, --help                help for fragments
       --id strings          Inventory id (required) (accepts pipeline)
       --interval string     Interval to check on the status, i.e. 10s or 1min (default "5s")
-      --retries int         Number of retries before giving up per id
       --strict              Strict mode, fail if no match is found
 ```
 
@@ -89,6 +89,7 @@ $ c8y inventory list --device 1111 | c8y operations fragments --status "FAILED" 
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/measurements/assert/c8y_measurements_assert_count.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/measurements/assert/c8y_measurements_assert_count.md
@@ -40,6 +40,7 @@ $ c8y devices list | c8y measurements assert count --maximum 0 --dateFrom -7d
 ### Options
 
 ```
+      --attempts int                 Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --dateFrom string              Start date or date and time of measurement occurrence.
       --dateTo string                End date or date and time of measurement occurrence.
       --device strings               The ManagedObject which is the source of this event. (accepts pipeline)
@@ -48,7 +49,6 @@ $ c8y devices list | c8y measurements assert count --maximum 0 --dateFrom -7d
       --interval string              Interval to check on the status, i.e. 10s or 1min (default "5s")
       --maximum int                  Maximum measurement count (inclusive). A value of -1 will disable this check (default -1)
       --minimum int                  Minimum measurement count (inclusive). A value of -1 will disable this check (default -1)
-      --retries int                  Number of retries before giving up per id
       --strict                       Strict mode, fail if no match is found
       --type string                  Measurement type.
       --valueFragmentSeries string   value fragment series
@@ -97,6 +97,7 @@ $ c8y devices list | c8y measurements assert count --maximum 0 --dateFrom -7d
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/operations/assert/c8y_operations_assert_count.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/operations/assert/c8y_operations_assert_count.md
@@ -40,6 +40,7 @@ $ c8y devices list | c8y operations assert count --maximum 0 --dateFrom -7d
 ### Options
 
 ```
+      --attempts int             Number of attempts before giving up per id (-1 = unlimited) (default -1)
       --bulkOperationId string   Bulk operation id. Only retrieve operations related to the given bulk operation.
       --dateFrom string          Start date or date and time of operation.
       --dateTo string            End date or date and time of operation.
@@ -50,7 +51,6 @@ $ c8y devices list | c8y operations assert count --maximum 0 --dateFrom -7d
       --interval string          Interval to check on the status, i.e. 10s or 1min (default "5s")
       --maximum int              Maximum operation count (inclusive). A value of -1 will disable this check (default -1)
       --minimum int              Minimum operation count (inclusive). A value of -1 will disable this check (default -1)
-      --retries int              Number of retries before giving up per id
       --status string            Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING.
       --strict                   Strict mode, fail if no match is found
 ```
@@ -97,6 +97,7 @@ $ c8y devices list | c8y operations assert count --maximum 0 --dateFrom -7d
       --progress                   Show progress bar. This will also disable any other verbose output
       --proxy string               Proxy setting, i.e. http://10.0.0.1:8080
   -r, --raw                        Show raw response. This mode will force output=json and view=off
+      --retries int                Max number of attempts when a failed http call is encountered (default 3)
       --select stringArray         Comma separated list of properties to return. wildcards and globstar accepted, i.e. --select 'id,name,type,**.serialNumber'
       --session string             Session configuration
       --sessionMode string         Override default session mode for a single command which would normally be disabled

--- a/docs/go-c8y-cli/docs/cli/c8y/scripts/_category_.json
+++ b/docs/go-c8y-cli/docs/cli/c8y/scripts/_category_.json
@@ -1,0 +1,1 @@
+{"key": "c8y-scripts", "label": "scripts"}

--- a/docs/go-c8y-cli/docs/cli/c8y/scripts/c8y_scripts.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/scripts/c8y_scripts.md
@@ -1,57 +1,17 @@
 ---
-category: assert
-title: c8y events assert count
+category: scripts
+title: c8y scripts
 ---
-Assert event count
+Script utilities
 
 ### Synopsis
 
-Assert that a device has a specific amount of events and pass the input untouched
-
-If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
-This is useful if you want to filter a list of devices by whether by a specific entity count, and use the results
-in some downstream command (in the pipeline)
-
-By default, a failed assertion will not set the exit code to a non-zero value. If you want a non-zero exit code
-in such as case then use the --strict option.
-
-
-```
-c8y events assert count [flags]
-```
-
-### Examples
-
-```
-$ c8y events assert count --device 1234 --minimum 1
-# => 1234 (if the ID exists)
-# => <no response> (if the ID does not exist)
-# Assert that a device exists, and has at least 1 event
-
-$ c8y events assert count --device 1234 --minimum 5 --maximum 10 --dateFrom -1d --strict
-# Assert that the device with id=1111 should have between 5 and 10 events (inclusive) in the last day
-# Return an error if not
-
-$ c8y devices list | c8y events assert count --maximum 0 --dateFrom -7d
-# Find a list of devices which have not created any events in the last 7 days
-
-```
+Utilities for processing and formatting shell scripts
 
 ### Options
 
 ```
-      --attempts int          Number of attempts before giving up per id (-1 = unlimited) (default -1)
-      --dateFrom string       Start date or date and time of event occurrence.
-      --dateTo string         End date or date and time of event occurrence.
-      --device strings        The ManagedObject which is the source of this event. (accepts pipeline)
-      --duration string       Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
-      --fragmentType string   Fragment name from event.
-  -h, --help                  help for count
-      --interval string       Interval to check on the status, i.e. 10s or 1min (default "5s")
-      --maximum int           Maximum event count (inclusive). A value of -1 will disable this check (default -1)
-      --minimum int           Minimum event count (inclusive). A value of -1 will disable this check (default -1)
-      --strict                Strict mode, fail if no match is found
-      --type string           Event type.
+  -h, --help   help for scripts
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/scripts/c8y_scripts_format.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/scripts/c8y_scripts_format.md
@@ -1,57 +1,35 @@
 ---
-category: assert
-title: c8y events assert count
+category: scripts
+title: c8y scripts format
 ---
-Assert event count
+Format shell scripts
 
 ### Synopsis
 
-Assert that a device has a specific amount of events and pass the input untouched
-
-If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
-This is useful if you want to filter a list of devices by whether by a specific entity count, and use the results
-in some downstream command (in the pipeline)
-
-By default, a failed assertion will not set the exit code to a non-zero value. If you want a non-zero exit code
-in such as case then use the --strict option.
-
+Format shell scripts by adjusting -n flags for c8y commands
 
 ```
-c8y events assert count [flags]
+c8y scripts format [flags]
 ```
 
 ### Examples
 
 ```
-$ c8y events assert count --device 1234 --minimum 1
-# => 1234 (if the ID exists)
-# => <no response> (if the ID does not exist)
-# Assert that a device exists, and has at least 1 event
-
-$ c8y events assert count --device 1234 --minimum 5 --maximum 10 --dateFrom -1d --strict
-# Assert that the device with id=1111 should have between 5 and 10 events (inclusive) in the last day
-# Return an error if not
-
-$ c8y devices list | c8y events assert count --maximum 0 --dateFrom -7d
-# Find a list of devices which have not created any events in the last 7 days
+$ c8y scripts format script.sh
+$ c8y scripts format --in-place script.sh
+$ c8y scripts format --add-comment --indent 4 script.sh
 
 ```
 
 ### Options
 
 ```
-      --attempts int          Number of attempts before giving up per id (-1 = unlimited) (default -1)
-      --dateFrom string       Start date or date and time of event occurrence.
-      --dateTo string         End date or date and time of event occurrence.
-      --device strings        The ManagedObject which is the source of this event. (accepts pipeline)
-      --duration string       Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
-      --fragmentType string   Fragment name from event.
-  -h, --help                  help for count
-      --interval string       Interval to check on the status, i.e. 10s or 1min (default "5s")
-      --maximum int           Maximum event count (inclusive). A value of -1 will disable this check (default -1)
-      --minimum int           Minimum event count (inclusive). A value of -1 will disable this check (default -1)
-      --strict                Strict mode, fail if no match is found
-      --type string           Event type.
+      --add-comment         Add a comment block at the top explaining the script modifications
+      --backup              Create backup files before in-place modification
+  -h, --help                help for format
+  -i, --in-place            Modify files in place (implies --verify-idempotent)
+      --indent int          Number of spaces to use for indentation. If 0, then tabs will be used
+      --verify-idempotent   Verify that the transformation is idempotent
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_clone.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_clone.md
@@ -32,8 +32,8 @@ Clone the existing session and rename it to "dev-otheruser" and change the sessi
 ```
       --fileType string   Session file type to save as. i.e. json, yaml, toml etc. (default "json")
   -h, --help              help for clone
+      --mode string       Session mode which controls which commands are enabled by default
       --newName string    Name of the new session file which will be created (required)
-      --type string       Session type of the cloned session, i.e. dev, qual, prod
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_create.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_create.md
@@ -15,45 +15,54 @@ c8y sessions create [flags]
 ### Examples
 
 ```
-### Example 1: Create a DEV new session. Prompt for username and password
-
-$ c8y sessions create --type dev --host "https://mytenant.eu-latest.cumulocity.com"
-
-### Example 2: Create a new QA (QUAL) session prompting for password
+$ c8y sessions create --mode dev --host "https://mytenant.eu-latest.cumulocity.com"
+Example 1: Create a DEV new session. Prompt for username and password
 
 $ c8y sessions create \
-    --type qual \
+    --mode qual \
 	--host "https://mytenant.eu-latest.cumulocity.com"
 	--username "myUser@me.com"
+Create a new QA (QUAL) session prompting for password
 
-### Example 3: Create a new production session where only only GET commands are enabled (with no password storage)
+$ c8y sessions create --mode prod --host "https://mytenant.eu-latest.cumulocity.com" --noStorage
+Create a new production session where only only GET commands are enabled (with no password storage)
 
-$ c8y sessions create --type prod --host "https://mytenant.eu-latest.cumulocity.com" --noStorage
+$ c8y sessions create --mode prod --host "https://localhost:443" --insecure
+Create a session which points to a local api endpoint (most like an Cumulocity Edge instance)
 
-### Example 4: Create a session which points to a local api endpoint (most like an Cumulocity Edge instance)
+$ c8y sessions create --mode dev --host example.cumulocity.com --loginType BROWSER
+Create a session which uses SSO / OAUTH2 using Authorization Flow (via a local web browser)
+Note: Requires the "Redirect to the user interface application" to be enabled in Cumulocity
 
-$ c8y sessions create --type prod --host "https://localhost:443" --insecure
+c8y sessions create --mode dev --host example.cumulocity.com --loginType BROWSER --browserCallback localhost:8008/mycallback
+Create a session which uses SSO / OAUTH2 using Authorization Flow (via a local web browser)
+and define an explicit redirect/callback URI which is whitelisted in the SSO providers configuration
+Note: Requires the "Redirect to the user interface application" to be enabled in Cumulocity
+
+$ c8y sessions create --mode dev --host example.cumulocity.com --loginType DEVICE
+Create a session with SSO / OAUTH2 Device Flow (RFC 8628)
 		
 ```
 
 ### Options
 
 ```
-      --allowInsecure        Allow insecure connection (e.g. when using self-signed certificates)
-      --description string   Description about the session
-      --encrypt              Encrypt passwords and tokens (occurs when logging in)
-  -h, --help                 help for create
-      --host string          Host. .e.g. test.cumulocity.com. (required)
-      --loginType string     Login Type, e.g. BASIC, OAUTH2_INTERNAL, NONE
-      --mode string          Session mode which controls which commands are enabled by default
-      --name string          Name of the session
-      --noStorage            Don't store any passwords or tokens in the session file
-      --noTenantPrefix       Don't use tenant name as a prefix to the user name when using Basic Authentication. Defaults to false
-      --password string      Password. If left blank then you will be prompted for the password
-      --prompt               Force prompting of missing information
-      --tenant string        Tenant ID
-      --token string         Token
-      --username string      Username (without tenant). (required)
+      --allowInsecure            Allow insecure connection (e.g. when using self-signed certificates)
+      --browserCallback string   Custom redirect URI for the browser authorization code flow, e.g. http://127.0.0.1:8080/callback
+      --description string       Description about the session
+      --encrypt                  Encrypt passwords and tokens (occurs when logging in)
+  -h, --help                     help for create
+      --host string              Host. .e.g. test.cumulocity.com. (required)
+      --loginType string         Login Type, e.g. BASIC, OAUTH2_INTERNAL, OAUTH2, BROWSER, DEVICE, CERTIFICATE, NONE
+      --mode string              Session mode which controls which commands are enabled by default
+      --name string              Name of the session
+      --noStorage                Don't store any passwords or tokens in the session file
+      --noTenantPrefix           Don't use tenant name as a prefix to the user name when using Basic Authentication. Defaults to false
+      --password string          Password. If left blank then you will be prompted for the password
+      --prompt                   Force prompting of missing information
+      --tenant string            Tenant ID
+      --token string             Token
+      --username string          Username (without tenant). (required)
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_login.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_login.md
@@ -32,30 +32,43 @@ Set a session from an external command, where the external commands returns the 
 
 $ eval "$( c8y sessions login --from-prompt --host example.cumulocity.com)"
 
+$ eval "$( c8y sessions login --from-file .env --loginType DEVICE )"
+Login using the OAuth2 device flow (polls for approval after visiting the URL shown in the terminal)
+
+$ eval "$( c8y sessions login --from-file .env --loginType BROWSER )"
+Login using Authorization Code flow – opens the system browser and waits for the callback
+
+$ eval "$( c8y sessions login --from-file .env --loginType BROWSER --browserCallback http://127.0.0.1:8080/callback )"
+Login via browser with a custom callback URL registered in the SSO provider
+
+$ eval "$( c8y sessions login --from-file .env --loginType CERTIFICATE )"
+Login using a device certificate (mTLS); reads cert paths from the session file or C8Y_CERTIFICATE / C8Y_CERTIFICATE_KEY env vars
+
 ```
 
 ### Options
 
 ```
-      --clear                  Clear any existing tokens
-      --format string          External command format, e.g. json, yaml, toml
-      --from-cmd string        External command to execute to get the log in details
-      --from-env               Read from environment variables
-      --from-file string       Read session from a file
-      --from-prompt            Read from user prompted input
-      --from-stdin             Read from standard input
-  -h, --help                   help for login
-      --host string            Cumulocity host. Only used with the 'interactive' provider
-      --loginType string       Login type preference, e.g. OAUTH2_INTERNAL, OAUTH2 (device flow) or BASIC. When set to BASIC, any existing token will be cleared
-      --mode string            Session mode which controls which commands are allowed, e.g. dev, qual or prod
-      --no-banner              Don't show the session banner
-      --output-format string   Output format
-      --provider string        Session provider which returns the session to use
-      --secrets strings        List of secrets to include as env variables when running an external command. Only valid with from-cmd
-      --shell string           Shell type to return the environment variables
-      --sso-audience string    SSO Audience
-      --sso-scopes string      SSO Scopes
-      --tfaCode string         Two Factor Authentication code
+      --browserCallback string   Custom redirect URI for the browser flow local callback server, e.g. http://127.0.0.1:8080/callback. Must match a URI registered in the SSO provider. Defaults to http://127.0.0.1:5001/callback
+      --clear                    Clear any existing tokens
+      --format string            External command format, e.g. json, yaml, toml
+      --from-cmd string          External command to execute to get the log in details
+      --from-env                 Read from environment variables
+      --from-file string         Read session from a file
+      --from-prompt              Read from user prompted input
+      --from-stdin               Read from standard input
+  -h, --help                     help for login
+      --host string              Cumulocity host. Only used with the 'interactive' provider
+      --loginType string         Login type preference, e.g. OAUTH2_INTERNAL, DEVICE (device flow), BROWSER (Authorization Code via browser), BASIC or CERTIFICATE (mTLS). OAUTH2 is a legacy alias for DEVICE. When set to BASIC, any existing token will be cleared
+      --mode string              Session mode which controls which commands are allowed, e.g. dev, qual or prod
+      --no-banner                Don't show the session banner
+      --output-format string     Output format
+      --provider string          Session provider which returns the session to use
+      --secrets strings          List of secrets to include as env variables when running an external command. Only valid with from-cmd
+      --shell string             Shell type to return the environment variables
+      --sso-audience string      SSO Audience
+      --sso-scopes string        SSO Scopes
+      --tfaCode string           Two Factor Authentication code
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_set.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/sessions/c8y_sessions_set.md
@@ -24,18 +24,31 @@ Set a session but only include session matching company AND dev
 $ eval $( c8y sessions set --session myfile.json --tfaCode 123456 )
 Set a session using a given file (non-interactively)
 
+$ eval $( c8y sessions set --session myfile.json --loginType DEVICE )
+Login using the OAuth2 device flow (polls for approval after visiting the URL shown in the terminal)
+
+$ eval $( c8y sessions set --session myfile.json --loginType BROWSER )
+Login using Authorization Code flow – opens the system browser and waits for the callback
+
+$ eval $( c8y sessions set --session myfile.json --loginType BROWSER --browserCallback http://127.0.0.1:8080/callback )
+Login via browser with a custom callback URL registered in the SSO provider
+
+$ eval $( c8y sessions set --session myfile.json --loginType CERTIFICATE )
+Login using a device certificate (mTLS); reads cert paths from the session file or C8Y_CERTIFICATE / C8Y_CERTIFICATE_KEY env vars
+
 ```
 
 ### Options
 
 ```
-      --clear                  Clear any existing tokens
-  -h, --help                   help for set
-      --loginType string       Login type preference, e.g. OAUTH2_INTERNAL, OAUTH2 (device flow) or BASIC. When set to BASIC, any existing token will be cleared
-      --no-banner              Don't show the session banner
-      --sessionFilter string   Filter to be applied to the list of sessions even before the values can be selected
-      --shell string           Shell type to return the environment variables
-      --tfaCode string         Two Factor Authentication code
+      --browserCallback string   Custom redirect URI for the browser flow local callback server, e.g. http://127.0.0.1:8080/callback. Must match a URI registered in the SSO provider. Defaults to http://127.0.0.1:5001/callback
+      --clear                    Clear any existing tokens
+  -h, --help                     help for set
+      --loginType string         Login type preference, e.g. OAUTH2_INTERNAL, DEVICE (device flow), BROWSER (Authorization Code via browser), BASIC or CERTIFICATE (mTLS). OAUTH2 is a legacy alias for DEVICE. When set to BASIC, any existing token will be cleared
+      --no-banner                Don't show the session banner
+      --sessionFilter string     Filter to be applied to the list of sessions even before the values can be selected
+      --shell string             Shell type to return the environment variables
+      --tfaCode string           Two Factor Authentication code
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/tenants/assert/_category_.json
+++ b/docs/go-c8y-cli/docs/cli/c8y/tenants/assert/_category_.json
@@ -1,0 +1,1 @@
+{"key": "c8y-tenants-assert", "label": "assert"}

--- a/docs/go-c8y-cli/docs/cli/c8y/tenants/assert/c8y_tenants_assert.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/tenants/assert/c8y_tenants_assert.md
@@ -1,57 +1,17 @@
 ---
 category: assert
-title: c8y events assert count
+title: c8y tenants assert
 ---
-Assert event count
+Cumulocity tenant assertions
 
 ### Synopsis
 
-Assert that a device has a specific amount of events and pass the input untouched
-
-If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
-This is useful if you want to filter a list of devices by whether by a specific entity count, and use the results
-in some downstream command (in the pipeline)
-
-By default, a failed assertion will not set the exit code to a non-zero value. If you want a non-zero exit code
-in such as case then use the --strict option.
-
-
-```
-c8y events assert count [flags]
-```
-
-### Examples
-
-```
-$ c8y events assert count --device 1234 --minimum 1
-# => 1234 (if the ID exists)
-# => <no response> (if the ID does not exist)
-# Assert that a device exists, and has at least 1 event
-
-$ c8y events assert count --device 1234 --minimum 5 --maximum 10 --dateFrom -1d --strict
-# Assert that the device with id=1111 should have between 5 and 10 events (inclusive) in the last day
-# Return an error if not
-
-$ c8y devices list | c8y events assert count --maximum 0 --dateFrom -7d
-# Find a list of devices which have not created any events in the last 7 days
-
-```
+Assertions for Cumulocity tenants
 
 ### Options
 
 ```
-      --attempts int          Number of attempts before giving up per id (-1 = unlimited) (default -1)
-      --dateFrom string       Start date or date and time of event occurrence.
-      --dateTo string         End date or date and time of event occurrence.
-      --device strings        The ManagedObject which is the source of this event. (accepts pipeline)
-      --duration string       Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
-      --fragmentType string   Fragment name from event.
-  -h, --help                  help for count
-      --interval string       Interval to check on the status, i.e. 10s or 1min (default "5s")
-      --maximum int           Maximum event count (inclusive). A value of -1 will disable this check (default -1)
-      --minimum int           Minimum event count (inclusive). A value of -1 will disable this check (default -1)
-      --strict                Strict mode, fail if no match is found
-      --type string           Event type.
+  -h, --help   help for assert
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/c8y/tenants/assert/c8y_tenants_assert_exists.md
+++ b/docs/go-c8y-cli/docs/cli/c8y/tenants/assert/c8y_tenants_assert_exists.md
@@ -1,15 +1,15 @@
 ---
 category: assert
-title: c8y events assert count
+title: c8y tenants assert exists
 ---
-Assert event count
+Assert existence of a tenant
 
 ### Synopsis
 
-Assert that a device has a specific amount of events and pass the input untouched
+Assert that a tenant exists or not and pass input untouched
 
 If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
-This is useful if you want to filter a list of devices by whether by a specific entity count, and use the results
+This is useful if you want to filter a list of tenants by whether they exist or not in the platform, and use the results
 in some downstream command (in the pipeline)
 
 By default, a failed assertion will not set the exit code to a non-zero value. If you want a non-zero exit code
@@ -17,41 +17,38 @@ in such as case then use the --strict option.
 
 
 ```
-c8y events assert count [flags]
+c8y tenants assert exists [flags]
 ```
 
 ### Examples
 
 ```
-$ c8y events assert count --device 1234 --minimum 1
-# => 1234 (if the ID exists)
-# => <no response> (if the ID does not exist)
-# Assert that a device exists, and has at least 1 event
+$ c8y tenants assert exists --tenant t12345
+# => t12345 (if the tenant exists)
+# => <no response> (if the tenant does not exist)
+# Assert the tenant exists
 
-$ c8y events assert count --device 1234 --minimum 5 --maximum 10 --dateFrom -1d --strict
-# Assert that the device with id=1111 should have between 5 and 10 events (inclusive) in the last day
-# Return an error if not
+$ echo "t12345" | c8y tenants assert exists
+# Pass the piped input only on if the tenant exists
 
-$ c8y devices list | c8y events assert count --maximum 0 --dateFrom -7d
-# Find a list of devices which have not created any events in the last 7 days
+$ echo -e "t11111\nt22222" | c8y tenants assert exists --not
+# Only select the tenant ids which do not exist
+
+$ echo t12345 | c8y tenants assert exists --strict
+# Return non-zero exit code if tenant t12345 does not exist
 
 ```
 
 ### Options
 
 ```
-      --attempts int          Number of attempts before giving up per id (-1 = unlimited) (default -1)
-      --dateFrom string       Start date or date and time of event occurrence.
-      --dateTo string         End date or date and time of event occurrence.
-      --device strings        The ManagedObject which is the source of this event. (accepts pipeline)
-      --duration string       Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
-      --fragmentType string   Fragment name from event.
-  -h, --help                  help for count
-      --interval string       Interval to check on the status, i.e. 10s or 1min (default "5s")
-      --maximum int           Maximum event count (inclusive). A value of -1 will disable this check (default -1)
-      --minimum int           Minimum event count (inclusive). A value of -1 will disable this check (default -1)
-      --strict                Strict mode, fail if no match is found
-      --type string           Event type.
+      --attempts int      Number of attempts before giving up per id (-1 = unlimited) (default -1)
+      --duration string   Timeout duration. i.e. 30s or 1m (1 minute) (default "30s")
+  -h, --help              help for exists
+      --interval string   Interval to check on the status, i.e. 10s or 1min (default "5s")
+      --not               Negate the match
+      --strict            Strict mode, fail if no match is found
+      --tenant strings    Tenant id (accepts pipeline)
 ```
 
 ### Options inherited from parent commands

--- a/docs/go-c8y-cli/docs/cli/psc8y/Sessions/New-Session.md
+++ b/docs/go-c8y-cli/docs/cli/psc8y/Sessions/New-Session.md
@@ -24,7 +24,9 @@ New-Session
 	[[-Password] <Object>]
 	[[-Name] <String>]
 	[[-Mode] <String>]
+	[[-LoginType] <String>]
 	[[-Description] <String>]
+	[[-BrowserCallback] <String>]
 	[-NoTenantPrefix]
 	[-AllowInsecure]
 	[<CommonParameters>]
@@ -145,6 +147,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -LoginType
+LoginType.
+Login Type, e.g.
+BASIC, OAUTH2_INTERNAL, OAUTH2, BROWSER, DEVICE, CERTIFICATE, NONE
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Description
 Description
 
@@ -154,7 +173,23 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BrowserCallback
+Custom redirect URI for the browser authorization code flow, e.g.
+http://127.0.0.1:8080/callback
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/go-c8y-cli/docs/concepts/sessions.md
+++ b/docs/go-c8y-cli/docs/concepts/sessions.md
@@ -8,7 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeExample from '@site/src/components/CodeExample';
 
-A session holds the current Cumulocity settings and authentication to use for each command. For example, as session will contain the Cumulocity platform address, tenant, username and password. All of these settings are required in order to send REST requests to the platform.
+A session holds the current Cumulocity settings and authentication to use for each command. For example, as session will contain the Cumulocity platform address, tenant, and authorization (which depends on the login type). All of these settings are required in order to send REST requests to the platform.
 
 To use a session, you must first "activate" it, which will then start the "login" process where it uses the given session details and checks what login actions are required. For instance, if you have Two-Factor-Authentication (TFA) enabled, then you'll be prompted for your TFA code.
 
@@ -22,15 +22,10 @@ The session activate process is fairly complex due to the number of different lo
 
 The output of a successfully activate session is a set of environment variables that need to be set on the shell. Due to OS security restrictions, no subprocess (**c8y** in this can) can modify environment variables of the parent process (the **shell**), so instead shell helper function is required to evaluate the output of the session activation which in turn sets the required environment variables. The main motivation for using environment variables is to also allow other Cumulocity tooling to be able to access the required session information to run their own requests without having to know anything about session files and decryption etc.
 
-:::caution
-SSO (Single Sign On) is not currently supported due to a security mechanism on the platform side which makes any cli implementation impossible.
+:::tip
+SSO users can authenticate via the browser-based **Authorization Code** flow (`--loginType BROWSER`) or the headless **Device Authorization** flow (`--loginType DEVICE`). See [Create a session with SSO](#create-a-session-with-sso) below.
 
-If you are an SSO user, then you will have to do one of the following before you can use go-c8y-cli:
-
-* Create a dedicated local user in Cumulocity (via the Administration -> Users page)
-* Create a service user via the Application User interface (though only for advanced users whom already have a username/password, see the [example](../../cli/c8y/microservices/serviceusers/c8y_microservices_serviceusers_create/#examples))
-
-If you are using a local Cumulocity user, it recommended that you use TFA (Two-Factor Authentication) and use the "OAI-Secure" preferred login mode, which enables the usage of tokens (e.g. Bearer Authorization header), all of which is supported out of the box by go-c8y-cli.
+If you need a non-SSO account, you can create a dedicated local user in Cumulocity (Administration → Users) or a [service user](../../cli/c8y/microservices/serviceusers/c8y_microservices_serviceusers_create/#examples).
 :::
 
 ## Create a new session
@@ -81,6 +76,78 @@ Alternatively you can allow insecure mode (i.e. disable SSL verification) for a 
 
 ```bash
 c8y devices list --insecure
+```
+
+</CodeExample>
+
+## Create a session - SSO (Single Sign On) / OAUTH2 {#create-a-session-with-sso}
+
+go-c8y-cli supports two OAuth2-based SSO flows that don't require a username or password to be stored in the session file. The login type is selected with the `--loginType` flag and is saved in the session file so that subsequent `set-session` calls use the same flow automatically.
+
+### Browser Authorization Code Flow
+
+The **BROWSER** login type opens the system browser at the tenant's SSO authorization URL, starts a local callback server, and waits for the redirect. This is the most user-friendly option on a desktop.
+
+:::tip
+For the Browser Authorization Code Flow to work, the following is **required**:
+
+* The Cumulocity tenant must have **"Redirect to the user interface application"** enabled in its SSO configuration.
+* Your SSO provider (Keycloak, Azure AD, Auth0 etc.) must allow a redirect uri which matches the server that go-c8y-cli will create. By default this is `http://localhost:5001/callback` (but it can be customized via the **browserCallback** flag.)
+:::
+
+<CodeExample>
+
+```bash
+c8y sessions create \
+  --host "https://example.cumulocity.com" \
+  --loginType BROWSER
+```
+
+</CodeExample>
+
+If your SSO provider can't whitelist the default HTTP callback address, then you can customize the browser callback path when creating the session:
+
+<CodeExample>
+
+```bash
+c8y sessions create \
+  --host "https://example.cumulocity.com" \
+  --loginType BROWSER \
+  --browserCallback "http://127.0.0.1:8080/callback"
+```
+
+</CodeExample>
+
+### Device Authorization Flow
+
+The **DEVICE** login type (RFC 8628) is suited for headless environments or cases where a browser cannot open automatically. The CLI prints a URL and a short code; the user visits the URL in any browser to approve the login while the CLI polls for the result.
+
+<CodeExample>
+
+```bash
+c8y sessions create \
+  --host "https://example.cumulocity.com" \
+  --loginType DEVICE
+```
+
+</CodeExample>
+
+Once the session file is created, activating it will trigger the device flow automatically:
+
+<CodeExample transform="true">
+
+```bash
+set-session example.cumulocity.com
+```
+
+</CodeExample>
+
+You can also force the device flow at activation time for any existing session:
+
+<CodeExample transform="true">
+
+```bash
+set-session example.cumulocity.com --loginType DEVICE
 ```
 
 </CodeExample>
@@ -200,15 +267,33 @@ All of the values in the sessions file, can also be overridden using environment
 
 ### Continuous Integration usage (environment variables)
 
-Alternatively, the Cumulocity session can be controlled purely by environment variables.
+Alternatively, the Cumulocity session can be controlled purely by environment variables. This is the recommended approach for CI pipelines (GitHub Actions, GitLab CI, etc.).
 
-Then the Cumulocity settings can be set by the following environment variables.
+The Cumulocity settings can be set by the following environment variables.
 
-* `C8Y_HOST` (example "https://cumulocity.com")
-* `C8Y_TENANT` (example "myTenant")
-* `C8Y_USER`
-* `C8Y_PASSWORD`
-* `CI`
+| Variable | Description |
+|---|---|
+| `C8Y_HOST` | Host URL (e.g. `https://cumulocity.com`); also accepted as `C8Y_URL` or `C8Y_BASEURL` |
+| `C8Y_TENANT` | Tenant ID (e.g. `myTenant`) |
+| `C8Y_USER` | Username; also accepted as `C8Y_USERNAME` |
+| `C8Y_PASSWORD` | Password |
+| `C8Y_TOKEN` | Pre-obtained bearer token (skips the login step) |
+| `C8Y_SETTINGS_LOGIN_TYPE` | Override the login type (e.g. `BASIC`, `OAUTH2_INTERNAL`, `DEVICE`, `BROWSER`, `CERTIFICATE`) |
+| `C8Y_CERTIFICATE` | Path to a PEM-encoded client certificate for mTLS authentication |
+| `C8Y_CERTIFICATE_KEY` | Path to the corresponding PEM-encoded private key |
+| `C8Y_MODE` | Session mode (`dev`, `qual`, `prod`, `ci`) |
+
+Then load the session from the environment:
+
+<CodeExample>
+
+```bash
+eval "$( c8y sessions login --from-env )"
+```
+
+</CodeExample>
+
+If `C8Y_CERTIFICATE` is set and no `C8Y_SETTINGS_LOGIN_TYPE` is provided, the CLI automatically selects the `CERTIFICATE` login type.
 
 
 ### Switching sessions for a single command
@@ -317,7 +402,7 @@ c8y inventory create --name hello --sessionMode dev
 
 ## Using encryption in Cumulocity session files
 
-Encrypted password and cookies fields can be activated by adding the following fragment into the session file or your global `settings.json` file.
+By default, **go-c8y-cli** encrypts sensitive information when writing it to file. You can control whether encryption is used by either setting the following setting in the session file, or in the or the global `settings.json` file.
 
 ```json
 {
@@ -329,7 +414,7 @@ Encrypted password and cookies fields can be activated by adding the following f
 }
 ```
 
-When enabled the "password", and "authorization.cookies" fields will be encrypted using a passphrase chosen by the user.
+When enabled the sensitive information will be encrypted using a passphrase chosen by the user.
 The passphrase should be something that is sufficiently complex and should not be stored on disk.
 
 When the user sets the passphrase, a key file will be created within the Cumulocity session home folder, `.key`. This file will be used as a reference when comparing your passphrase to keep the passphrase constant across different sessions.

--- a/docs/go-c8y-cli/docs/getting-started-shell.md
+++ b/docs/go-c8y-cli/docs/getting-started-shell.md
@@ -9,15 +9,10 @@ import CodeExample from '@site/src/components/CodeExample';
 
 Before you can send any requests to Cumulocity you need to configure the Cumulocity session which has the details which Cumulocity platform and authentication should be used for each of the commands/requests. This process only needs to be done once.
 
-:::caution
-SSO (Single Sign On) is not currently supported due to a security mechanism on the platform side which makes any cli implementation impossible.
+:::tip
+SSO users can authenticate via the browser-based **Authorization Code** flow (`--loginType BROWSER`) or the headless **Device Authorization** flow (`--loginType DEVICE`). See [Creating a session with SSO](#creating-a-session-with-sso) below.
 
-If you are an SSO user, then you will have to do one of the following before you can use go-c8y-cli:
-
-* Create a dedicated local user in Cumulocity (via the Administration -> Users page)
-* Create a service user via the Application User interface (though only for advanced users whom already have a username/password, see the [example](../cli/c8y/microservices/serviceusers/c8y_microservices_serviceusers_create/#examples))
-
-If you are using a local Cumulocity user, it recommended that you use TFA (Two-Factor Authentication) and use the "OAI-Secure" preferred login mode, which enables the usage of tokens (e.g. Bearer Authorization header), all of which is supported out of the box by go-c8y-cli.
+If you need a non-SSO account, you can create a dedicated local user in Cumulocity (Administration → Users) or a [service user](../cli/c8y/microservices/serviceusers/c8y_microservices_serviceusers_create/#examples).
 :::
 
 ## Basics
@@ -35,6 +30,40 @@ c8y sessions create
 </CodeExample>
 
 You will be prompted the session information including url, username and password. Alternatively, you can provide any of the settings via flags.
+
+### Creating a session with SSO
+
+go-c8y-cli supports two OAuth2-based SSO flows that don't require a username or password to be stored in the session file. The login type is saved in the session file so subsequent `set-session` calls use the same flow automatically.
+
+**Browser Authorization Code Flow** — opens a browser at the tenant's SSO URL and waits for the redirect. Best for desktop use.
+
+:::tip
+The following is required for the Browser flow:
+* The Cumulocity tenant must have **"Redirect to the user interface application"** enabled in its SSO configuration.
+* Your SSO provider must allow the redirect URI `http://localhost:5001/callback` (customizable via `--browserCallback`).
+:::
+
+<CodeExample>
+
+```bash
+c8y sessions create \
+  --host "https://example.cumulocity.com" \
+  --loginType BROWSER
+```
+
+</CodeExample>
+
+**Device Authorization Flow** — suited for headless environments. The CLI prints a URL and a short code; visit the URL in any browser to approve the login while the CLI polls for the result.
+
+<CodeExample>
+
+```bash
+c8y sessions create \
+  --host "https://example.cumulocity.com" \
+  --loginType DEVICE
+```
+
+</CodeExample>
 
 ### Activating a session (interactive)
 

--- a/docs/go-c8y-cli/docusaurus.config.js
+++ b/docs/go-c8y-cli/docusaurus.config.js
@@ -210,7 +210,7 @@ const baseUrl = `${process.env.BASE_URL || '/'}`;
     announcementBar: {
       id: 'extensions',
       content:
-        '📦 go-c8y-cli now supports extensions. Install the latest version (>=2.30.0) and check out the concepts page 🚀',
+        '📦 go-c8y-cli now supports SSO via Authorization Code and Device Flows. Install the latest version (>=2.54.0) and have a read of the sessions concept page 🚀',
     },
     navbar: {
       title: 'go-c8y-cli',


### PR DESCRIPTION
Update the cli man pages and include updated docs to include notes about how to use the SSO login.

Testing it out:

1. Install the unreleased version using [these instructions](https://github.com/reubenmiller/go-c8y-cli/blob/7f8221ac99698ae11474f6df072f19da81bd061b/README.md#testing-an-unreleased-version).

2. Create a new session for a tenant that you want to interact with using SSO

    ```sh
    # create a session and opt into the new SSO Browser (Authorization Code) Flow
    c8y sessions create \
      --host "https://example.cumulocity.com" \
      --loginType BROWSER
    ```

3. Then activate it the session

    ```sh
    # activate that session by selecting it from the list
    set-session
    ```

    Alternatively, if you don't want to do step 2 (as your session file already exists), then you can just specify the `--loginType BROWSER` when setting a session (but you don't get tab completion):

    ```sh
    set-session --loginType BROWSER
    ```

