### PR TITLE
fix(assert): rename retries to attempts in the inventory/devices assert exists command

### DIFF
--- a/pkg/cmd/devices/assert/factory/factory.manual.go
+++ b/pkg/cmd/devices/assert/factory/factory.manual.go
@@ -26,7 +26,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 	cmd.Flags().StringSlice("id", []string{""}, "Inventory id (required) (accepts pipeline)")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
-	cmd.Flags().Int64("retries", 0, "Number of retries before giving up per id")
+	cmd.Flags().Int64("attempts", -1, "Number of attempts before giving up per id (-1 = unlimited)")
 	cmd.Flags().Bool("strict", false, "Strict mode, fail if no match is found")
 	flags.WithOptions(
 		cmd,
@@ -63,7 +63,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			return err
 		}
 
-		retries, err := cmd.Flags().GetInt64("retries")
+		attempts, err := cmd.Flags().GetInt64("attempts")
 		if err != nil {
 			return err
 		}
@@ -102,7 +102,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			}
 
 			_ = state.SetValue(itemID)
-			result, err := desiredstate.WaitForWithRetries(retries, interval, duration, state)
+			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
 
 			if err == nil {
 				outValue := h.GetValue(result, input)
@@ -129,7 +129,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject which is the source of this event. (accepts pipeline)")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
-	cmd.Flags().Int64("retries", 0, "Number of retries before giving up per id")
+	cmd.Flags().Int64("attempts", -1, "Number of attempts before giving up per id (-1 = unlimited)")
 	cmd.Flags().Bool("strict", false, "Strict mode, fail if no match is found")
 	flags.WithOptions(
 		cmd,
@@ -173,7 +173,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			return err
 		}
 
-		retries, err := cmd.Flags().GetInt64("retries")
+		attempts, err := cmd.Flags().GetInt64("attempts")
 		if err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			}
 
 			_ = state.SetValue(itemID)
-			result, err := desiredstate.WaitForWithRetries(retries, interval, duration, state)
+			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
 
 			if err == nil {
 				outValue := h.GetValue(result, input)

--- a/pkg/cmd/inventory/assert/factory/factory.manual.go
+++ b/pkg/cmd/inventory/assert/factory/factory.manual.go
@@ -25,7 +25,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 	cmd.Flags().StringSlice("id", []string{""}, "Inventory id (required) (accepts pipeline)")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
-	cmd.Flags().Int64("retries", 0, "Number of retries before giving up per id")
+	cmd.Flags().Int64("attempts", -1, "Number of attempts before giving up per id (-1 = unlimited)")
 	cmd.Flags().Bool("strict", false, "Strict mode, fail if no match is found")
 	flags.WithOptions(
 		cmd,
@@ -62,7 +62,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			return err
 		}
 
-		retries, err := cmd.Flags().GetInt64("retries")
+		attempts, err := cmd.Flags().GetInt64("attempts")
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			if inputErr == nil {
 				// Skip checking if the input has errors
 				_ = state.SetValue(itemID)
-				result, err = desiredstate.WaitForWithRetries(retries, interval, duration, state)
+				result, err = desiredstate.WaitForWithRetries(attempts, interval, duration, state)
 				if err == nil {
 					outValue := h.GetValue(result, input)
 					_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
@@ -138,7 +138,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 	cmd.Flags().StringSlice("device", []string{""}, "The ManagedObject which is the source of this event. (accepts pipeline)")
 	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
 	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
-	cmd.Flags().Int64("retries", 0, "Number of retries before giving up per id")
+	cmd.Flags().Int64("attempts", -1, "Number of attempts before giving up per id (-1 = unlimited)")
 	cmd.Flags().Bool("strict", false, "Strict mode, fail if no match is found")
 	flags.WithOptions(
 		cmd,
@@ -182,7 +182,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			return err
 		}
 
-		retries, err := cmd.Flags().GetInt64("retries")
+		attempts, err := cmd.Flags().GetInt64("attempts")
 		if err != nil {
 			return err
 		}
@@ -225,7 +225,7 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			if inputErr == nil {
 				// Skip checking if the input has errors
 				_ = state.SetValue(itemID)
-				result, err = desiredstate.WaitForWithRetries(retries, interval, duration, state)
+				result, err = desiredstate.WaitForWithRetries(attempts, interval, duration, state)
 				if err == nil {
 					outValue := h.GetValue(result, input)
 					_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})

--- a/pkg/desiredstate/desiredstate.go
+++ b/pkg/desiredstate/desiredstate.go
@@ -57,10 +57,15 @@ func wait(retries int64, interval time.Duration, timeout time.Duration, predicat
 	}()
 
 	var lastValue interface{}
+	var lastCheckErr error
 	for {
 		select {
 		case <-timeoutCh:
-			return lastValue, cmderrors.NewUserErrorWithExitCode(cmderrors.ExitTimeout, fmt.Sprintf("Timeout after %v", timeout))
+			msg := fmt.Sprintf("Timeout after %v", timeout)
+			if lastCheckErr != nil {
+				msg = fmt.Sprintf("%s: %s", msg, lastCheckErr)
+			}
+			return lastValue, cmderrors.NewUserErrorWithExitCode(cmderrors.ExitTimeout, msg)
 
 		case msg := <-valueCh:
 			attemptCounter++
@@ -71,11 +76,14 @@ func wait(retries int64, interval time.Duration, timeout time.Duration, predicat
 				lastValue = msg
 			}
 			done, err := predicate.Check(msg)
+			if err != nil {
+				lastCheckErr = err
+			}
 			if done {
 				return msg, err
 			}
 
-			if retries >= 0 && attemptCounter > retries {
+			if retries >= 0 && attemptCounter >= retries {
 				// wrappedErr := fmt.Errorf("Max retries exceeded")
 				// if err != nil {
 				// 	wrappedErr = fmt.Errorf("%s: %w", wrappedErr, err)

--- a/tests/manual/alarms/assert/count/001_assert.sh
+++ b/tests/manual/alarms/assert/count/001_assert.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
 # set -eou pipefail
 
-mo_id=$( c8y devices create --name "device_with_alarms" --select id --output csv )
+NAME=$(c8y template execute -n --template "'device_with_alarms' + _.Char(10)")
+mo_id=$( c8y devices create -n -f --name "$NAME" --select id --output csv )
 cleanup () {
-    c8y inventory delete --id $mo_id > /dev/null 2>&1 || true
+    c8y inventory delete -n -f --id "$mo_id" > /dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 # case 1: Strict assertion
-c8y alarms assert count --device $mo_id --minimum 1 --strict
+c8y alarms assert count --device "$mo_id" --minimum 1 --strict --attempts 1 --interval 1s
 if [[ $? -ne 112 ]]; then
     exit 1
 fi
 
-c8y alarms assert count --device $mo_id --minimum 1
+c8y alarms assert count --device "$mo_id" --minimum 1 --attempts 1 --interval 1s
 if [[ $? -ne 0 ]]; then
     exit 2
 fi
 
-echo "$mo_id" | c8y alarms create --type c8y_TestAlarm --time "-0s" --text "Test alarm" --severity MAJOR
+echo "$mo_id" | c8y alarms create -f --type c8y_TestAlarm --time "-0s" --text "Test alarm" --severity MAJOR
 
 # case 2
-echo "$mo_id" | c8y alarms assert count --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y alarms assert count --minimum 1 --attempts 1 --interval 1s | grep "^${mo_id}$"
 
 # case 3: Filter by type
-echo "$mo_id" | c8y alarms assert count --type c8y_TestAlarm --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y alarms assert count --type c8y_TestAlarm --minimum 1 --attempts 1 --interval 1s | grep "^${mo_id}$"

--- a/tests/manual/devices/assert/exists/devices_assert_exists.yaml
+++ b/tests/manual/devices/assert/exists/devices_assert_exists.yaml
@@ -1,21 +1,21 @@
 tests:
     It filters a single id that does not exist:
-        command:  c8y devices assert exists --not --device 1
+        command:  c8y devices assert exists --not --device 1 --attempts 1 --interval 1s
         exit-code: 0
         stdout:
             exactly: '1'
     
     It fails the negated assertion when using dry mode:
-        command:  c8y devices assert exists --not --device 1 --strict --dry
+        command:  c8y devices assert exists --not --device 1 --strict --dry --attempts 1 --interval 1s
         exit-code: 112
     
     It fails the assertion when using dry mode:
-        command:  c8y devices assert exists --device 1 --strict --dry
+        command:  c8y devices assert exists --device 1 --strict --dry --attempts 1 --interval 1s
         exit-code: 112
 
     It accepts multiple ids using comma separated values:
         command: |
-            c8y inventory assert exists --id 1,2 --strict --dry --dryFormat json \
+            c8y inventory assert exists --id 1,2 --strict  --attempts 1 --interval 1s --dry --dryFormat json \
             | c8y util show --select path
         exit-code: 0
         stderr:
@@ -30,17 +30,17 @@ tests:
                 ..1.path: /inventory/managedObjects/2
 
     It filters a single id that does not exist (using pipeline):
-        command: echo "1" | c8y devices assert exists --not
+        command: echo "1" | c8y devices assert exists --not  --attempts 1 --interval 1s
         exit-code: 0
         stdout:
             exactly: '1'
     
     It returns an error when a single id does not exist (single entry):
-        command: echo "1" | c8y devices assert exists --strict
+        command: echo "1" | c8y devices assert exists --strict --attempts 1 --interval 1s
         exit-code: 112
     
     It filters multiple ids given in a list:
-        command: echo "1\n2" | c8y devices assert exists --not
+        command: echo "1\n2" | c8y devices assert exists --not  --attempts 1 --interval 1s
         exit-code: 0
         stdout:
             line-count: 2
@@ -50,7 +50,7 @@ tests:
 
     It filters a list of json objects:
         command: >
-          echo "{\"id\":\"1\"}" | c8y devices assert exists --not
+          echo "{\"id\":\"1\"}" | c8y devices assert exists --not  --attempts 1 --interval 1s
         exit-code: 0
         stdout:
             json:
@@ -66,17 +66,17 @@ tests:
     
     It checks if a managed object exists, and then uses a downstream command to safely get a value:
         command: >
-          echo "1" | c8y devices assert exists | c8y inventory get
+          echo "1" | c8y devices assert exists  --attempts 1 --interval 1s | c8y inventory get
         exit-code: 0
 
     It fails if an object exists but was expecting to not exist:
         command: >
-          c8y inventory list --pageSize 1 | c8y devices assert exists --not --strict
+          c8y inventory list --pageSize 1 | c8y devices assert exists --not --strict  --attempts 1 --interval 1s
         exit-code: 112
 
     It does not write to stderr when not using strict mode:
         command: >
-          echo "0" | c8y devices assert exists
+          echo "0" | c8y devices assert exists --attempts 1 --interval 1s
         exit-code: 0
         stderr:
             not-contains:
@@ -84,7 +84,7 @@ tests:
     
     It writes errors to stderr when using strict mode:
         command: >
-          echo "0" | c8y devices assert exists --strict
+          echo "0" | c8y devices assert exists --strict  --attempts 1 --interval 1s
         exit-code: 112
         stderr:
             line-count: 1

--- a/tests/manual/devices/assert/fragments/devices_assert_fragments.yaml
+++ b/tests/manual/devices/assert/fragments/devices_assert_fragments.yaml
@@ -5,7 +5,7 @@ tests:
 
     It accepts multiple ids using comma separated values:
         command: |
-            c8y devices assert fragments --device 1,2 --fragments name --strict --dry --dryFormat json \
+            c8y devices assert fragments --device 1,2 --fragments name --strict --attempts 1 --interval 1s --dry --dryFormat json \
             | c8y util show --select path
         exit-code: 0
         stderr:

--- a/tests/manual/events/assert/count/001_assert.sh
+++ b/tests/manual/events/assert/count/001_assert.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
 # set -eou pipefail
 
-mo_id=$( c8y devices create --name "device_with_events" --select id --output csv )
+NAME=$(c8y template execute -n --template "'device_with_events' + _.Char(10)")
+mo_id=$( c8y devices create -f --name "$NAME" --select id --output csv )
 cleanup () {
-    c8y inventory delete --id $mo_id > /dev/null 2>&1 || true
+    c8y inventory delete -n -f --id "$mo_id" > /dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 # case 1: Strict assertion
-c8y events assert count --device $mo_id --minimum 1 --strict
+c8y events assert count --device "$mo_id" --minimum 1 --strict --attempts 2 --interval 1s
 if [[ $? -ne 112 ]]; then
     exit 1
 fi
 
-c8y events assert count --device $mo_id --minimum 1
+c8y events assert count --device "$mo_id" --minimum 1 --attempts 2 --interval 1s
 if [[ $? -ne 0 ]]; then
     exit 2
 fi
 
-echo "$mo_id" | c8y events create --type c8y_TestEvent --time "-0s" --text "Test alarm"
+echo "$mo_id" | c8y events create -f --type c8y_TestEvent --time "-0s" --text "Test alarm"
 
 # case 2
-echo "$mo_id" | c8y events assert count --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y events assert count --minimum 1 --attempts 2 --interval 1s | grep "^${mo_id}$"
 
 # case 3: Filter by type
-echo "$mo_id" | c8y events assert count --type c8y_TestEvent --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y events assert count --type c8y_TestEvent --minimum 1 --attempts 2 --interval 1s | grep "^${mo_id}$"

--- a/tests/manual/inventory/assert/exists/002_assert.sh
+++ b/tests/manual/inventory/assert/exists/002_assert.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-set -eou pipefail
+set -exou pipefail
 
 mo_id=$( c8y inventory create -n --select id --output csv )
 cleanup () {
-    c8y inventory delete --id $mo_id > /dev/null 2>&1 || true
+    c8y inventory delete -f -n --id $mo_id > /dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 echo -e "$mo_id" | c8y inventory assert exists --strict
-echo -e "1\n$mo_id" | c8y inventory assert exists --strict
+echo -e "1\n$mo_id" | c8y inventory assert exists --strict --attempts 1 --interval 1s --duration 5s

--- a/tests/manual/inventory/assert/exists/003_assert.sh
+++ b/tests/manual/inventory/assert/exists/003_assert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Regression test: assert exists --not --duration should poll until timeout
+# when the managed object exists, not return immediately.
+set -eou pipefail
+
+DURATION=5
+TOLERANCE=2
+
+mo_id=$( c8y inventory create -f -n --select id --output csv )
+cleanup () {
+    c8y inventory delete -f --id "$mo_id" > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+start=$(date +%s)
+
+# The managed object exists, so --not can never be satisfied.
+# The command should poll for the full duration before giving up.
+c8y inventory assert exists --not --id "$mo_id" --duration "${DURATION}s" --interval 1s --strict || true
+
+elapsed=$(( $(date +%s) - start ))
+
+if [[ $elapsed -lt $(( DURATION - TOLERANCE )) ]]; then
+    echo "FAIL: command returned after ${elapsed}s, expected at least $(( DURATION - TOLERANCE ))s" >&2
+    exit 1
+fi

--- a/tests/manual/inventory/assert/exists/inventory_assert_exists.yaml
+++ b/tests/manual/inventory/assert/exists/inventory_assert_exists.yaml
@@ -6,16 +6,16 @@ tests:
             exactly: '1'
     
     It fails the negated assertion when using dry mode:
-        command:  c8y inventory assert exists --not --id 1 --strict --dry
+        command:  c8y inventory assert exists --not --id 1 --strict --dry --duration 1s
         exit-code: 112
     
     It fails the assertion when using dry mode:
-        command:  c8y inventory assert exists --id 1 --strict --dry
+        command:  c8y inventory assert exists --id 1 --strict --dry --attempts 1 --interval 1s
         exit-code: 112
 
     It accepts multiple ids using comma separated values:
         command: |
-            c8y inventory assert exists --id 1,2 --strict --dry --dryFormat json \
+            c8y inventory assert exists --id 1,2 --strict --dry --dryFormat json --attempts 1 --duration 1s \
             | c8y util show --select path
         exit-code: 0
         stderr:
@@ -36,7 +36,7 @@ tests:
             exactly: '1'
     
     It returns an error when a single id does not exist (single entry):
-        command: echo "1" | c8y inventory assert exists --strict
+        command: echo "1" | c8y inventory assert exists --strict --attempts 1 --duration 2s
         exit-code: 112
     
     It filters multiple ids given in a list:
@@ -66,27 +66,34 @@ tests:
     
     It checks if a managed object exists, and then uses a downstream command to safely get a value:
         command: >
-          echo "1" | c8y inventory assert exists | c8y inventory get
+          echo "1" | c8y inventory assert exists --attempts 1 --interval 1s | c8y inventory get
         exit-code: 0
 
     It fails if an object exists but was expecting to not exist:
         command: >
-          c8y inventory list --pageSize 1 | c8y inventory assert exists --not --strict
+          c8y inventory list --pageSize 1 | c8y inventory assert exists --not --strict --attempts 1
         exit-code: 112
 
     It does not write to stderr when not using strict mode:
         command: >
-          echo "0" | c8y inventory assert exists
+          echo "0" | c8y inventory assert exists --attempts 1 --attempts 1 --interval 1s
         exit-code: 0
         stderr:
             not-contains:
                 - assertionError
+
+    It waits for the full duration when using --not on an existing object:
+        command: manual/inventory/assert/exists/003_assert.sh
+        exit-code: 0
+        stderr:
+            contains:
+                - "Timeout after 5s: assertionError: managedObject"
     
     It writes errors to stderr when using strict mode:
         command: >
-          echo "0" | c8y inventory assert exists --strict
+          echo "0" | c8y inventory assert exists --strict --attempts 1 --interval 1s
         exit-code: 112
         stderr:
             line-count: 1
             contains:
-                - 'assertionError: managedObject - wanted: Found, got: NotFound, context'
+                - 'assertionError: managedObject - wanted: Found, got: NotFound'

--- a/tests/manual/inventory/assert/fragments/inventory_assert_fragments.yaml
+++ b/tests/manual/inventory/assert/fragments/inventory_assert_fragments.yaml
@@ -14,7 +14,7 @@ tests:
 
     It accepts multiple ids using comma separated values:
         command: |
-            c8y inventory assert fragments --id 1,2 --fragments name --strict --dry --dryFormat json \
+            c8y inventory assert fragments --id 1,2 --fragments name --strict --attempts 1 --interval 1s --dry --dryFormat json \
             | c8y util show --select path
         exit-code: 0
         stderr:

--- a/tests/manual/measurements/assert/count/001_assert.sh
+++ b/tests/manual/measurements/assert/count/001_assert.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
 # set -eou pipefail
 
-mo_id=$( c8y devices create --name "device_with_measurements" --select id --output csv )
+NAME=$(c8y template execute -n --template "'device_with_measurements' + _.Char(10)")
+mo_id=$( c8y devices create -n -f --name "$NAME" --select id --output csv )
 cleanup () {
-    c8y inventory delete --id $mo_id > /dev/null 2>&1 || true
+    c8y inventory delete -n -f --id "$mo_id" > /dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 # case 1: Strict assertion
-c8y measurements assert count --device $mo_id --minimum 1 --strict
+c8y measurements assert count --device "$mo_id" --minimum 1 --strict --attempts 2 --interval 1s
 if [[ $? -ne 112 ]]; then
     exit 1
 fi
 
-c8y measurements assert count --device $mo_id --minimum 1
+c8y measurements assert count --device "$mo_id" --minimum 1 --attempts 2 --interval 1s
 if [[ $? -ne 0 ]]; then
     exit 2
 fi
 
-echo "$mo_id" | c8y measurements create --type c8y_TestMeasurement --time "-0s" --template "{c8y_Signal:{sensor01:{value:1.0,unit:'°C'}}}"
+echo "$mo_id" | c8y measurements create -f --type c8y_TestMeasurement --time "-0s" --template "{c8y_Signal:{sensor01:{value:1.0,unit:'°C'}}}"
 
 # case 2
-echo "$mo_id" | c8y measurements assert count --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y measurements assert count --minimum 1 --attempts 2 --interval 1s | grep "^${mo_id}$"
 
 # case 3: Filter by type
-echo "$mo_id" | c8y measurements assert count --type c8y_TestMeasurement --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y measurements assert count --type c8y_TestMeasurement --minimum 1 --attempts 2 --interval 1s | grep "^${mo_id}$"

--- a/tests/manual/operations/assert/count/001_assert.sh
+++ b/tests/manual/operations/assert/count/001_assert.sh
@@ -1,30 +1,31 @@
 #!/bin/bash
 # set -eou pipefail
 
-mo_id=$( c8y agents create --name "device_with_operations" --select id --output csv )
+NAME=$(c8y template execute -n --template "'device_with_operations' + _.Char(10)")
+mo_id=$( c8y agents create -n -f --name "$NAME" --select id --output csv )
 cleanup () {
-    c8y inventory delete --id $mo_id > /dev/null 2>&1 || true
+    c8y inventory delete -n -f --id $mo_id > /dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 # case 1: Strict assertion
-c8y operations assert count --device $mo_id --minimum 1 --strict
+c8y operations assert count --device $mo_id --minimum 1 --strict --attempts 2 --interval 1s --duration 5s
 if [[ $? -ne 112 ]]; then
     exit 1
 fi
 
-c8y operations assert count --device $mo_id --minimum 1
+c8y operations assert count --device $mo_id --minimum 1 --attempts 2 --interval 1s --duration 5s
 if [[ $? -ne 0 ]]; then
     exit 2
 fi
 
 
-echo "$mo_id" | c8y operations create --data "c8y_TestOperation.command='example'"
+echo "$mo_id" | c8y operations create -f --data "c8y_TestOperation.command='example'"
 
 # case 2
-echo "$mo_id" | c8y operations assert count --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y operations assert count --minimum 1 --attempts 2 --interval 1s --duration 5s | grep "^${mo_id}$"
 
 # case 3: Filter by type
-echo "$mo_id" | c8y operations assert count --fragmentType c8y_TestOperation --minimum 1 | grep "^${mo_id}$"
+echo "$mo_id" | c8y operations assert count --fragmentType c8y_TestOperation --minimum 1  --attempts 2 --interval 1s --duration 5s | grep "^${mo_id}$"
 
-echo "device_with_operations" | c8y operations assert count --fragmentType c8y_TestOperation --minimum 1 | grep "^device_with_operations$"
+echo "$NAME" | c8y operations assert count --fragmentType c8y_TestOperation --strict --minimum 1 --attempts 2 --interval 1s --duration 5s | grep "^${NAME}$"


### PR DESCRIPTION
With the introduction of the global `retries` flag, this broke the contract for the following commands causing the retry mechanism to  be skipped:

```sh
c8y inventory assert exists --id 1234
c8y devices assert exists --id 1234
```