### PR TITLE
feat: new command to check the existence of a tenant

### DIFF
--- a/pkg/c8ywaiter/tenant.go
+++ b/pkg/c8ywaiter/tenant.go
@@ -1,0 +1,93 @@
+package c8ywaiter
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+)
+
+// TenantExistence tenant existence checker
+type TenantExistence struct {
+	ID     string
+	Client *c8y.Client
+	Negate bool
+}
+
+type tenantResponse struct {
+	Tenant   *c8y.Tenant
+	Response *c8y.Response
+}
+
+// Check check if tenant exists or not
+func (s *TenantExistence) Check(m interface{}) (done bool, err error) {
+	if result, ok := m.(*tenantResponse); ok {
+		var exists, notFound bool
+		tenantID := s.ID
+
+		if result.Response != nil {
+			exists = result.Response.StatusCode() >= 200 && result.Response.StatusCode() <= 399
+			notFound = result.Response.StatusCode() == http.StatusNotFound
+		}
+
+		if s.Negate {
+			done = notFound
+			if !done {
+				err = cmderrors.NewAssertionError(&cmderrors.AssertionError{
+					Type:    cmderrors.Tenant,
+					Wanted:  "NotFound",
+					Got:     "Found",
+					Context: struct{ ID string }{ID: tenantID},
+				})
+			}
+		} else {
+			done = exists
+			if !done {
+				err = cmderrors.NewAssertionError(&cmderrors.AssertionError{
+					Type:    cmderrors.Tenant,
+					Wanted:  "Found",
+					Got:     "NotFound",
+					Context: struct{ ID string }{ID: tenantID},
+				})
+			}
+		}
+
+		if done {
+			return done, nil
+		}
+	}
+	return
+}
+
+func (s *TenantExistence) SetValue(v interface{}) error {
+	if id, ok := v.(string); ok {
+		s.ID = id
+	}
+	return nil
+}
+
+// Get get current tenant state
+func (s *TenantExistence) Get() (interface{}, error) {
+	// Corner case: check if it is the current tenant as the getTenant by id will fail with 403 error
+	// however since they already have access to the current tenant so it should work fine
+	if currentTenant := s.Client.GetTenantName(context.Background()); currentTenant == s.ID {
+		tenant, resp, err := s.Client.Tenant.GetCurrentTenant(context.Background())
+		// resp.JSON("id").String()
+		return &tenantResponse{&c8y.Tenant{
+			ID:     tenant.Name,
+			Domain: tenant.DomainName,
+		}, resp}, err
+	}
+
+	tenant, resp, err := s.Client.Tenant.GetTenant(
+		context.Background(),
+		s.ID,
+	)
+
+	if resp != nil && resp.StatusCode() == http.StatusNotFound {
+		// ignore not found errors, these are processed in the Check func
+		err = nil
+	}
+	return &tenantResponse{tenant, resp}, err
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -106,6 +106,7 @@ import (
 	tenantoptionsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenantoptions"
 	tenantsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenants"
 	tenantsApplicationsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenants/applications"
+	tenantsAssertCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenants/assert"
 	tenantsTFACmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenants/tfa"
 	tenantstatisticsCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenantstatistics"
 	uiCmd "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/ui"
@@ -369,6 +370,7 @@ func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	tenants := tenantsCmd.NewSubCommand(f).GetCommand()
 	tenants.AddCommand(tenantsApplicationsCmd.NewSubCommand(f).GetCommand())
 	tenants.AddCommand(tenantsTFACmd.NewSubCommand(f).GetCommand())
+	tenants.AddCommand(tenantsAssertCmd.NewSubCommand(f).GetCommand())
 	cmd.AddCommand(tenants)
 
 	features := featuresCmd.NewSubCommand(f).GetCommand()

--- a/pkg/cmd/tenants/assert/assert.manual.go
+++ b/pkg/cmd/tenants/assert/assert.manual.go
@@ -1,0 +1,29 @@
+package assert
+
+import (
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	cmdExists "github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/tenants/assert/exists"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type SubCmdAssert struct {
+	*subcommand.SubCommand
+}
+
+func NewSubCommand(f *cmdutil.Factory) *SubCmdAssert {
+	ccmd := &SubCmdAssert{}
+
+	cmd := &cobra.Command{
+		Use:   "assert",
+		Short: "Cumulocity tenant assertions",
+		Long:  `Assertions for Cumulocity tenants`,
+	}
+
+	// Subcommands
+	cmd.AddCommand(cmdExists.NewCmdExists(f).GetCommand())
+
+	ccmd.SubCommand = subcommand.NewSubCommand(cmd)
+
+	return ccmd
+}

--- a/pkg/cmd/tenants/assert/exists/exists.manual.go
+++ b/pkg/cmd/tenants/assert/exists/exists.manual.go
@@ -1,0 +1,78 @@
+package exists
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8ywaiter"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmd/subcommand"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/desiredstate"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type AssertExists struct{}
+
+func (a *AssertExists) GetStateHandler(cmd *cobra.Command, client *c8y.Client) desiredstate.StateDefiner {
+	negate, err := cmd.Flags().GetBool("not")
+	_ = err
+	return &c8ywaiter.TenantExistence{
+		Client: client,
+		Negate: negate,
+	}
+}
+
+func (a *AssertExists) GetValue(v interface{}, input interface{}) []byte {
+	if raw, ok := input.([]byte); ok {
+		return raw
+	}
+	return nil
+}
+
+type CmdExists struct {
+	*subcommand.SubCommand
+
+	factory *cmdutil.Factory
+}
+
+func NewCmdExists(f *cmdutil.Factory) *CmdExists {
+	ccmd := &CmdExists{
+		factory: f,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "exists",
+		Short: "Assert existence of a tenant",
+		Long: heredoc.Doc(`
+			Assert that a tenant exists or not and pass input untouched
+
+			If the assertion is true, then the input value (stdin or an explicit argument value) will be passed untouched to stdout.
+			This is useful if you want to filter a list of tenants by whether they exist or not in the platform, and use the results
+			in some downstream command (in the pipeline)
+
+			By default, a failed assertion will not set the exit code to a non-zero value. If you want a non-zero exit code
+			in such as case then use the --strict option.
+		`),
+		Example: heredoc.Doc(`
+			$ c8y tenants assert exists --tenant t12345
+			# => t12345 (if the tenant exists)
+			# => <no response> (if the tenant does not exist)
+			# Assert the tenant exists
+
+			$ echo "t12345" | c8y tenants assert exists
+			# Pass the piped input only on if the tenant exists
+
+			$ echo -e "t11111\nt22222" | c8y tenants assert exists --not
+			# Only select the tenant ids which do not exist
+
+			$ echo t12345 | c8y tenants assert exists --strict
+			# Return non-zero exit code if tenant t12345 does not exist
+		`),
+	}
+
+	cmd.Flags().Bool("not", false, "Negate the match")
+
+	assertExists := &AssertExists{}
+	ccmd.SubCommand = subcommand.NewSubCommand(NewAssertTenantCmdFactory(cmd, f, assertExists))
+
+	return ccmd
+}

--- a/pkg/cmd/tenants/assert/exists/factory.manual.go
+++ b/pkg/cmd/tenants/assert/exists/factory.manual.go
@@ -1,0 +1,151 @@
+package exists
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8yfetcher"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/desiredstate"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
+	"github.com/reubenmiller/go-c8y/pkg/c8y"
+	"github.com/spf13/cobra"
+)
+
+type StateChecker interface {
+	GetStateHandler(*cobra.Command, *c8y.Client) desiredstate.StateDefiner
+	GetValue(interface{}, interface{}) []byte
+}
+
+func NewAssertTenantCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker) *cobra.Command {
+	cmd.Flags().StringSlice("tenant", []string{}, "Tenant id (accepts pipeline)")
+	cmd.Flags().String("duration", "30s", "Timeout duration. i.e. 30s or 1m (1 minute)")
+	cmd.Flags().String("interval", "5s", "Interval to check on the status, i.e. 10s or 1min")
+	cmd.Flags().Int64("attempts", -1, "Number of attempts before giving up per id (-1 = unlimited)")
+	cmd.Flags().Bool("strict", false, "Strict mode, fail if no match is found")
+	flags.WithOptions(
+		cmd,
+		flags.WithExtendedPipelineSupport("tenant", "tenant", false, "tenantId", "id", "owner.tenant.id", "tenant"),
+	)
+
+	cmd.SilenceUsage = true
+
+	completion.WithOptions(
+		cmd,
+		completion.WithTenantID("tenant", func() (*c8y.Client, error) { return f.Client() }),
+	)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		cfg, err := f.Config()
+		if err != nil {
+			return err
+		}
+		client, err := f.Client()
+		if err != nil {
+			return err
+		}
+
+		inputIterators, err := cmdutil.NewRequestInputIterators(cmd, cfg)
+		if err != nil {
+			return err
+		}
+
+		duration, err := flags.GetDurationFlag(cmd, "duration", true, time.Second)
+		if err != nil {
+			return err
+		}
+
+		interval, err := flags.GetDurationFlag(cmd, "interval", true, time.Second)
+		if err != nil {
+			return err
+		}
+
+		attempts, err := cmd.Flags().GetInt64("attempts")
+		if err != nil {
+			return err
+		}
+
+		strictMode, err := cmd.Flags().GetBool("strict")
+		if err != nil {
+			return err
+		}
+
+		// path parameters
+		path := flags.NewStringTemplate("{tenant}")
+		if v := f.GetTenant(); v != "" {
+			if !cmd.Flags().Changed("tenant") {
+				// Set a default value to the current tenant so the user doesn't have to define one
+				path.SetVariable("tenant", iterator.NewRepeatIterator(v, 1))
+			}
+		}
+		err = flags.WithParameters(
+			cmd,
+			path,
+			inputIterators,
+			c8yfetcher.WithIDSlice(args, "tenant", "tenant"),
+		)
+		if err != nil {
+			return err
+		}
+
+		state := h.GetStateHandler(cmd, client)
+
+		totalErrors := 0
+		var lastErr error
+		var result interface{}
+
+		for {
+			tenantID, input, inputErr := path.Execute(false)
+
+			if tenantID != "" && input == nil {
+				// set the input manually when the value is not provided
+				// from the pipeline, and using the default value.
+				input = []byte(tenantID)
+			}
+
+			if inputErr == io.EOF {
+				break
+			}
+
+			if totalErrors >= cfg.AbortOnErrorCount() {
+				msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
+				return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
+			}
+
+			if inputErr == nil {
+				// Skip checking if the input has errors
+				_ = state.SetValue(tenantID)
+				result, err = desiredstate.WaitForWithRetries(attempts, interval, duration, state)
+				if err == nil {
+					outValue := h.GetValue(result, input)
+					_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
+				}
+			} else {
+				err = inputErr
+			}
+
+			if err != nil {
+				if !errors.Is(err, cmderrors.ErrAssertion) || strictMode {
+					totalErrors++
+					lastErr = f.CheckPostCommandError(err)
+
+					// wrap error so it is not printed twice, and is still an assertion error
+					cErr := cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAssertionError, lastErr)
+					cErr.Processed = true
+					lastErr = cErr
+				}
+			}
+		}
+
+		if totalErrors > 0 {
+			return lastErr
+		}
+		return nil
+	}
+	return cmd
+}

--- a/pkg/cmderrors/cmderrors.go
+++ b/pkg/cmderrors/cmderrors.go
@@ -161,6 +161,7 @@ type AssertionErrorContext string
 
 var (
 	ManagedObject          AssertionErrorContext = "managedObject"
+	Tenant                 AssertionErrorContext = "tenant"
 	ManagedObjectFragments AssertionErrorContext = "managedObjectFragments"
 	AlarmCount             AssertionErrorContext = "alarmCount"
 	EventCount             AssertionErrorContext = "eventCount"

--- a/tests/manual/tenants/assert/exists/tenant_assert_exists.yaml
+++ b/tests/manual/tenants/assert/exists/tenant_assert_exists.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+tests:
+    It uses the current tenant by default:
+        command: c8y tenants assert exists
+        exit-code: 0
+        stdout:
+            match-pattern: ^t\d+$
+        stderr:
+            line-count: 0
+
+    It uses the accepts a tenant via a flag:
+        command: c8y tenants assert exists --tenant $C8Y_TENANT
+        exit-code: 0
+        stdout:
+            match-pattern: ^t\d+$
+        stderr:
+            line-count: 0
+
+    It uses the accepts a tenant via the pipeline:
+        command: echo $C8Y_TENANT | c8y tenants assert exists
+        exit-code: 0
+        stdout:
+            match-pattern: ^t\d+$
+        stderr:
+            line-count: 0
+
+    It fails the negated assertion when using dry mode:
+        command: c8y tenants assert exists --not --strict --dry --attempts 1 --interval 1s
+        exit-code: 112
+        stderr:
+            contains:
+                - "assertionError: tenant - wanted: NotFound, got: Found"
+
+    It fails the negated assertion:
+        command: c8y tenants assert exists --not --strict --attempts 1 --interval 1s
+        exit-code: 112
+        stderr:
+            match-pattern: "^.*assertionError: tenant - wanted: NotFound, got: Found, context: \\{ID:t\\d+\\}.*$"


### PR DESCRIPTION
New command for testing if a tenant exists or not, though generally you will only be able to use it to check subtenants of your current tenant.

**Examples**

```sh
# Wait for a tenant to be deleted
c8y tenants list | c8y tenants assert exists --not

# Wait for a child tenant to exist
echo t9707 | c8y tenants assert exists
```