### PR TITLE
fix(login): login should respect the sensitive info logging to not leak secrets by default

### DIFF
--- a/pkg/cmd/sessions/login/login.manual.go
+++ b/pkg/cmd/sessions/login/login.manual.go
@@ -353,7 +353,15 @@ func (n *CmdLogin) FromExternalProvider(args []string) (*c8ysession.CumulocitySe
 		}
 	}
 
-	log.Infof("Parsing session provider output: %s", output)
+	if client, err := n.factory.Client(); err == nil {
+		if cfg.HideSensitive() {
+			log.Infof("Parsing session provider output: %s", cfg.HideSensitiveInformation(client, strings.TrimSpace(string(output))))
+		} else {
+			log.Infof("Parsing session provider output: %s", strings.TrimSpace(string(output)))
+		}
+	} else {
+		log.Infof("Parsing session provider output")
+	}
 	return n.FromReader(bytes.NewReader(output), n.Format)
 }
 
@@ -554,7 +562,16 @@ func (n *CmdLogin) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if sessionContents, err := json.Marshal(session); err == nil {
-		cfg.Logger.Infof("Received session from external source:\n%s\n", sessionContents)
+
+		if client, err := n.factory.Client(); err == nil {
+			if cfg.HideSensitive() {
+				log.Infof("Received session from external source:\n%s\n", cfg.HideSensitiveInformation(client, string(sessionContents)))
+			} else {
+				cfg.Logger.Infof("Received session from external source:\n%s\n", sessionContents)
+			}
+		} else {
+			log.Infof("Received session from external source")
+		}
 	}
 
 	if session.SessionUri != "" {


### PR DESCRIPTION
Fix some log entries within the `c8y sessions login` which didn't respect the `C8Y_SETTINGS_LOGGER_HIDESENSITIVE` setting (namely the interaction with an external session provider).