### PR TITLE
chore: update GitHub Actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -63,7 +63,7 @@ jobs:
           install-only: true
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         install-only: true
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: go-task/setup-task@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -116,7 +116,7 @@ jobs:
         go-version-file:  go.mod
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: go-task/setup-task@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -162,12 +162,12 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file:  go.mod
     
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: go-task/setup-task@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-linux-packages.yml
+++ b/.github/workflows/publish-linux-packages.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file:  go.mod
 
@@ -48,7 +48,7 @@ jobs:
         install-only: true
 
     - name: Install Task
-      uses: arduino/setup-task@v2
+      uses: go-task/setup-task@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,21 +28,21 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file:  go.mod
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: go-task/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Update the remaining Github Actions to the latest versions to resolve the remove the deprecation warnings.