### PR TITLE
docs: reference new c8y.app domain

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,7 @@ nfpms:
     package_name: go-c8y-cli
     license: MIT
     maintainer: Reuben Miller <reuben.d.miller@gmail.com>
-    homepage: http://goc8ycli.netlify.app
+    homepage: https://c8y.app
     bindir: /usr
     description: Cumulocity command line tool
     section: utils
@@ -178,7 +178,7 @@ brews:
 
       Then reload your shell to see the effects.
 
-    homepage: "https://goc8ycli.netlify.app/"
+    homepage: "https://c8y.app/"
     description: "Cumulocity command line tool"
     license: "MIT"
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Supported on
 
 See the following installation instructions
 
-* [Shell](https://goc8ycli.netlify.app/docs/installation/shell-installation)
-* [Docker](https://goc8ycli.netlify.app/docs/installation/docker-installation)
-* [PowerShell](https://goc8ycli.netlify.app/docs/installation/powershell-installation)
+* [Shell](https://c8y.app/docs/installation/shell-installation)
+* [Docker](https://c8y.app/docs/installation/docker-installation)
+* [PowerShell](https://c8y.app/docs/installation/powershell-installation)
 
 
 ## Testing an unreleased version
@@ -76,7 +76,7 @@ hash -r
 
 ## Documentation
 
-See the [documentation website](https://goc8ycli.netlify.app/) for instructions on how to install and use it.
+See the [documentation website](https://c8y.app/) for instructions on how to install and use it.
 
 ## Contributing
 

--- a/docs/go-c8y-cli/demos/2023-09-06/2023-09-06-an-update.md
+++ b/docs/go-c8y-cli/demos/2023-09-06/2023-09-06-an-update.md
@@ -52,9 +52,9 @@ go-c8y-cli is constantly being improved and new features are added frequently. S
 
 As always a tool is useless unless it can be installed on your system.
 
-* [shell](https://goc8ycli.netlify.app/docs/installation/shell-installation/)
-* [Docker](https://goc8ycli.netlify.app/docs/installation/docker-installation/)
-* [PowerShell](https://goc8ycli.netlify.app/docs/installation/powershell-installation/)
+* [shell](https://c8y.app/docs/installation/shell-installation/)
+* [Docker](https://c8y.app/docs/installation/docker-installation/)
+* [PowerShell](https://c8y.app/docs/installation/powershell-installation/)
 
 Or you can always download the binary directly using some new instructions (which will eventually also make it on the website as well)
 

--- a/docs/go-c8y-cli/docs/cli/psc8y/Misc/Watch-Notification2Subscription.md
+++ b/docs/go-c8y-cli/docs/cli/psc8y/Misc/Watch-Notification2Subscription.md
@@ -3,7 +3,7 @@ category: Misc
 external help file: PSc8y-help.xml
 id: Watch-Notification2Subscription
 Module Name: PSc8y
-online version: https://goc8ycli.netlify.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/
+online version: https://c8y.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/
 schema: 2.0.0
 slug: /docs/cli/psc8y/Misc/watch-notification2subscription
 title: Watch-Notification2Subscription
@@ -914,5 +914,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://goc8ycli.netlify.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/](https://goc8ycli.netlify.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/)
+[https://c8y.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/](https://c8y.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/)
 

--- a/docs/go-c8y-cli/docs/examples/remoteaccess.md
+++ b/docs/go-c8y-cli/docs/examples/remoteaccess.md
@@ -34,7 +34,7 @@ There are a few moving parts in this scenario, as there needs to be a client on 
 
 The good news is that there are existing open source projects which can be used to take advantage of the Remote Access feature; these components are:
 
-* [go-c8y-cli](https://goc8ycli.netlify.app/docs/introduction/) (on your machine)
+* [go-c8y-cli](https://c8y.app/docs/introduction/) (on your machine)
 * [thin-edge.io](https://thin-edge.io) - a Rust based agent that has out-of-the-box support for the Cumulocity Cloud Remote Access feature (on the device)
 
 ### Prerequisites

--- a/docs/go-c8y-cli/docs/installation.md
+++ b/docs/go-c8y-cli/docs/installation.md
@@ -28,14 +28,14 @@ Install %%c8y%% on Linux, macOS or WSL2 (Windows Subsystem for Linux) using the 
     <TabItem value="wget">
 
     ```bash
-    wget -qO - https://goc8ycli.netlify.app/install.sh | sh -s
+    wget -qO - https://get.c8y.app | sh -s
     ```
 
     </TabItem>
     <TabItem value="curl">
 
     ```bash
-    curl -fsSL https://goc8ycli.netlify.app/install.sh | sh -s
+    curl -fsSL https://get.c8y.app | sh -s
     ```
 
     </TabItem>
@@ -54,14 +54,14 @@ The convenience script can be customized, for example you can choose how it is i
     <TabItem value="wget">
 
     ```bash
-    wget -qO - https://goc8ycli.netlify.app/install.sh | sh -s -- --help
+    wget -qO - https://get.c8y.app | sh -s -- --help
     ```
 
     </TabItem>
     <TabItem value="curl">
 
     ```bash
-    curl -fsSL https://goc8ycli.netlify.app/install.sh | sh -s -- --help
+    curl -fsSL https://get.c8y.app | sh -s -- --help
     ```
 
     </TabItem>
@@ -72,7 +72,7 @@ The convenience script can be customized, for example you can choose how it is i
 %%c8y%% can be installed using PowerShell using the following one-liner.
 
 ```bash
-. { Invoke-WebRequest https://goc8ycli.netlify.app/install.ps1 } | Invoke-Expression; install-c8y
+. { Invoke-WebRequest https://c8y.app/install.ps1 } | Invoke-Expression; install-c8y
 ```
 
 ### Alternative Installation Methods

--- a/docs/go-c8y-cli/static/manifest.json
+++ b/docs/go-c8y-cli/static/manifest.json
@@ -10,7 +10,7 @@
   "related_applications": [
     {
       "platform": "webapp",
-      "url": "https://goc8ycli.netlify.app/manifest.json"
+      "url": "https://c8y.app/manifest.json"
     }
   ],
   "icons": [

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting to https://goc8ycli.netlify.app/</title>
-<meta http-equiv="refresh" content="0; URL=https://goc8ycli.netlify.app/">
-<link rel="canonical" href="https://goc8ycli.netlify.app/">
+<title>Redirecting to https://c8y.app/</title>
+<meta http-equiv="refresh" content="0; URL=https://c8y.app/">
+<link rel="canonical" href="https://c8y.app/">

--- a/pkg/cmd/extension/command.go
+++ b/pkg/cmd/extension/command.go
@@ -447,7 +447,7 @@ func NewCmdExtension(f *cmdutil.Factory) *cobra.Command {
 						- fill in script/build.sh with your compilation script for automated builds
 						- compile a %[1]s binary locally and run 'c8y %[2]s' to see changes`, fullName, extName)
 					}
-					link := "https://goc8ycli.netlify.app/docs/tutorials/extensions/"
+					link := "https://c8y.app/docs/tutorials/extensions/"
 					out := heredoc.Docf(`
 						%[1]s Created directory %[2]s
 						%[1]s Initialized git repository

--- a/tools/PSc8y/Public-manual/Watch-Notification2Subscription.ps1
+++ b/tools/PSc8y/Public-manual/Watch-Notification2Subscription.ps1
@@ -7,7 +7,7 @@ Subscribe to a subscription
 Subscribe to an existing subscription. If no token is provided, a token will be created automatically before starting the realtime client
 
 .LINK
-https://goc8ycli.netlify.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/
+https://c8y.app/docs/cli/c8y/notification2/subscriptions/c8y_notification2_subscriptions_subscribe/
 
 .EXAMPLE
 PS> Watch-Notification2Subscription -Name registration


### PR DESCRIPTION
Update to use the new custom domain for hosting the docs and install scripts.

The new custom domain is:

https://c8y.app

The old domain should continue to work, however the [https://c8y.app](https://c8y.app) should be reachable in more countries and from more ISPs as it was discovered that some countries couldn't access and install go-c8y-cli as the website was blocked.