### PR TITLE
feat(operations): add agent flag to allow users to set and update the agentId of an operation

### DIFF
--- a/api/spec/json/devicecontrol.json
+++ b/api/spec/json/devicecontrol.json
@@ -216,6 +216,13 @@
           "description": "Identifies the target device on which this operation should be performed."
         },
         {
+          "name": "agent",
+          "type": "agent[]",
+          "property": "agentId",
+          "description": "Agent ID or name",
+          "pipeline": false
+        },
+        {
           "name": "description",
           "type": "string",
           "required": false,
@@ -286,6 +293,13 @@
           "type": "string",
           "required": false,
           "description": "Reason for the failure. Use when setting status to FAILED"
+        },
+        {
+          "name": "agent",
+          "type": "agent[]",
+          "property": "agentId",
+          "description": "Agent ID or name",
+          "pipeline": false
         },
         {
           "name": "data",

--- a/api/spec/yaml/devicecontrol.yaml
+++ b/api/spec/yaml/devicecontrol.yaml
@@ -159,6 +159,12 @@ commands:
         pipeline: true
         description: Identifies the target device on which this operation should be performed.
 
+      - name: agent
+        type: agent[]
+        property: agentId
+        description: Agent ID or name
+        pipeline: false
+
       - name: description
         type: string
         required: false
@@ -208,6 +214,12 @@ commands:
         type: string
         required: false
         description: Reason for the failure. Use when setting status to FAILED
+
+      - name: agent
+        type: agent[]
+        property: agentId
+        description: Agent ID or name
+        pipeline: false
 
       - name: data
         type: json

--- a/pkg/cmd/operations/create/create.auto.go
+++ b/pkg/cmd/operations/create/create.auto.go
@@ -46,11 +46,13 @@ Create operation for a device
 	cmd.SilenceUsage = true
 
 	cmd.Flags().StringSlice("device", []string{""}, "Identifies the target device on which this operation should be performed. (accepts pipeline)")
+	cmd.Flags().StringSlice("agent", []string{""}, "Agent ID or name")
 	cmd.Flags().String("description", "", "Text description of the operation.")
 
 	completion.WithOptions(
 		cmd,
 		completion.WithDevice("device", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
+		completion.WithAgent("agent", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
@@ -60,6 +62,7 @@ Create operation for a device
 		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("device", "deviceId", false, "deviceId", "source.id", "managedObject.id", "id"),
 		flags.WithPipelineAliases("device", "deviceId", "source.id", "managedObject.id", "id"),
+		flags.WithPipelineAliases("agent", "deviceId", "source.id", "managedObject.id", "id"),
 	)
 
 	// Required flags
@@ -139,6 +142,7 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithDataFlagValue(),
 		c8yfetcher.WithDeviceByNameFirstMatch(n.factory, args, "device", "deviceId"),
+		c8yfetcher.WithAgentByNameFirstMatch(n.factory, args, "agent", "agentId"),
 		flags.WithStringValue("description", "description"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),

--- a/pkg/cmd/operations/update/update.auto.go
+++ b/pkg/cmd/operations/update/update.auto.go
@@ -49,10 +49,12 @@ Update an operation
 	cmd.Flags().StringSlice("id", []string{""}, "Operation id (required) (accepts pipeline)")
 	cmd.Flags().String("status", "", "Operation status, can be one of SUCCESSFUL, FAILED, EXECUTING or PENDING.")
 	cmd.Flags().String("failureReason", "", "Reason for the failure. Use when setting status to FAILED")
+	cmd.Flags().StringSlice("agent", []string{""}, "Agent ID or name")
 
 	completion.WithOptions(
 		cmd,
 		completion.WithValidateSet("status", "PENDING", "EXECUTING", "SUCCESSFUL", "FAILED"),
+		completion.WithAgent("agent", func() (*c8y.Client, error) { return ccmd.factory.Client() }),
 	)
 
 	flags.WithOptions(
@@ -61,6 +63,7 @@ Update an operation
 		flags.WithData(),
 		f.WithTemplateFlag(cmd),
 		flags.WithExtendedPipelineSupport("id", "id", true),
+		flags.WithPipelineAliases("agent", "deviceId", "source.id", "managedObject.id", "id"),
 	)
 
 	// Required flags
@@ -141,6 +144,7 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("status", "status"),
 		flags.WithStringValue("failureReason", "failureReason"),
+		c8yfetcher.WithAgentByNameFirstMatch(n.factory, args, "agent", "agentId"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
 		flags.WithRequiredProperties("status"),

--- a/tools/PSc8y/Public/New-Operation.ps1
+++ b/tools/PSc8y/Public/New-Operation.ps1
@@ -33,6 +33,11 @@ Create operation for a device (using pipeline)
         [object[]]
         $Device,
 
+        # Agent ID or name
+        [Parameter()]
+        [object[]]
+        $Agent,
+
         # Text description of the operation.
         [Parameter()]
         [string]

--- a/tools/PSc8y/Public/Update-Operation.ps1
+++ b/tools/PSc8y/Public/Update-Operation.ps1
@@ -44,7 +44,12 @@ Update multiple operations
         # Reason for the failure. Use when setting status to FAILED
         [Parameter()]
         [string]
-        $FailureReason
+        $FailureReason,
+
+        # Agent ID or name
+        [Parameter()]
+        [object[]]
+        $Agent
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Update", "Template"


### PR DESCRIPTION
Minimize potential for user error when creating or updating an operation with the `agentId` fragment.

Having a flag prevents users from using the incorrect data type as which can happen when using `--data agentId=12345` where the agentId should be string and not a number.

**Examples**

```sh
# using explicit id
c8y operations update --id 12345 --agent 2222 --dry --status PENDING

# using agent name
c8y operations update --id 12345 --agent mydevice01 --dry --status PENDING
```