### PR TITLE
fix(dependencies): update go-c8y to version 0.37.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.8
+	github.com/reubenmiller/go-c8y v0.37.9
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.8 h1:2XIVpjEFRlW0YDlW9K1inbsYKGp4bPge7xYd1xDZLsU=
-github.com/reubenmiller/go-c8y v0.37.8/go.mod h1:omJlFF3uDmYwbhiBC5ll5mq44+Yk9jax+tDzkjNje/A=
+github.com/reubenmiller/go-c8y v0.37.9 h1:55XOj9G5fok84gOexyuLny+o9bF5chCBvzOyHVBFOqU=
+github.com/reubenmiller/go-c8y v0.37.9/go.mod h1:omJlFF3uDmYwbhiBC5ll5mq44+Yk9jax+tDzkjNje/A=
 github.com/reubenmiller/go-c8y/v2 v2.0.0-20260318160755-635d890df069 h1:aXy+nj/MHQjF8WWiSohXakDDxhfBwvFP5UIHKls+Kfs=
 github.com/reubenmiller/go-c8y/v2 v2.0.0-20260318160755-635d890df069/go.mod h1:djqzpynYVs+Q+7azobc1mKEh0B1u2zSKCIY0ZB2zy4M=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=


### PR DESCRIPTION
Update go-c8y to 0.37.9 to fix a panic within the caching logic.

**Example of the panic**

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x102d1b424]

goroutine 9 [running]:
github.com/reubenmiller/go-c8y/pkg/c8y.(*fileStorage).read(0x14000a2bce0, {0x140008321c0, 0x40})
        github.com/reubenmiller/go-c8y@v0.37.8/pkg/c8y/cache.go:214 +0x314
github.com/reubenmiller/go-c8y/pkg/c8y.NewCachedClient.NewCachedClient.CacheResponse.func1.func2(0x14000172640)
        github.com/reubenmiller/go-c8y@v0.37.8/pkg/c8y/cache.go:70 +0x98
github.com/reubenmiller/go-c8y/pkg/c8y.funcTripper.RoundTrip(...)
        github.com/reubenmiller/go-c8y@v0.37.8/pkg/c8y/client.go:417
net/http.send(0x14000172640, {0x1039fd1c0, 0x14000185738}, {0x102b6d588?, 0x8?, 0x0?})
        net/http/client.go:259 +0x478
net/http.(*Client).send(0x1400049b230, 0x14000172640, {0x14000da22a0?, 0x27?, 0x0?})
        net/http/client.go:180 +0x88
net/http.(*Client).do(0x1400049b230, 0x14000172640)
        net/http/client.go:729 +0x710
net/http.(*Client).Do(...)
        net/http/client.go:587
github.com/reubenmiller/go-c8y/pkg/c8y.(*Client).Do(0x1400020b800, {0x103a05fc8, 0x14000bfe060}, 0x14000172000, {0x1038b5f20, 0x14000bfe090}, {0x0, 0x0, 0x140005ce330?})
        github.com/reubenmiller/go-c8y@v0.37.8/pkg/c8y/client.go:1559 +0x6e4
github.com/reubenmiller/go-c8y/pkg/c8y.(*Client).SendRequest(0x1400020b800, {0x103a05fc8, 0x14000bfe060}, {{0x10355632f, 0x4}, {0x0, 0x0}, {0x140002cf8c0, 0x18}, {0x0, ...}, ...})
        github.com/reubenmiller/go-c8y@v0.37.8/pkg/c8y/client.go:987 +0xbc4
github.com/reubenmiller/go-c8y-cli/v2/pkg/request.(*RequestHandler).ProcessRequestAndResponse(0x14000056550, {0x14000bfa0d0?, 0xd0?, 0x103859f80?}, {0x0, 0x0}, {{0x103561dba, 0xd}, {0x0, 0x0}, ...})
        github.com/reubenmiller/go-c8y-cli/v2/pkg/request/request.go:114 +0x3f4
github.com/reubenmiller/go-c8y-cli/v2/pkg/worker.(*Worker).batchWorker(0x140005c0540, 0x5, 0x140001ca7e0, 0x140001ca850, 0x140002d1780, 0x14000196240?)
        github.com/reubenmiller/go-c8y-cli/v2/pkg/worker/worker.go:451 +0x490
created by github.com/reubenmiller/go-c8y-cli/v2/pkg/worker.(*Worker).runBatched in goroutine 1
        github.com/reubenmiller/go-c8y-cli/v2/pkg/worker/worker.go:211 +0xd4
```