### PR TITLE
feat: improve microservice version parsing

### DIFF
--- a/pkg/artifact/artifact.go
+++ b/pkg/artifact/artifact.go
@@ -17,6 +17,6 @@ func ParseName(file string) string {
 	suffixRegex := regexp.MustCompile(`\s+\(\d+\)$`)
 	baseFileName = suffixRegex.ReplaceAllString(baseFileName, "")
 
-	versionRegex := regexp.MustCompile(`([_-]v?\d+\.\d+\.\d+(-SNAPSHOT)?)?$`)
+	versionRegex := regexp.MustCompile(`([_-]v?\d+(\.\d+){1,}(-SNAPSHOT)?)?$`)
 	return versionRegex.ReplaceAllString(baseFileName, "")
 }

--- a/pkg/artifact/artifact_test.go
+++ b/pkg/artifact/artifact_test.go
@@ -23,6 +23,10 @@ func Test_Filename(t *testing.T) {
 			Filename: "./helloworld3-0.0.1-SNAPSHOT (100).zip",
 			Expected: "helloworld3",
 		},
+		{
+			Filename: "./foo-bar-example-1.4-SNAPSHOT.zip",
+			Expected: "foo-bar-example",
+		},
 	}
 
 	for _, testcase := range cases {


### PR DESCRIPTION
Improve the microservice name parsing to not requires the versions to have `x.y.z` and also accept `x.y` style versions.

**Example**

```sh
foo-bar-example-1.4-SNAPSHOT.zip
```