### PR TITLE
docs(measurements): add example on using the revert flag

### DIFF
--- a/api/spec/json/measurements.json
+++ b/api/spec/json/measurements.json
@@ -26,6 +26,11 @@
             "command": "Get-MeasurementCollection"
           },
           {
+            "description": "Get a list of measurements from the last day, showing the oldest first",
+            "command": "Get-MeasurementCollection -DateFrom -1d -Revert:$false",
+            "skipTest": true
+          },
+          {
             "description": "Get a list of measurements for a particular device",
             "beforeEach": [
               "$Device = PSc8y\\New-TestDevice",
@@ -52,6 +57,10 @@
           {
             "description": "Get a list of measurements",
             "command": "c8y measurements list"
+          },
+          {
+            "description": "Get a list of measurements from the last day, showing the oldest first",
+            "command": "c8y measurements list --dateFrom -1d --revert=false"
           }
         ]
       },
@@ -123,7 +132,7 @@
         {
           "name": "revert",
           "type": "boolean",
-          "description": "Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters"
+          "description": "Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters. By default, the results are sorted by the newest measurements first for time series and by the oldest first for legacy measurements"
         }
       ]
     },

--- a/api/spec/yaml/measurements.yaml
+++ b/api/spec/yaml/measurements.yaml
@@ -23,6 +23,10 @@ commands:
         - description: Get a list of measurements
           command: Get-MeasurementCollection
 
+        - description: Get a list of measurements from the last day, showing the oldest first
+          command: Get-MeasurementCollection -DateFrom -1d -Revert:$false
+          skipTest: true
+
         - description: Get a list of measurements for a particular device
           beforeEach:
             - $Device = PSc8y\New-TestDevice
@@ -43,6 +47,9 @@ commands:
       go:
         - description: Get a list of measurements
           command: c8y measurements list
+
+        - description: Get a list of measurements from the last day, showing the oldest first
+          command: c8y measurements list --dateFrom -1d --revert=false
     headerParameters:
       - name: csvFormat
         type: boolean
@@ -96,7 +103,7 @@ commands:
 
       - name: revert
         type: boolean
-        description: Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters
+        description: Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters. By default, the results are sorted by the newest measurements first for time series and by the oldest first for legacy measurements
 
   - name: getMeasurementLatestCollection
     method: GET

--- a/pkg/cmd/measurements/list/list.auto.go
+++ b/pkg/cmd/measurements/list/list.auto.go
@@ -37,6 +37,9 @@ func NewListCmd(f *cmdutil.Factory) *ListCmd {
 		Example: heredoc.Doc(`
 $ c8y measurements list
 Get a list of measurements
+
+$ c8y measurements list --dateFrom -1d --revert=false
+Get a list of measurements from the last day, showing the oldest first
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return nil
@@ -53,7 +56,7 @@ Get a list of measurements
 	cmd.Flags().String("fragmentType", "", "Fragment name from measurement (deprecated).")
 	cmd.Flags().String("dateFrom", "", "Start date or date and time of measurement occurrence.")
 	cmd.Flags().String("dateTo", "", "End date or date and time of measurement occurrence.")
-	cmd.Flags().Bool("revert", false, "Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters")
+	cmd.Flags().Bool("revert", false, "Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters. By default, the results are sorted by the newest measurements first for time series and by the oldest first for legacy measurements")
 	cmd.Flags().Bool("csvFormat", false, "Results will be displayed in csv format. Note: -IncludeAll, is not supported when using using this parameter")
 	cmd.Flags().Bool("excelFormat", false, "Results will be displayed in Excel format Note: -IncludeAll, is not supported when using using this parameter")
 	cmd.Flags().String("unit", "", "Every measurement fragment which contains 'unit' property will be transformed to use required system of units.")

--- a/tests/auto/measurements/tests/measurements_list.yaml
+++ b/tests/auto/measurements/tests/measurements_list.yaml
@@ -6,3 +6,13 @@ tests:
             json:
                 method: GET
                 path: /measurement/measurements
+    measurements_list_Get a list of measurements from the last day, showing the oldest first:
+        command: c8y measurements list --dateFrom -1d --revert=false
+        exit-code: 0
+        stdout:
+            json:
+                method: GET
+                path: /measurement/measurements
+            contains:
+                - dateFrom=
+                - revert=false

--- a/tools/PSc8y/Public/Get-MeasurementCollection.ps1
+++ b/tools/PSc8y/Public/Get-MeasurementCollection.ps1
@@ -16,6 +16,11 @@ PS> Get-MeasurementCollection
 Get a list of measurements
 
 .EXAMPLE
+PS> Get-MeasurementCollection -DateFrom -1d -Revert:$false
+
+Get a list of measurements from the last day, showing the oldest first
+
+.EXAMPLE
 PS> Get-MeasurementCollection -Device $Device.id -Type "TempReading"
 
 Get a list of measurements for a particular device
@@ -63,7 +68,7 @@ Get measurements from a device (using pipeline)
         [string]
         $DateTo,
 
-        # Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters
+        # Return the newest instead of the oldest measurements. Must be used with dateFrom and dateTo parameters. By default, the results are sorted by the newest measurements first for time series and by the oldest first for legacy measurements
         [Parameter()]
         [switch]
         $Revert,

--- a/tools/PSc8y/Tests/Get-MeasurementCollection.auto.Tests.ps1
+++ b/tools/PSc8y/Tests/Get-MeasurementCollection.auto.Tests.ps1
@@ -13,6 +13,12 @@ Describe -Name "Get-MeasurementCollection" {
         $Response | Should -Not -BeNullOrEmpty
     }
 
+    It "Get a list of measurements from the last day, showing the oldest first" {
+        $Response = PSc8y\Get-MeasurementCollection -DateFrom -1d -Revert:$false
+        $LASTEXITCODE | Should -Be 0
+        $Response | Should -Not -BeNullOrEmpty
+    }
+
     It "Get a list of measurements for a particular device" {
         $Response = PSc8y\Get-MeasurementCollection -Device $Device.id -Type "TempReading"
         $LASTEXITCODE | Should -Be 0


### PR DESCRIPTION
Add an example how to list measurements from oldest to newest when the measurements are using the Cumulocity time series feature, as the default is to have `revert=true`, so the flag must be set to `--revert=false` which might not be obvious for users.

**Example**

```
$ c8y measurements list --examples
```

*Output*
```
$ c8y measurements list
Get a list of measurements

$ c8y measurements list --dateFrom -1d --revert=false
Get a list of measurements from the last day, showing the oldest first
```