### PR TITLE
feat: support filename placeholders in outputFile global flag

### DIFF
--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -23,6 +23,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/dataview"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/encrypt"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/extensions"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/fileutilities"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
@@ -722,6 +723,23 @@ func (f *Factory) WriteOutputWithRows(output []byte, params OutputContext, commo
 
 	unfilteredSize := 0
 	outputJSON := gjson.ParseBytes(output)
+
+	// write response to file instead of to stdout
+	if commonOptions.OutputFileRaw != "" {
+		fields := make(map[string]string)
+		// Only works if it is json, otherwise these values will be empty
+		props := []string{"id", "name", "type", "owner"}
+		for _, prop := range props {
+			fields[prop] = outputJSON.Get(prop).String()
+		}
+
+		fullFilePath, err := fileutilities.WriteToFile(strings.NewReader(outputJSON.Raw), commonOptions.OutputFileRaw, false, false, fields)
+		if err != nil {
+			return 0, cmderrors.NewSystemError("write to file failed", err)
+		}
+
+		logg.Infof("Saved response: %s", fullFilePath)
+	}
 
 	if len(output) > 0 || commonOptions.HasOutputTemplate() {
 		// estimate size based on utf8 encoding. 1 char is 1 byte

--- a/pkg/fileutilities/save.go
+++ b/pkg/fileutilities/save.go
@@ -1,0 +1,78 @@
+package fileutilities
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Matches control characters (0x00-0x1F, 0x7F) AND Windows forbidden chars: < > : " / \ | ? *
+var badPathChars = regexp.MustCompile(`[\x00-\x1F\x7F<>:"/\\|?*]`)
+
+func SanitizeFileName(userInput string) string {
+	// Standardize path formatting (removes redundant slashes or '.' markers)
+	cleaned := filepath.Clean(userInput)
+
+	// Wipe out Windows-illegal characters (except path separators) and control characters
+	sanitized := badPathChars.ReplaceAllString(cleaned, "_")
+
+	return sanitized
+}
+
+// WriteToFile write input to a filepath which can include template variables
+// @text	text to be written to file
+// @filename	filename
+// @directory	output directory. If empty, then a temp directory will be used
+// if filename
+func WriteToFile(src io.Reader, filename string, append bool, newline bool, fields map[string]string) (string, error) {
+	// Support simple variable substitution to be able to set the output file name dynamically to download a collection of files
+	if strings.Contains(filename, "{") && strings.Contains(filename, "}") {
+		for k, v := range fields {
+			fieldName := fmt.Sprintf("{%s}", k)
+			if strings.Contains(filename, fieldName) {
+				filename = strings.ReplaceAll(filename, fieldName, SanitizeFileName(v))
+			}
+		}
+	}
+
+	var out *os.File
+	var err error
+	dirPath := path.Dir(filename)
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return "", fmt.Errorf("could not create directory. dir=%s,  err=%w", dirPath, err)
+	}
+	if append {
+		out, err = os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	} else {
+		out, err = os.Create(filename)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("Could not create file. %s", err)
+	}
+	defer out.Close()
+
+	if append && newline {
+		if fs, err := out.Stat(); err == nil {
+			if fs.Size() > 0 {
+				// add newline when appending so that content is separated (only if file is not empty)
+				fmt.Fprintf(out, "\n")
+			}
+		}
+	}
+
+	// Write to file
+	_, writeErr := io.Copy(out, src)
+	if writeErr != nil {
+		return "", fmt.Errorf("failed to copy file contents to file. %s", err)
+	}
+
+	if fullpath, err := filepath.Abs(filename); err == nil {
+		return fullpath, nil
+	}
+	return filename, nil
+}

--- a/pkg/jsonformatter/jsonformatter.go
+++ b/pkg/jsonformatter/jsonformatter.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/fileutilities"
 	"github.com/tidwall/gjson"
 )
 
@@ -90,22 +90,17 @@ func WithOptionalFormatter(enabled bool, formatter ByteFormatter) OutputFormatte
 }
 
 func writeToFile(text []byte, filename string, append bool) error {
+	fields := make(map[string]string)
 
-	var out *os.File
-	var err error
-	if append {
-		out, err = os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	} else {
-		out, err = os.Create(filename)
+	if bytes.Contains(text, []byte("{")) && bytes.Contains(text, []byte("}")) {
+		// Only works if it is json, otherwise these values will be empty
+		props := []string{"id", "name", "type", "owner"}
+		for i, result := range gjson.GetManyBytes(text, props...) {
+			fields[props[i]] = result.String()
+		}
 	}
 
-	if err != nil {
-		return fmt.Errorf("Could not create file. %s", err)
-	}
-	defer out.Close()
-
-	// Writer the body to file
-	fmt.Fprintf(out, "%s\n", text)
+	_, err := fileutilities.WriteToFile(bytes.NewReader(text), filename, append, true, fields)
 
 	if err != nil {
 		return fmt.Errorf("failed to copy file contents to file. %s", err)

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -10,9 +10,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -27,6 +25,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/curly"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/dataview"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/encoding"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/fileutilities"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonUtilities"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonformatter"
@@ -800,10 +799,33 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 			newline := strings.Contains(strings.ToLower(resp.Response.Header.Get("Content-Type")), "json")
 			fields := make(map[string]string)
 			// Only works if it is json, otherwise these values will be empty
-			fields["name"] = resp.JSON("name").String()
-			fields["type"] = resp.JSON("type").String()
-			fields["owner"] = resp.JSON("owner").String()
-			fullFilePath, err := r.saveResponseToFile(resp, commonOptions.OutputFileRaw, false, newline, fields)
+			props := []string{"id", "name", "type", "owner"}
+			for _, prop := range props {
+				fields[prop] = resp.JSON(prop).String()
+			}
+
+			if _, params, err := mime.ParseMediaType(resp.Response.Header.Get("Content-Disposition")); err == nil {
+				if name, ok := params["filename"]; ok {
+					fields["filename"] = name
+				}
+			}
+			if resp.Response.Request != nil {
+				fields["basename"] = path.Base(resp.Response.Request.URL.Path)
+			}
+
+			if resp.Response.Request != nil {
+				r.Logger.Infof("Request: %s", resp.Response.Request.URL.Path)
+
+				for part := range strings.SplitSeq(resp.Response.Request.URL.Path, "/") {
+					if part != "" && c8y.IsID(part) {
+						r.Logger.Debugf("Found id like value. value=%s", part)
+						fields["id"] = part
+						break
+					}
+				}
+			}
+
+			fullFilePath, err := fileutilities.WriteToFile(bytes.NewReader(resp.Body()), commonOptions.OutputFileRaw, false, newline, fields)
 
 			if err != nil {
 				return 0, cmderrors.NewSystemError("write to file failed", err)
@@ -1067,95 +1089,6 @@ func (r *RequestHandler) guessDataProperty(resp *c8y.Response) string {
 		r.Logger.Debugf("Data property: %s", property)
 	}
 	return property
-}
-
-// saveResponseToFile saves a response to file
-// @filename	filename
-// @directory	output directory. If empty, then a temp directory will be used
-// if filename
-func (r *RequestHandler) saveResponseToFile(resp *c8y.Response, filename string, append bool, newline bool, fields map[string]string) (string, error) {
-
-	// Support simple variable substitution to be able to set the output file name dynamically to download a collection of files
-	if strings.Contains(filename, "{") && strings.Contains(filename, "}") {
-		if strings.Contains(filename, "{filename}") {
-			if _, params, err := mime.ParseMediaType(resp.Response.Header.Get("Content-Disposition")); err == nil {
-				if name, ok := params["filename"]; ok {
-					filename = strings.ReplaceAll(filename, "{filename}", name)
-				}
-			}
-		}
-
-		if strings.Contains(filename, "{basename}") {
-			if resp.Response.Request != nil {
-				filename = strings.ReplaceAll(filename, "{basename}", path.Base(resp.Response.Request.URL.Path))
-			}
-		}
-
-		if strings.Contains(filename, "{id}") {
-			if resp.Response.Request != nil {
-				r.Logger.Infof("Request: %s", resp.Response.Request.URL.Path)
-
-				urlParts := strings.Split(resp.Response.Request.URL.Path, "/")
-				for _, part := range urlParts {
-					if part != "" && c8y.IsID(part) {
-						r.Logger.Debugf("Found id like value. Substituting {id} for %s", part)
-						filename = strings.ReplaceAll(filename, "{id}", part)
-						break
-					}
-				}
-			} else {
-				r.Logger.Infof("Request is nill")
-			}
-		}
-
-		// Replace any additional fields
-		for k, v := range fields {
-			fieldName := fmt.Sprintf("{%s}", k)
-			if strings.Contains(filename, fieldName) {
-				r.Logger.Debugf("Replacing %s with %s", fieldName, v)
-				filename = strings.ReplaceAll(filename, fieldName, v)
-			}
-		}
-	}
-
-	var out *os.File
-	var err error
-	dirPath := path.Dir(filename)
-	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
-		return "", fmt.Errorf("could not create directory. dir=%s,  err=%w", dirPath, err)
-	}
-	if append {
-		out, err = os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	} else {
-		out, err = os.Create(filename)
-	}
-
-	if err != nil {
-		return "", fmt.Errorf("Could not create file. %s", err)
-	}
-	defer out.Close()
-
-	if append && newline {
-		if fs, err := out.Stat(); err == nil {
-			if fs.Size() > 0 {
-				// add newline when appending so that content is separated (only if file is not empty)
-				fmt.Fprintf(out, "\n")
-			}
-		}
-	}
-
-	// Writer the body to file
-	r.Logger.Printf("header: %v", resp.Header())
-	fmt.Fprintf(out, "%s", resp.Body())
-
-	if err != nil {
-		return "", fmt.Errorf("failed to copy file contents to file. %s", err)
-	}
-
-	if fullpath, err := filepath.Abs(filename); err == nil {
-		return fullpath, nil
-	}
-	return filename, nil
 }
 
 // HasJSONHeader returns true if the header contains a json content type

--- a/tests/manual/common/flags/outputFile/flag_outputfiler.yaml
+++ b/tests/manual/common/flags/outputFile/flag_outputfiler.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+tests:
+  It should support template expansion when storing output to file:
+    command: |
+      ./manual/common/flags/outputFile/tests.sh
+    exit-code: 0

--- a/tests/manual/common/flags/outputFile/tests.sh
+++ b/tests/manual/common/flags/outputFile/tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -ex
+
+export C8Y_SETTINGS_DEFAULTS_DRY=false
+
+createdir () {
+    # Cross-platform compatible
+    local name="${1:-"c8y-temp"}"
+    tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t "$name")
+    echo "$tmpdir"
+}
+
+export TEMP_DIR=$(createdir)
+
+IDS=()
+
+cleanup () {
+    exit_status=$?
+    for i in "${IDS[@]}"; do
+        c8y binaries delete --id "$i" || true
+    done
+    exit "$exit_status"
+}
+trap cleanup EXIT
+
+create_inventory () {
+    local name="$1"
+    local type="$2"
+    local mo_id=
+
+    mo_id=$( c8y inventory create -n -f --name "$name" --type "$type" --select id --output csv )
+    IDS+=("$mo_id")
+    echo "$mo_id"    
+}
+
+test01_api_command () {
+    NAME=$(c8y template execute -n --template "'ci_' + _.Char(10)")
+    TYPE=$(c8y template execute -n --template "'ci_type_' + _.Char(10)")
+    mo_id=$(create_inventory "$NAME" "$TYPE")
+    c8y inventory get -n --id "$mo_id" --select id,name,type --outputFile "$TEMP_DIR/output/prefix-{id}.{name}.{type}.json" --verbose
+    test -f "$TEMP_DIR/output/prefix-${mo_id}.${NAME}.${TYPE}.json"
+}
+
+test02_non_api_commands () {
+    printf '{"name":"foo1","type":"type1","owner":"owner1"}' | c8y util show --outputFile "$TEMP_DIR/output/prefix-{name}-{type}-{owner}.json" > /dev/null
+    test -f "$TEMP_DIR/output/prefix-foo1-type1-owner1.json"
+
+    printf '{"name":"foo2","type":"type2","owner":"owner2"}' | c8y template execute --template 'input.value' --outputFile "$TEMP_DIR/output/prefix-{name}-{type}-{owner}.json" > /dev/null
+    test -f "$TEMP_DIR/output/prefix-foo2-type2-owner2.json"
+}
+
+test02_non_api_commands

--- a/tests/manual/common/flags/outputFileRaw/tests.sh
+++ b/tests/manual/common/flags/outputFileRaw/tests.sh
@@ -36,8 +36,17 @@ create_inventory_binary () {
 
 test01 () {
     binary_id=$(create_inventory_binary "mycustomfilename.py")
-    c8y binaries get --id "$binary_id" --outputFileRaw "$TEMP_DIR/output/prefix-{id}.{filename}" > /dev/null
+    c8y binaries get --id "$binary_id" --outputFileRaw "$TEMP_DIR/output/prefix-{id}.{filename}" --verbose
     test -f "$TEMP_DIR/output/prefix-$binary_id.mycustomfilename.py"
 }
 
+test02_non_api_commands () {
+    printf '{"name":"foo1","type":"type1","owner":"owner1"}' | c8y util show --outputFileRaw "$TEMP_DIR/output/prefix-{name}-{type}-{owner}.json" > /dev/null
+    test -f "$TEMP_DIR/output/prefix-foo1-type1-owner1.json"
+
+    printf '{"name":"foo2","type":"type2","owner":"owner2"}' | c8y template execute --template 'input.value' --outputFileRaw "$TEMP_DIR/output/prefix-{name}-{type}-{owner}.json" > /dev/null
+    test -f "$TEMP_DIR/output/prefix-foo2-type2-owner2.json"
+}
+
 test01
+test02_non_api_commands


### PR DESCRIPTION
Add support for placholder expansion in the `--outputFile` global flag. This makes it easier to write output from multiple input.

Also, the `outputFile` and `outputFileRaw` are now supported non-API related commands, e.g.:

* `c8y util show`
* `c8y template execute`

**Note**

There is a gotcha here, that when using the following command, it will evaluate the `{name}` based on the first item in the list...so that means it is a single file that will include the output of all the devices.

```
c8y devices list --select name,type --outputFile 'tmp/{name}.json'
```

**Examples**

```sh
printf '{"name":"foo1","type":"type1","owner":"owner1"}' | c8y util show --outputFile 'output-{name}.json'
# => output-foo1.json

c8y devices list --select name,type | c8y util show --outputFile 'tmp/{name}.json'
```