### PR TITLE
feat: support using workers on assert commands

### DIFF
--- a/pkg/cmd/assert/text/text.manual.go
+++ b/pkg/cmd/assert/text/text.manual.go
@@ -3,9 +3,7 @@ package json
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"regexp"
 	"strings"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/spf13/cobra"
 )
@@ -130,20 +129,9 @@ func (n *CmdText) RunE(cmd *cobra.Command, args []string) error {
 		_ = n.factory.WriteOutputWithoutPropertyGuess(output, cmdutil.OutputContext{})
 	}
 
-	totalErrors := 0
-	var lastErr error
-	for {
-		err = nil
-		input, _, inputErr := iter.GetNext()
-
-		if inputErr == io.EOF {
-			break
-		}
-
-		if totalErrors >= cfg.AbortOnErrorCount() {
-			msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
-			return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
-		}
+	return n.factory.RunWithGenericWorkers(cmd, inputIterators, iter, func(j worker.Job) (any, error) {
+		var err error
+		input := j.Value.([]byte)
 
 		// schema match
 		if schema != nil {
@@ -179,22 +167,7 @@ func (n *CmdText) RunE(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
-
-		if err != nil {
-			if !errors.Is(err, cmderrors.ErrAssertion) || n.strictMode {
-				totalErrors++
-				lastErr = n.factory.CheckPostCommandError(err)
-
-				// wrap error so it is not printed twice, and is still an assertion error
-				cErr := cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAssertionError, lastErr)
-				cErr.Processed = true
-				lastErr = cErr
-			}
-		}
-	}
-	if totalErrors > 0 {
-		return lastErr
-	}
-	return nil
+		return nil, err
+	}, cmdutil.ProcessAssertError(n.factory, n.strictMode))
 
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/create/create.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/create/create.manual.go
@@ -112,5 +112,5 @@ func (n *CreateCmd) RunE(cmd *cobra.Command, args []string) error {
 
 		err = n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
 		return nil, err
-	})
+	}, nil)
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/delete/delete.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/delete/delete.manual.go
@@ -80,5 +80,5 @@ func (n *DeleteCmd) RunE(cmd *cobra.Command, args []string) error {
 		}
 		_, err = fmt.Fprintf(n.factory.IOStreams.ErrOut, "%s Deleted certificate-authority for tenant %s\n", cs.SuccessIconWithColor(cs.Red), client.GetTenantName(context.Background()))
 		return nil, err
-	})
+	}, nil)
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/get/get.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/get/get.manual.go
@@ -85,5 +85,5 @@ func (n *GetCmd) RunE(cmd *cobra.Command, args []string) error {
 
 		err = n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
 		return nil, err
-	})
+	}, nil)
 }

--- a/pkg/cmd/devicemanagement/certificate_authority/update/update.manual.go
+++ b/pkg/cmd/devicemanagement/certificate_authority/update/update.manual.go
@@ -111,5 +111,5 @@ func (n *UpdateCmd) RunE(cmd *cobra.Command, args []string) error {
 
 		err = n.factory.WriteOutputWithoutPropertyGuess(b, cmdutil.OutputContext{})
 		return nil, err
-	})
+	}, nil)
 }

--- a/pkg/cmd/deviceregistration/registerBulk/register-basic.manual.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-basic.manual.go
@@ -159,5 +159,5 @@ func (n *RegisterBasicCmd) RunE(cmd *cobra.Command, args []string) error {
 		Client:        c8yclient,
 		Factory:       n.factory,
 		CommonOptions: commonOptions,
-	}, mappings))
+	}, mappings), nil)
 }

--- a/pkg/cmd/deviceregistration/registerBulk/register-ca.manual.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-ca.manual.go
@@ -164,5 +164,5 @@ func (n *RegisterCumulocityCACmd) RunE(cmd *cobra.Command, args []string) error 
 		Client:        c8yclient,
 		Factory:       n.factory,
 		CommonOptions: commonOptions,
-	}, mappings))
+	}, mappings), nil)
 }

--- a/pkg/cmd/deviceregistration/registerBulk/register-external-ca.go
+++ b/pkg/cmd/deviceregistration/registerBulk/register-external-ca.go
@@ -159,5 +159,5 @@ func (n *RegisterExternalCACmd) RunE(cmd *cobra.Command, args []string) error {
 		Client:        c8yclient,
 		Factory:       n.factory,
 		CommonOptions: commonOptions,
-	}, mappings))
+	}, mappings), nil)
 }

--- a/pkg/cmd/devices/assert/factory/factory.manual.go
+++ b/pkg/cmd/devices/assert/factory/factory.manual.go
@@ -1,20 +1,17 @@
 package factory
 
 import (
-	"errors"
-	"fmt"
-	"io"
-	"strings"
 	"time"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8yfetcher"
-	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/desiredstate"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
 )
 
 type StateChecker interface {
@@ -85,42 +82,21 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			return err
 		}
 
-		state := h.GetStateHandler(cmd, client)
+		return f.RunWithGenericWorkers(cmd, inputIterators, path, func(j worker.Job) (any, error) {
+			state := h.GetStateHandler(cmd, client)
 
-		totalErrors := 0
-		var lastErr error
-		for {
-			itemID, input, inputErr := path.Execute(false)
+			itemID := gjson.ParseBytes(j.Value.([]byte))
+			input := j.Input
 
-			if inputErr == io.EOF {
-				break
-			}
-
-			if totalErrors >= cfg.AbortOnErrorCount() {
-				msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
-				return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
-			}
-
-			_ = state.SetValue(itemID)
+			// Skip checking if the input has errors
+			_ = state.SetValue(itemID.String())
 			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
-
 			if err == nil {
 				outValue := h.GetValue(result, input)
 				_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
 			}
-
-			if err != nil {
-				if !strings.Contains(err.Error(), "Max retries exceeded") || strictMode {
-					totalErrors++
-					_ = f.CheckPostCommandError(err)
-					lastErr = err
-				}
-			}
-		}
-		if totalErrors > 0 {
-			return lastErr
-		}
-		return nil
+			return nil, err
+		}, cmdutil.ProcessAssertError(f, strictMode))
 	}
 	return cmd
 }
@@ -195,44 +171,21 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			return err
 		}
 
-		state := h.GetStateHandler(cmd, client)
+		return f.RunWithGenericWorkers(cmd, inputIterators, path, func(j worker.Job) (any, error) {
+			state := h.GetStateHandler(cmd, client)
 
-		totalErrors := 0
-		var lastErr error
-		for {
-			itemID, input, inputErr := path.Execute(false)
+			itemID := gjson.ParseBytes(j.Value.([]byte))
+			input := j.Input
 
-			if inputErr == io.EOF {
-				break
-			}
-
-			if totalErrors >= cfg.AbortOnErrorCount() {
-				msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
-				return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
-			}
-
-			_ = state.SetValue(itemID)
+			// Skip checking if the input has errors
+			_ = state.SetValue(itemID.String())
 			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
-
 			if err == nil {
 				outValue := h.GetValue(result, input)
 				_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
 			}
-
-			if err != nil {
-				if !errors.Is(err, cmderrors.ErrAssertion) || strictMode {
-					totalErrors++
-					_ = f.CheckPostCommandError(err)
-					lastErr = err
-				}
-			}
-		}
-
-		// TODO: In strict mode print out the error earlier
-		if totalErrors > 0 {
-			return lastErr
-		}
-		return nil
+			return nil, err
+		}, cmdutil.ProcessAssertError(f, strictMode))
 	}
 	return cmd
 }

--- a/pkg/cmd/devices/enroll/enroll.manual.go
+++ b/pkg/cmd/devices/enroll/enroll.manual.go
@@ -437,7 +437,7 @@ func (n *DeviceEnrollCmd) RunE(cmd *cobra.Command, args []string) error {
 		}, &commonOptions)
 
 		return nil, nil
-	})
+	}, nil)
 }
 
 type EnrollmentResult struct {

--- a/pkg/cmd/inventory/assert/factory/factory.manual.go
+++ b/pkg/cmd/inventory/assert/factory/factory.manual.go
@@ -1,19 +1,17 @@
 package factory
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"time"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8yfetcher"
-	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/desiredstate"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
+	"github.com/tidwall/gjson"
 )
 
 type StateChecker interface {
@@ -84,52 +82,21 @@ func NewAssertCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateChecker)
 			return err
 		}
 
-		state := h.GetStateHandler(cmd, client)
+		return f.RunWithGenericWorkers(cmd, inputIterators, path, func(j worker.Job) (any, error) {
+			state := h.GetStateHandler(cmd, client)
 
-		totalErrors := 0
-		var lastErr error
-		var result interface{}
+			itemID := gjson.ParseBytes(j.Value.([]byte))
+			input := j.Input
 
-		for {
-			itemID, input, inputErr := path.Execute(false)
-
-			if inputErr == io.EOF {
-				break
+			// Skip checking if the input has errors
+			_ = state.SetValue(itemID.String())
+			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
+			if err == nil {
+				outValue := h.GetValue(result, input)
+				_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
 			}
-
-			if totalErrors >= cfg.AbortOnErrorCount() {
-				msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
-				return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
-			}
-
-			if inputErr == nil {
-				// Skip checking if the input has errors
-				_ = state.SetValue(itemID)
-				result, err = desiredstate.WaitForWithRetries(attempts, interval, duration, state)
-				if err == nil {
-					outValue := h.GetValue(result, input)
-					_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
-				}
-			} else {
-				err = inputErr
-			}
-
-			if err != nil {
-				if !errors.Is(err, cmderrors.ErrAssertion) || strictMode {
-					totalErrors++
-					lastErr = f.CheckPostCommandError(err)
-
-					// wrap error so it is not printed twice, and is still an assertion error
-					cErr := cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAssertionError, lastErr)
-					cErr.Processed = true
-					lastErr = cErr
-				}
-			}
-		}
-		if totalErrors > 0 {
-			return lastErr
-		}
-		return nil
+			return nil, err
+		}, cmdutil.ProcessAssertError(f, strictMode))
 	}
 	return cmd
 }
@@ -204,54 +171,21 @@ func NewAssertDeviceCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			return err
 		}
 
-		state := h.GetStateHandler(cmd, client)
+		return f.RunWithGenericWorkers(cmd, inputIterators, path, func(j worker.Job) (any, error) {
+			state := h.GetStateHandler(cmd, client)
 
-		totalErrors := 0
-		var lastErr error
-		var result interface{}
+			itemID := gjson.ParseBytes(j.Value.([]byte))
+			input := j.Input
 
-		for {
-			itemID, input, inputErr := path.Execute(false)
-
-			if inputErr == io.EOF {
-				break
+			// Skip checking if the input has errors
+			_ = state.SetValue(itemID.String())
+			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
+			if err == nil {
+				outValue := h.GetValue(result, input)
+				_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
 			}
-
-			if totalErrors >= cfg.AbortOnErrorCount() {
-				msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
-				return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
-			}
-
-			if inputErr == nil {
-				// Skip checking if the input has errors
-				_ = state.SetValue(itemID)
-				result, err = desiredstate.WaitForWithRetries(attempts, interval, duration, state)
-				if err == nil {
-					outValue := h.GetValue(result, input)
-					_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
-				}
-			} else {
-				err = inputErr
-			}
-
-			if err != nil {
-				if !errors.Is(err, cmderrors.ErrAssertion) || strictMode {
-					totalErrors++
-					lastErr = f.CheckPostCommandError(err)
-
-					// wrap error so it is not printed twice, and is still an assertion error
-					cErr := cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAssertionError, lastErr)
-					cErr.Processed = true
-					lastErr = cErr
-				}
-			}
-		}
-
-		// TODO: In strict mode print out the error earlier
-		if totalErrors > 0 {
-			return lastErr
-		}
-		return nil
+			return nil, err
+		}, cmdutil.ProcessAssertError(f, strictMode))
 	}
 	return cmd
 }

--- a/pkg/cmd/remoteaccess/connect/run/run.manual.go
+++ b/pkg/cmd/remoteaccess/connect/run/run.manual.go
@@ -229,5 +229,5 @@ func (n *CmdRun) RunE(cmd *cobra.Command, args []string) error {
 		}
 
 		return nil, runErr
-	})
+	}, nil)
 }

--- a/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
+++ b/pkg/cmd/remoteaccess/connect/ssh/ssh.manual.go
@@ -265,5 +265,5 @@ func (n *CmdSSH) RunE(cmd *cobra.Command, args []string) error {
 		}
 
 		return nil, sshErr
-	})
+	}, nil)
 }

--- a/pkg/cmd/remoteaccess/server/server.manual.go
+++ b/pkg/cmd/remoteaccess/server/server.manual.go
@@ -255,5 +255,5 @@ func (n *CmdServer) RunE(cmd *cobra.Command, args []string) error {
 
 		serverErr := craClient.Serve()
 		return nil, serverErr
-	})
+	}, nil)
 }

--- a/pkg/cmd/sessions/decrypttext/decryptText.manual.go
+++ b/pkg/cmd/sessions/decrypttext/decryptText.manual.go
@@ -128,5 +128,5 @@ func (n *CmdDecryptText) RunE(cmd *cobra.Command, args []string) error {
 			return "", err
 		}
 		return "", nil
-	})
+	}, nil)
 }

--- a/pkg/cmd/sessions/encrypttext/encryptText.manual.go
+++ b/pkg/cmd/sessions/encrypttext/encryptText.manual.go
@@ -114,5 +114,5 @@ func (n *CmdEncryptText) RunE(cmd *cobra.Command, args []string) error {
 			err = n.factory.WriteOutputWithoutPropertyGuess(encryptedText, cmdutil.OutputContext{})
 		}
 		return "", nil
-	})
+	}, nil)
 }

--- a/pkg/cmd/template/execute/execute.manual.go
+++ b/pkg/cmd/template/execute/execute.manual.go
@@ -136,5 +136,5 @@ func (n *CmdExecute) newTemplate(cmd *cobra.Command, args []string) error {
 			Input: j.Input,
 		}, &commonOptions)
 		return nil, err
-	})
+	}, nil)
 }

--- a/pkg/cmd/tenants/assert/exists/factory.manual.go
+++ b/pkg/cmd/tenants/assert/exists/factory.manual.go
@@ -1,18 +1,15 @@
 package exists
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"time"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/c8yfetcher"
-	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmdutil"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/completion"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/desiredstate"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/flags"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iterator"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/worker"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
 	"github.com/spf13/cobra"
 )
@@ -93,59 +90,28 @@ func NewAssertTenantCmdFactory(cmd *cobra.Command, f *cmdutil.Factory, h StateCh
 			return err
 		}
 
-		state := h.GetStateHandler(cmd, client)
+		return f.RunWithGenericWorkers(cmd, inputIterators, path, func(j worker.Job) (any, error) {
+			state := h.GetStateHandler(cmd, client)
 
-		totalErrors := 0
-		var lastErr error
-		var result interface{}
+			itemID := string(j.Value.([]byte))
+			input := j.Input
 
-		for {
-			tenantID, input, inputErr := path.Execute(false)
-
-			if tenantID != "" && input == nil {
-				// set the input manually when the value is not provided
-				// from the pipeline, and using the default value.
-				input = []byte(tenantID)
+			// when the value is not provided from the pipeline (e.g. using the
+			// default value or an explicit flag), use the resolved id as the input
+			// so it can be passed untouched to the output
+			if _, ok := input.([]byte); !ok {
+				input = j.Value
 			}
 
-			if inputErr == io.EOF {
-				break
+			// Skip checking if the input has errors
+			_ = state.SetValue(itemID)
+			result, err := desiredstate.WaitForWithRetries(attempts, interval, duration, state)
+			if err == nil {
+				outValue := h.GetValue(result, input)
+				_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
 			}
-
-			if totalErrors >= cfg.AbortOnErrorCount() {
-				msg := fmt.Sprintf("Too many errors. total=%d, max=%d. lastError=%s", totalErrors, cfg.AbortOnErrorCount(), lastErr)
-				return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAbortedWithErrors, msg)
-			}
-
-			if inputErr == nil {
-				// Skip checking if the input has errors
-				_ = state.SetValue(tenantID)
-				result, err = desiredstate.WaitForWithRetries(attempts, interval, duration, state)
-				if err == nil {
-					outValue := h.GetValue(result, input)
-					_ = f.WriteOutputWithoutPropertyGuess(outValue, cmdutil.OutputContext{})
-				}
-			} else {
-				err = inputErr
-			}
-
-			if err != nil {
-				if !errors.Is(err, cmderrors.ErrAssertion) || strictMode {
-					totalErrors++
-					lastErr = f.CheckPostCommandError(err)
-
-					// wrap error so it is not printed twice, and is still an assertion error
-					cErr := cmderrors.NewUserErrorWithExitCode(cmderrors.ExitAssertionError, lastErr)
-					cErr.Processed = true
-					lastErr = cErr
-				}
-			}
-		}
-
-		if totalErrors > 0 {
-			return lastErr
-		}
-		return nil
+			return nil, err
+		}, cmdutil.ProcessAssertError(f, strictMode))
 	}
 	return cmd
 }

--- a/pkg/cmderrors/cmderrors.go
+++ b/pkg/cmderrors/cmderrors.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	nativeErrors "errors"
+
 	"github.com/pkg/errors"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/iostreams"
 	"github.com/reubenmiller/go-c8y/pkg/c8y"
@@ -321,4 +323,13 @@ func NewErrorSummary(message string, errorsCh <-chan error) error {
 		return nil
 	}
 	return errorSummary
+}
+
+func IsNotFound(err error) bool {
+	if errResponse, ok := err.(*c8y.ErrorResponse); ok && errResponse != nil {
+		if errResponse.Response.StatusCode() == 404 {
+			return true
+		}
+	}
+	return nativeErrors.Is(err, ErrNoMatchesFound)
 }

--- a/pkg/cmdutil/assert.go
+++ b/pkg/cmdutil/assert.go
@@ -1,0 +1,29 @@
+package cmdutil
+
+import (
+	"errors"
+
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/cmderrors"
+)
+
+func (f *Factory) WithExitCodeError(exitCode cmderrors.ExitCode) func(error) error {
+	return func(err error) error {
+		err = f.CheckPostCommandError(err)
+		if err == nil {
+			return nil
+		}
+		wrappedErr := cmderrors.NewUserErrorWithExitCode(exitCode, err)
+		wrappedErr.Processed = true
+		return wrappedErr
+	}
+}
+
+func ProcessAssertError(f *Factory, strictMode bool) func(error) error {
+	return func(err error) error {
+		if !strictMode && errors.Is(err, cmderrors.ErrAssertion) {
+			// ignore assertion errors
+			return nil
+		}
+		return f.WithExitCodeError(cmderrors.ExitAssertionError)(err)
+	}
+}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -317,7 +317,7 @@ func (f *Factory) RunWithWorkers(client *c8y.Client, cmd *cobra.Command, req *c8
 	return w.ProcessRequestAndResponse(cmd, req, inputIterators)
 }
 
-func (f *Factory) RunWithGenericWorkers(cmd *cobra.Command, inputIterators *flags.RequestInputIterators, iter iterator.Iterator, runFunc worker.Runner) error {
+func (f *Factory) RunWithGenericWorkers(cmd *cobra.Command, inputIterators *flags.RequestInputIterators, iter iterator.Iterator, runFunc worker.Runner, checkError func(error) error) error {
 	client, err := f.Client()
 	if err != nil {
 		return err
@@ -349,7 +349,11 @@ func (f *Factory) RunWithGenericWorkers(cmd *cobra.Command, inputIterators *flag
 	// 	return err
 	// }
 
-	w, err := worker.NewGenericWorker(log, cfg, f.IOStreams, client, activityLogger, runFunc, f.CheckPostCommandError)
+	if checkError == nil {
+		checkError = f.CheckPostCommandError
+	}
+
+	w, err := worker.NewGenericWorker(log, cfg, f.IOStreams, client, activityLogger, runFunc, checkError)
 
 	if err != nil {
 		return err
@@ -502,12 +506,14 @@ func (f *Factory) CheckPostCommandError(err error) error {
 			silentStatusCodes = cfg.GetSilentStatusCodes()
 		}
 		if !cErr.IsSilent() && !strings.Contains(silentStatusCodes, fmt.Sprintf("%d", cErr.StatusCode)) {
-			if printLogEntries {
-				logg.Errorf("%s", cErr.ErrorPretty())
-			}
-			fmt.Fprintf(w, "%s\n", cErr.JSONString())
+			if !cErr.Processed {
+				if printLogEntries {
+					logg.Errorf("%s", cErr.ErrorPretty())
+				}
+				fmt.Fprintf(w, "%s\n", cErr.JSONString())
 
-			cErr.Processed = true
+				cErr.Processed = true
+			}
 			outErr = cErr
 		}
 	} else {
@@ -518,8 +524,11 @@ func (f *Factory) CheckPostCommandError(err error) error {
 			logg.Errorf("%s", cErr)
 		}
 		logg.Debugf("Processing unexpected error. %s, exitCode=%d", err, cErr.ExitCode)
-		fmt.Fprintf(w, "%s\n", cErr.JSONString())
-		cErr.Processed = true
+
+		if !cErr.Processed {
+			fmt.Fprintf(w, "%s\n", cErr.JSONString())
+			cErr.Processed = true
+		}
 		outErr = cErr
 	}
 

--- a/pkg/worker/generic_worker.go
+++ b/pkg/worker/generic_worker.go
@@ -368,7 +368,11 @@ func (w *GenericWorker) run(iter iterator.Iterator, commonOptions config.CommonC
 		if maxJobsReached {
 			message += fmt.Sprintf(". job limit exceeded=%v", maxJobsReached)
 		}
-		return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitCompletedWithErrors, message)
+		aggregateErr := cmderrors.NewUserErrorWithExitCode(cmderrors.ExitCompletedWithErrors, message)
+		// the individual errors have already been processed (logged) via CheckError,
+		// so flag the aggregate as processed to avoid emitting a redundant summary line
+		aggregateErr.Processed = true
+		return aggregateErr
 	}
 	if maxJobsReached {
 		return cmderrors.NewUserErrorWithExitCode(cmderrors.ExitJobLimitExceeded, fmt.Sprintf("max job limit exceeded. limit=%d", maxJobs))

--- a/tests/manual/alarms/assert/count/alarms_assert_count.yaml
+++ b/tests/manual/alarms/assert/count/alarms_assert_count.yaml
@@ -18,7 +18,7 @@ tests:
     It returns an error when the device does not exist (using pipeline):
         command: >
           echo "{\"id\":\"1\"}" | c8y alarms assert count --minimum 0
-        exit-code: 112            
+        exit-code: 112
         stderr:
             line-count: 1
             contains:


### PR DESCRIPTION
Support using the `--workers` global flag on assert style commands.

**Example**

```
echo "1\n1238303\n2\n3\n4\n" | c8y inventory assert exists --workers 5 --attempts 2
```