### PR TITLE
fix: fix with error in output templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.9
+	github.com/reubenmiller/go-c8y v0.37.10
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.9 h1:55XOj9G5fok84gOexyuLny+o9bF5chCBvzOyHVBFOqU=
-github.com/reubenmiller/go-c8y v0.37.9/go.mod h1:omJlFF3uDmYwbhiBC5ll5mq44+Yk9jax+tDzkjNje/A=
+github.com/reubenmiller/go-c8y v0.37.10 h1:a3w/HSsZZ5MUVeF2jGKVotBnVa95XWD00g7xk3aUyR8=
+github.com/reubenmiller/go-c8y v0.37.10/go.mod h1:omJlFF3uDmYwbhiBC5ll5mq44+Yk9jax+tDzkjNje/A=
 github.com/reubenmiller/go-c8y/v2 v2.0.0-20260318160755-635d890df069 h1:aXy+nj/MHQjF8WWiSohXakDDxhfBwvFP5UIHKls+Kfs=
 github.com/reubenmiller/go-c8y/v2 v2.0.0-20260318160755-635d890df069/go.mod h1:djqzpynYVs+Q+7azobc1mKEh0B1u2zSKCIY0ZB2zy4M=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=

--- a/pkg/cmd/ui/plugins/create/create.manual.go
+++ b/pkg/cmd/ui/plugins/create/create.manual.go
@@ -261,7 +261,8 @@ func (n *CmdCreate) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := c8y.WithCommonOptionsContext(context.Background(), c8y.CommonOptions{
-		DryRun: dryRun,
+		DryRun:    dryRun,
+		WithError: commonOptions.WithError,
 	})
 
 	file, fileErr := os.Open(n.file)

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -1911,6 +1911,7 @@ func (c *Config) GetOutputCommonOptions(cmd *cobra.Command) (CommonCommandOption
 		OutputFile:     c.GetOutputFile(),
 		OutputFileRaw:  c.GetOutputFileRaw(),
 		OutputTemplate: c.GetOutputTemplate(),
+		WithError:      c.WithError(),
 	}
 
 	// Store flag values for usage in the output template

--- a/pkg/config/commonoptions.go
+++ b/pkg/config/commonoptions.go
@@ -16,6 +16,7 @@ type CommonCommandOptions struct {
 	CommandFlags      map[string]string
 	Filters           *jsonfilter.JSONFilters
 	ResultProperty    string
+	WithError         bool
 	IncludeAll        bool
 	WithTotalPages    bool
 	WithTotalElements bool

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -92,7 +92,8 @@ func (r *RequestHandler) ProcessRequestAndResponse(requests []c8y.RequestOptions
 		ctx,
 		c8y.GetContextCommonOptionsKey(),
 		c8y.CommonOptions{
-			DryRun: req.DryRun,
+			DryRun:    req.DryRun,
+			WithError: r.Config.WithError(),
 			OnResponse: func(response *http.Response) io.Reader {
 				// Add progress bar for binary downloads
 				prog := r.IO.ProgressIndicator()
@@ -875,12 +876,20 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 		printResponseSize(r.Logger, resp)
 
 		var responseText []byte
+
+		dataProperty := commonOptions.ResultProperty
+
+		if respError != nil && r.Config.WithError() {
+			// use the raw response
+			serverError := cmderrors.NewServerError(resp, respError, r.IO, !r.Config.WithError())
+			resp.SetBody([]byte(serverError.JSONString()))
+			dataProperty = "-"
+		}
+
 		isJSONResponse := jsonUtilities.IsValidJSON(resp.Body())
 
-		dataProperty := ""
 		showRaw := r.Config.RawOutput() || r.Config.WithTotalPages() || r.Config.WithTotalElements()
 
-		dataProperty = commonOptions.ResultProperty
 		if dataProperty == "" {
 			dataProperty = r.guessDataProperty(resp)
 		} else if dataProperty == "-" {
@@ -1026,7 +1035,7 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 		r.IO.WaitForProgressIndicator()
 
 		consol := r.Console
-		if respError == nil {
+		if respError == nil || commonOptions.WithError {
 			jsonformatter.WithOutputFormatters(
 				consol,
 				responseText,
@@ -1046,7 +1055,11 @@ func (r *RequestHandler) ProcessResponse(resp *c8y.Response, respError error, in
 		if userErr, ok := respError.(cmderrors.CommandError); ok {
 			return unfilteredSize, userErr
 		}
-		return unfilteredSize, cmderrors.NewServerError(resp, respError, r.IO, !r.Config.WithError())
+		rErr := cmderrors.NewServerError(resp, respError, r.IO, !r.Config.WithError())
+		if hasOutputTemplate {
+			rErr.Processed = true
+		}
+		return unfilteredSize, rErr
 	}
 	return unfilteredSize, nil
 }

--- a/tests/manual/common/flags/withError/flag_withError.yaml
+++ b/tests/manual/common/flags/withError/flag_withError.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reubenmiller/commander/feat/handle-nested-files/schema.json
+
+config:
+  env:
+    C8Y_SETTINGS_LOGGER_HIDESENSITIVE: true
+tests:
+  It should allow output templates to use the error when shaping the output:
+    command: |
+      c8y inventory get -n --id 1 --withError -o json --outputTemplate '
+        if std.objectHas(output, "errorType") then
+          {isError:true, input: input.value, output: output}
+        else
+          output
+      '
+    exit-code: 4
+    stdout:
+      json:
+        input: "1"
+        isError: "true"
+        output.errorType: serverError
+        output.message: r/^.+$
+        output.statusCode: "404"


### PR DESCRIPTION
Allow users to use `--outputTemplate` along with `--withError` to shape the error output.

**Example**

```
echo 1 | c8y inventory get --withError -o json --outputTemplate '
  if std.objectHas(output, "errorType") then
    {isError:true, input: input.value, output: output}
  else
    output
'
```