### PR TITLE
feat: improve table output column and width calculation

### DIFF
--- a/docs/go-c8y-cli/docs/configuration/settings.md
+++ b/docs/go-c8y-cli/docs/configuration/settings.md
@@ -472,3 +472,11 @@ It is recommended to only use this setting in your session file if you want a cu
 Row rendering mode. Accepts `truncate`, `wrap` or `overflow`. `truncated` is the default setting, however if there is an invalid settings, then `overflow` will be used.
 
 In `wrap` mode, row separators will also be included to better visually delimit the table cells.
+
+### views.sampleSize: int
+
+Maximum number of rows which are sampled when resolving the table columns and column widths. Sampling more rows makes the table layout more reliable when the first row does not contain all of the selected fragments, at the cost of slightly delaying the output. Defaults to `5`. Setting it to `1` resolves the columns and widths from the first row only.
+
+### views.sampleTimeout: string
+
+Maximum duration to buffer rows whilst waiting for more rows to be sampled, so that streamed output (e.g. realtime subscriptions) is not delayed indefinitely. Accepts a duration where the default unit is milliseconds, e.g. `500ms`, `1s`. Defaults to `500ms`. Setting it to `0` disables the timeout, so buffered rows are only rendered once the sample size is reached or no more output is expected.

--- a/pkg/cmd/root/command.go
+++ b/pkg/cmd/root/command.go
@@ -169,6 +169,8 @@ func NewCommand(buildVersion, buildBranch string) (*CmdRoot, error) {
 		ColumnPadding:            configHandler.ViewColumnPadding(),
 		RowMode:                  configHandler.ViewRowMode(),
 		NumberFormatter:          configHandler.GetTableViewNumberFormatter(),
+		SampleSize:               configHandler.ViewSampleSize(),
+		SampleTimeout:            configHandler.ViewSampleTimeout(),
 	}
 	consoleHandler = console.NewConsole(rootCmd.OutOrStdout(), tableOptions, func(s []string) []byte {
 		return getOutputHeaders(consoleHandler, configHandler, s)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -160,6 +160,16 @@ type CmdRoot struct {
 	muDataView  sync.RWMutex
 }
 
+// Execute runs the command and flushes any buffered output afterwards
+// (e.g. table output samples multiple rows before resolving the columns)
+func (c *CmdRoot) Execute() error {
+	err := c.Command.Execute()
+	if consol, consolErr := c.Factory.Console(); consolErr == nil && consol != nil {
+		consol.Flush()
+	}
+	return err
+}
+
 func NewCmdRoot(f *cmdutil.Factory, version, buildDate string) *CmdRoot {
 	ccmd := &CmdRoot{
 		Factory: f,

--- a/pkg/cmd/settings/update/update.manual.go
+++ b/pkg/cmd/settings/update/update.manual.go
@@ -404,6 +404,20 @@ var updateSettingsOptions = map[string]argumentHandler{
 		"30",
 	}, nil, cobra.ShellCompDirectiveNoFileComp},
 
+	"views.sampleSize": {"views.sampleSize", "int", config.SettingsViewSampleSize, []string{
+		"1",
+		"5",
+		"10",
+		"20",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
+	"views.sampleTimeout": {"views.sampleTimeout", "string", config.SettingsViewSampleTimeout, []string{
+		"0ms",
+		"500ms",
+		"1s",
+		"5s",
+	}, nil, cobra.ShellCompDirectiveNoFileComp},
+
 	//
 	// Table view number format
 	//

--- a/pkg/config/cliConfiguration.go
+++ b/pkg/config/cliConfiguration.go
@@ -291,6 +291,12 @@ const (
 	// SettingsViewRowMode controls row rendering, e.g. wrapping or truncation
 	SettingsViewRowMode = "settings.views.rowMode"
 
+	// SettingsViewSampleSize maximum number of rows which are sampled when resolving the table columns and column widths
+	SettingsViewSampleSize = "settings.views.sampleSize"
+
+	// SettingsViewSampleTimeout maximum duration to buffer rows whilst waiting for more rows to be sampled, so that streamed output (e.g. realtime subscriptions) is not delayed indefinitely. Accepts a duration, where the default unit is milliseconds
+	SettingsViewSampleTimeout = "settings.views.sampleTimeout"
+
 	// SettingsViewNumberFormat number format
 	SettingsViewNumberFormat = "settings.views.numberFormat"
 
@@ -587,6 +593,8 @@ func (c *Config) bindSettings() {
 		WithBindEnv(SettingsViewMaxColumnWidth, 80),
 		WithBindEnv(SettingsViewColumnPadding, 15),
 		WithBindEnv(SettingsViewRowMode, "truncate"),
+		WithBindEnv(SettingsViewSampleSize, 5),
+		WithBindEnv(SettingsViewSampleTimeout, "500ms"),
 
 		// Table number formatter
 		WithBindEnv(SettingsViewNumberFormat, NumberFormatMetric),
@@ -1439,6 +1447,16 @@ func (c *Config) ViewColumnPadding() int {
 // ViewRowMode get view row rendering mode (truncation or wrapping)
 func (c *Config) ViewRowMode() string {
 	return strings.ToLower(c.viper.GetString(SettingsViewRowMode))
+}
+
+// ViewSampleSize maximum number of rows which are sampled when resolving the table columns and column widths
+func (c *Config) ViewSampleSize() int {
+	return c.viper.GetInt(SettingsViewSampleSize)
+}
+
+// ViewSampleTimeout maximum duration to buffer rows whilst waiting for more rows to be sampled
+func (c *Config) ViewSampleTimeout() time.Duration {
+	return c.getDuration(SettingsViewSampleTimeout)
 }
 
 // RequestTimeout timeout to use when sending requests

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -6,27 +6,44 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/config"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonUtilities"
+	"github.com/reubenmiller/go-c8y-cli/v2/pkg/jsonfilter"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/numbers"
 	"github.com/reubenmiller/go-c8y-cli/v2/pkg/tableviewer"
 	"github.com/tidwall/pretty"
 )
 
+// DefaultSampleSize maximum number of rows sampled when resolving table columns
+const DefaultSampleSize = 5
+
+// DefaultTableFlushTimeout maximum time the first table rows are buffered while
+// waiting for more rows to be sampled, so long-running streams (e.g. realtime
+// subscriptions) are not delayed indefinitely
+const DefaultTableFlushTimeout = 500 * time.Millisecond
+
 // Console thread safe way to write to an output
 type Console struct {
-	mu          sync.Mutex
-	count       uint64
-	out         io.Writer
-	header      func([]string) []byte
-	samples     []string
-	sampleCount int
-	Colorized   bool
-	Compact     bool
-	Disabled    bool
-	Format      config.OutputFormat
-	TableViewer *tableviewer.TableView
+	mu               sync.Mutex
+	count            uint64
+	out              io.Writer
+	header           func([]string) []byte
+	samples          []string
+	sampleGroups     [][]jsonfilter.KeyGroup
+	sampleCount      int
+	sampleSize       int
+	sampleTimeout    time.Duration
+	tableBuffer      [][]byte
+	tableFlushed     bool
+	tableHeaderShown bool
+	flushTimer       *time.Timer
+	Colorized        bool
+	Compact          bool
+	Disabled         bool
+	Format           config.OutputFormat
+	TableViewer      *tableviewer.TableView
 }
 
 // TableOptions table options to control the column behaviour
@@ -49,6 +66,16 @@ type TableOptions struct {
 
 	// NumberFormatter formatting used when rendering numbers
 	NumberFormatter numbers.NumberFormatter
+
+	// SampleSize maximum number of rows which are sampled when resolving
+	// the table columns and column widths. If set to 0, then a default value will be used
+	SampleSize int
+
+	// SampleTimeout maximum duration to buffer rows whilst waiting for more rows
+	// to be sampled, so that streamed output is not delayed indefinitely.
+	// If set to 0, then buffered rows are only rendered once the sample size is
+	// reached or no more output is expected
+	SampleTimeout time.Duration
 }
 
 // NewConsole create a new console writer
@@ -58,6 +85,8 @@ func NewConsole(w io.Writer, tableOptions *TableOptions, header func([]string) [
 	columnPadding := 15
 	minEmptyWidth := 0
 	rowMode := ""
+	sampleSize := DefaultSampleSize
+	sampleTimeout := DefaultTableFlushTimeout
 	var numberFormatter numbers.NumberFormatter
 
 	if tableOptions != nil {
@@ -67,11 +96,17 @@ func NewConsole(w io.Writer, tableOptions *TableOptions, header func([]string) [
 		minEmptyWidth = tableOptions.MinEmptyValueColumnWidth
 		rowMode = tableOptions.RowMode
 		numberFormatter = tableOptions.NumberFormatter
+		if tableOptions.SampleSize > 0 {
+			sampleSize = tableOptions.SampleSize
+		}
+		sampleTimeout = tableOptions.SampleTimeout
 	}
 
 	return &Console{
-		out:    w,
-		header: header,
+		out:           w,
+		header:        header,
+		sampleSize:    sampleSize,
+		sampleTimeout: sampleTimeout,
 		TableViewer: &tableviewer.TableView{
 			Out:                      w,
 			MinColumnWidth:           minColumnWidth,
@@ -81,6 +116,7 @@ func NewConsole(w io.Writer, tableOptions *TableOptions, header func([]string) [
 			EnableColor:              false,
 			RowMode:                  rowMode,
 			NumberFormatter:          numberFormatter,
+			SampleSize:               sampleSize,
 		},
 		Format: config.OutputTable,
 	}
@@ -122,13 +158,65 @@ func (c *Console) IsTable() bool {
 	return c.Format == config.OutputTable
 }
 
-func (c *Console) SetHeaderFromInput(input string) {
+func (c *Console) SetHeaderFromInput(input string, groups []jsonfilter.KeyGroup) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.sampleCount < 5 {
+	if c.sampleCount < c.sampleLimit() {
 		c.samples = append(c.samples, input)
+		c.sampleGroups = append(c.sampleGroups, groups)
 		c.sampleCount++
 	}
+}
+
+// sampleLimit maximum number of rows which are sampled when resolving table columns
+func (c *Console) sampleLimit() int {
+	if c.sampleSize > 0 {
+		return c.sampleSize
+	}
+	return DefaultSampleSize
+}
+
+// renderTableRow render a single row, only including the table header if it has not been shown yet
+func (c *Console) renderTableRow(b []byte) {
+	c.TableViewer.Render(b, !c.tableHeaderShown)
+	c.tableHeaderShown = true
+}
+
+// flushTable resolve the table columns from the sampled rows and render any buffered rows.
+// The caller must hold the mutex
+func (c *Console) flushTable() {
+	if c.tableFlushed {
+		return
+	}
+	c.tableFlushed = true
+	if c.flushTimer != nil {
+		c.flushTimer.Stop()
+		c.flushTimer = nil
+	}
+
+	if len(c.TableViewer.Columns) == 0 {
+		if cols := jsonfilter.MergeKeyGroups(c.sampleGroups); len(cols) > 0 {
+			c.TableViewer.Columns = cols
+		} else if len(c.samples) > 0 {
+			c.TableViewer.Columns = strings.Split(c.samples[0], ",")
+		}
+	}
+
+	// resolve the column widths from all of the sampled rows (not just the first row)
+	c.TableViewer.SampleColumnWidths(c.tableBuffer)
+
+	for _, row := range c.tableBuffer {
+		c.renderTableRow(row)
+	}
+	c.tableBuffer = nil
+}
+
+// Flush render any buffered table output. It should be called once
+// no more output is expected (e.g. at the end of a command)
+func (c *Console) Flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.flushTable()
 }
 
 // Printf mimics fmt.Printf
@@ -151,7 +239,6 @@ func (c *Console) Write(b []byte) (n int, err error) {
 	if c.count == 0 && c.header != nil {
 		fmt.Fprintf(c.out, "%s", c.header(c.samples))
 	}
-	showHeader := c.count == 0
 	c.count++
 	c.TableViewer.EnableColor = c.Colorized
 
@@ -159,14 +246,24 @@ func (c *Console) Write(b []byte) (n int, err error) {
 
 		switch c.Format {
 		case config.OutputTable:
-			cols := []string{}
-			if len(c.samples) > 0 {
-				cols = append(cols, strings.Split(c.samples[0], ",")...)
+			if !c.tableFlushed {
+				// Buffer the first rows so the table columns can be resolved
+				// against multiple rows instead of just the first one, as the
+				// first row may not contain all of the selected fragments
+				row := make([]byte, len(b))
+				copy(row, b)
+				c.tableBuffer = append(c.tableBuffer, row)
+				if len(c.tableBuffer) >= c.sampleLimit() {
+					c.flushTable()
+				} else if c.flushTimer == nil && c.sampleTimeout > 0 {
+					// don't delay streamed output indefinitely (e.g. realtime subscriptions)
+					c.flushTimer = time.AfterFunc(c.sampleTimeout, func() {
+						c.Flush()
+					})
+				}
+				return 0, nil
 			}
-			if len(c.TableViewer.Columns) == 0 {
-				c.TableViewer.Columns = cols
-			}
-			c.TableViewer.Render(b, showHeader)
+			c.renderTableRow(b)
 			return 0, nil
 		}
 

--- a/pkg/jsonfilter/jsonfilter.go
+++ b/pkg/jsonfilter/jsonfilter.go
@@ -42,7 +42,60 @@ type JSONFilters struct {
 	AsCompletionFormat bool
 }
 
-func (f JSONFilters) Apply(jsonValue string, property string, showHeaders bool, setHeaderFunc func(string)) ([]byte, error) {
+// KeyGroup records which concrete json keys a single select pattern resolved to
+// within one row. Keys is empty when the pattern did not match anything in the row
+type KeyGroup struct {
+	// Pattern original (non-lowercased) select pattern
+	Pattern string
+
+	// Keys resolved json keys (empty if the pattern did not match)
+	Keys []string
+}
+
+// HeaderFunc callback which receives the resolved keys of a single row.
+// keys is the flat comma separated list (unmatched patterns are included as-is),
+// and groups contains the keys grouped by the select pattern which resolved them
+type HeaderFunc func(keys string, groups []KeyGroup)
+
+// MergeKeyGroups merges the resolved keys of multiple sampled rows into a single
+// ordered column list. Columns are ordered by select pattern, and each pattern
+// expands to the union of the keys it resolved to across all rows (deduplicated
+// case insensitively). Patterns which did not resolve against any row are
+// included as-is so the user can still see which selector returned nothing
+func MergeKeyGroups(rows [][]KeyGroup) []string {
+	patterns := []string{}
+	keysByPattern := map[string][]string{}
+	seenKeys := map[string]map[string]bool{}
+
+	for _, row := range rows {
+		for _, group := range row {
+			if _, ok := keysByPattern[group.Pattern]; !ok {
+				patterns = append(patterns, group.Pattern)
+				keysByPattern[group.Pattern] = []string{}
+				seenKeys[group.Pattern] = map[string]bool{}
+			}
+			for _, key := range group.Keys {
+				keyl := strings.ToLower(key)
+				if !seenKeys[group.Pattern][keyl] {
+					seenKeys[group.Pattern][keyl] = true
+					keysByPattern[group.Pattern] = append(keysByPattern[group.Pattern], key)
+				}
+			}
+		}
+	}
+
+	columns := []string{}
+	for _, pattern := range patterns {
+		if keys := keysByPattern[pattern]; len(keys) > 0 {
+			columns = append(columns, keys...)
+		} else {
+			columns = append(columns, pattern)
+		}
+	}
+	return columns
+}
+
+func (f JSONFilters) Apply(jsonValue string, property string, showHeaders bool, setHeaderFunc HeaderFunc) ([]byte, error) {
 	return f.filterJSON(jsonValue, property, showHeaders, setHeaderFunc)
 }
 
@@ -158,21 +211,22 @@ func (f *JSONFilters) Add(property, operation string, value interface{}) {
 }
 
 // FilterPropertyByWildcard filter a json string by using globstar (wildcards) on the nested json paths
-func FilterPropertyByWildcard(jsonValue string, prefix string, patterns []string, setAlias bool) (map[string]interface{}, []string, error) {
+func FilterPropertyByWildcard(jsonValue string, prefix string, patterns []string, setAlias bool) (map[string]interface{}, []string, []KeyGroup, error) {
 	rawMap := make(map[string]interface{})
 	err := c8y.DecodeJSONBytes([]byte(jsonValue), &rawMap)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	Logger.Debugf("flattening json")
 	flatMap, err := flatten.Flatten(rawMap, prefix, flatten.DotStyle)
 	Logger.Debugf("finished flattening json")
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	compiledPatterns := []glob.Glob{}
 	aliases := []string{}
+	originalPatterns := []string{}
 	filteredMap := make(map[string]interface{})
 
 	for _, p := range patterns {
@@ -183,6 +237,7 @@ func FilterPropertyByWildcard(jsonValue string, prefix string, patterns []string
 			alias = p[0:idx]
 			p = p[idx+1:]
 		}
+		originalPattern := p
 		p = strings.ToLower(p)
 
 		if p != "" {
@@ -193,18 +248,20 @@ func FilterPropertyByWildcard(jsonValue string, prefix string, patterns []string
 			}); err == nil {
 				compiledPatterns = append(compiledPatterns, cp)
 				aliases = append(aliases, alias)
+				originalPatterns = append(originalPatterns, originalPattern)
 			}
 		}
 	}
 
 	Logger.Debugf("running filterFlatMap")
-	resolvedProperties, _ := filterFlatMap(flatMap, filteredMap, compiledPatterns, aliases)
+	resolvedProperties, keyGroups, _ := filterFlatMap(flatMap, filteredMap, compiledPatterns, aliases, originalPatterns)
 	Logger.Debugf("finished filterFlatMap")
-	return filteredMap, resolvedProperties, err
+	return filteredMap, resolvedProperties, keyGroups, err
 }
 
-func filterFlatMap(src map[string]interface{}, dst map[string]interface{}, patterns []glob.Glob, aliases []string) ([]string, error) {
+func filterFlatMap(src map[string]interface{}, dst map[string]interface{}, patterns []glob.Glob, aliases []string, originalPatterns []string) ([]string, []KeyGroup, error) {
 	sortedKeys := []string{}
+	keyGroups := []KeyGroup{}
 
 	// sort source map keys, so matching is stable when using alias
 	// where one pattern can match multiple values (otherwise it will be random which property is selected)
@@ -223,6 +280,10 @@ func filterFlatMap(src map[string]interface{}, dst map[string]interface{}, patte
 
 	for i, pattern := range patterns {
 		found := false
+		group := KeyGroup{Pattern: pattern.String()}
+		if i < len(originalPatterns) {
+			group.Pattern = originalPatterns[i]
+		}
 		Logger.Debugf("filtering keys by pattern: total=%d, pattern=%s", len(sourceKeys), pattern.String())
 		for _, key := range sourceKeys {
 			value := src[key]
@@ -270,34 +331,51 @@ func filterFlatMap(src map[string]interface{}, dst map[string]interface{}, patte
 				}
 				dst[key] = value
 				sortedKeys = append(sortedKeys, key)
+				group.Keys = append(group.Keys, key)
 				found = true
 			}
 		}
 		if !found && !pattern.IsNegative() {
 			// store non-matching patterns for csv generation
-			sortedKeys = append(sortedKeys, pattern.String())
+			// using the original (non-lowercased) pattern so later rows
+			// can still resolve the value via a case-sensitive path lookup
+			sortedKeys = append(sortedKeys, group.Pattern)
 		}
+		if !pattern.IsNegative() {
+			keyGroups = append(keyGroups, group)
+		}
+	}
+
+	isNegatedKey := func(key string) bool {
+		keyl := strings.ToLower(key)
+		for _, pattern := range patterns {
+			if pattern.IsNegative() && pattern.MatchString(keyl) {
+				return true
+			}
+		}
+		return false
 	}
 
 	// filter for negated keys
 	sortedMatchingKeys := make([]string, 0)
 	for _, key := range sortedKeys {
-		keyl := strings.ToLower(key)
-		match := true
-		for _, pattern := range patterns {
-			if pattern.IsNegative() {
-				if pattern.MatchString(keyl) {
-					match = false
-					delete(dst, key)
-				}
-			}
-		}
-		if match {
+		if isNegatedKey(key) {
+			delete(dst, key)
+		} else {
 			sortedMatchingKeys = append(sortedMatchingKeys, key)
 		}
 	}
+	for i := range keyGroups {
+		matchingKeys := make([]string, 0, len(keyGroups[i].Keys))
+		for _, key := range keyGroups[i].Keys {
+			if !isNegatedKey(key) {
+				matchingKeys = append(matchingKeys, key)
+			}
+		}
+		keyGroups[i].Keys = matchingKeys
+	}
 
-	return sortedMatchingKeys, nil
+	return sortedMatchingKeys, keyGroups, nil
 }
 
 // NewJSONFilters create a json filter
@@ -346,7 +424,7 @@ func formatErrors(errs []error) error {
 	return nil
 }
 
-func (f JSONFilters) filterJSON(jsonValue string, property string, showHeaders bool, setHeaderFunc func(string)) ([]byte, error) {
+func (f JSONFilters) filterJSON(jsonValue string, property string, showHeaders bool, setHeaderFunc HeaderFunc) ([]byte, error) {
 	var b bytes.Buffer
 
 	var jq *gojsonq.JSONQ
@@ -426,9 +504,9 @@ func (f JSONFilters) filterJSON(jsonValue string, property string, showHeaders b
 			for _, myval := range formattedJSON.Array() {
 
 				if myval.IsObject() {
-					if line, keys := f.pluckJsonValues(&myval, f.Pluck); line != "" {
+					if line, keys, keyGroups := f.pluckJsonValues(&myval, f.Pluck); line != "" {
 						outputValues = append(outputValues, line)
-						setHeaderFunc(strings.Join(keys, ","))
+						setHeaderFunc(strings.Join(keys, ","), keyGroups)
 					}
 				} else {
 					outputValues = append(outputValues, myval.Raw)
@@ -437,8 +515,8 @@ func (f JSONFilters) filterJSON(jsonValue string, property string, showHeaders b
 			return []byte(strings.Join(outputValues, "\n")), formatErrors(jq.Errors())
 		}
 
-		if line, keys := f.pluckJsonValues(&formattedJSON, f.Pluck); line != "" {
-			setHeaderFunc(strings.Join(keys, ","))
+		if line, keys, keyGroups := f.pluckJsonValues(&formattedJSON, f.Pluck); line != "" {
+			setHeaderFunc(strings.Join(keys, ","), keyGroups)
 			return []byte(line), formatErrors(jq.Errors())
 		}
 
@@ -494,9 +572,9 @@ func resolveKeyName(item *gjson.Result, key string) (name string, value interfac
 	return key, nil, nil
 }
 
-func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (string, []string) {
+func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (string, []string, []KeyGroup) {
 	if item == nil {
-		return "", nil
+		return "", nil, nil
 	}
 
 	if len(properties) == 0 {
@@ -510,9 +588,9 @@ func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (s
 	}
 
 	useAliases := false
-	flatMap, flatKeys, err := FilterPropertyByWildcard(item.Raw, "", pathPatterns, useAliases)
+	flatMap, flatKeys, keyGroups, err := FilterPropertyByWildcard(item.Raw, "", pathPatterns, useAliases)
 	if err != nil {
-		return "", nil
+		return "", nil, nil
 	}
 
 	output := bytes.Buffer{}
@@ -520,11 +598,11 @@ func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (s
 	// json output
 	var v []byte
 	if f.AsCSV {
-		return convertToCSV(flatMap, flatKeys, ","), flatKeys
+		return convertToCSV(flatMap, flatKeys, ","), flatKeys, keyGroups
 	} else if f.AsTSV {
-		return convertToCSV(flatMap, flatKeys, "\t"), flatKeys
+		return convertToCSV(flatMap, flatKeys, "\t"), flatKeys, keyGroups
 	} else if f.AsCompletionFormat {
-		return convertToLine(flatMap, flatKeys), flatKeys
+		return convertToLine(flatMap, flatKeys), flatKeys, keyGroups
 	} else if f.Flatten {
 		v, err = json.Marshal(flatMap)
 	} else {
@@ -532,7 +610,7 @@ func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (s
 		Logger.Debugf("running unflatten. %v", pathPatterns)
 		if len(pathPatterns) == 1 && pathPatterns[0] == "**" {
 			Logger.Debugf("Returning all keys because globstar is being used")
-			return item.Raw, flatKeys
+			return item.Raw, flatKeys, keyGroups
 		}
 
 		// Protect against large amount of keys adn
@@ -547,7 +625,7 @@ func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (s
 				f.Logger.Warnf("Detected json with a large number of keys, returning all data by default. Use jq for further filtering. total_keys=%d, id=%s", keyCount, itemID)
 			}
 
-			return item.Raw, flatKeys
+			return item.Raw, flatKeys, keyGroups
 		}
 
 		v, err = flatten.UnflattenOrdered(flatMap, flatKeys)
@@ -562,10 +640,10 @@ func (f JSONFilters) pluckJsonValues(item *gjson.Result, properties []string) (s
 	}
 
 	if err != nil {
-		return "", nil
+		return "", nil, nil
 	}
 
-	return output.String(), flatKeys
+	return output.String(), flatKeys, keyGroups
 }
 
 func convertToCSV(flatMap map[string]interface{}, keys []string, separator string) string {

--- a/pkg/jsonfilter/jsonfilter_test.go
+++ b/pkg/jsonfilter/jsonfilter_test.go
@@ -25,7 +25,7 @@ func Test_SimpleGlobMatch(t *testing.T) {
 	}
 
 	dst := make(map[string]interface{})
-	_, err = filterFlatMap(src, dst, []glob.Glob{pattern}, []string{"id"})
+	_, _, err = filterFlatMap(src, dst, []glob.Glob{pattern}, []string{"id"}, []string{"id"})
 	assert.OK(t, err)
 	assert.EqualMarshalJSON(t, dst, `{"id":"12345"}`)
 
@@ -58,8 +58,38 @@ func Test_SimpleInvertedGlobMatch(t *testing.T) {
 	}
 
 	dst := make(map[string]interface{})
-	keys, err := filterFlatMap(src, dst, []glob.Glob{pattern1, pattern2}, []string{"", ""})
+	keys, _, err := filterFlatMap(src, dst, []glob.Glob{pattern1, pattern2}, []string{"", ""}, []string{"!id", "name"})
 	assert.OK(t, err)
 	assert.EqualMarshalJSON(t, dst, `{"name":"hello"}`)
 	assert.EqualMarshalJSON(t, keys, `["name"]`)
+}
+
+func Test_MergeKeyGroups(t *testing.T) {
+	// patterns which did not resolve against the first row should be
+	// replaced by the keys resolved from later rows
+	columns := MergeKeyGroups([][]KeyGroup{
+		{
+			{Pattern: "name", Keys: []string{"name"}},
+			{Pattern: "c8y_firmware.versio*", Keys: nil},
+		},
+		{
+			{Pattern: "name", Keys: []string{"name"}},
+			{Pattern: "c8y_firmware.versio*", Keys: []string{"c8y_Firmware.version"}},
+		},
+	})
+	assert.EqualMarshalJSON(t, columns, `["name","c8y_Firmware.version"]`)
+
+	// keys are deduplicated case insensitively, and patterns which never
+	// resolve are included as-is
+	columns = MergeKeyGroups([][]KeyGroup{
+		{
+			{Pattern: "c8y_firmware.*", Keys: []string{"c8y_Firmware.version"}},
+			{Pattern: "missing", Keys: nil},
+		},
+		{
+			{Pattern: "c8y_firmware.*", Keys: []string{"c8y_firmware.VERSION", "c8y_Firmware.url"}},
+			{Pattern: "missing", Keys: nil},
+		},
+	})
+	assert.EqualMarshalJSON(t, columns, `["c8y_Firmware.version","c8y_Firmware.url","missing"]`)
 }

--- a/pkg/mapbuilder/mapbuilder.go
+++ b/pkg/mapbuilder/mapbuilder.go
@@ -369,7 +369,7 @@ func registerNativeFunctions(vm *jsonnet.VM) {
 				return parameters[0], fmt.Errorf("no select values provided")
 			}
 
-			flatMap, flatKeys, err := jsonfilter.FilterPropertyByWildcard(string(jsonB), "", patterns, false)
+			flatMap, flatKeys, _, err := jsonfilter.FilterPropertyByWildcard(string(jsonB), "", patterns, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tableviewer/tableviewer.go
+++ b/pkg/tableviewer/tableviewer.go
@@ -38,6 +38,7 @@ type TableView struct {
 	MinEmptyValueColumnWidth int
 	MaxColumnWidth           int
 	ColumnPadding            int
+	SampleSize               int
 	Data                     gjson.Result
 	TableData                [][]string
 	EnableColor              bool
@@ -45,14 +46,27 @@ type TableView struct {
 	NumberFormatter          numbers.NumberFormatter
 }
 
-func (v *TableView) getValue(value gjson.Result) []string {
-	row := []string{}
+// DefaultSampleSize maximum number of rows sampled when resolving column widths
+const DefaultSampleSize = 5
 
-	addAlignments := false
-	if v.ColumnAlignments == nil {
-		v.ColumnAlignments = make([]int, 0)
-		addAlignments = true
+func (v *TableView) sampleLimit() int {
+	if v.SampleSize > 0 {
+		return v.SampleSize
 	}
+	return DefaultSampleSize
+}
+
+func (v *TableView) getValue(value gjson.Result) []string {
+	row, alignments := v.getRow(value)
+	if v.ColumnAlignments == nil {
+		v.ColumnAlignments = alignments
+	}
+	return row
+}
+
+func (v *TableView) getRow(value gjson.Result) (row []string, alignments []int) {
+	row = []string{}
+	alignments = []int{}
 
 	for i, col := range v.Columns {
 		node := value.Get(gjsonpath.EscapePath(col))
@@ -66,9 +80,7 @@ func (v *TableView) getValue(value gjson.Result) []string {
 			columnValue = strings.Trim(node.Raw, "\"")
 		}
 
-		if addAlignments {
-			v.ColumnAlignments = append(v.ColumnAlignments, columnAlignment)
-		}
+		alignments = append(alignments, columnAlignment)
 
 		columnWidth := v.MaxColumnWidth
 		if i < len(v.ColumnWidths) {
@@ -84,7 +96,7 @@ func (v *TableView) getValue(value gjson.Result) []string {
 		row = append(row, columnValue)
 
 	}
-	return row
+	return row, alignments
 }
 
 func (v *TableView) getWidth(defaultWidth int) int {
@@ -109,7 +121,22 @@ func minmax(values []int) (min int, max int) {
 	return
 }
 
-func (v *TableView) calculateColumnWidths(minWidth int, row []string) {
+// cellDisplayWidth display width of a cell value, using the widest line
+// for multi-line (e.g. wrapped) values
+func cellDisplayWidth(s string) int {
+	if !strings.Contains(s, "\n") {
+		return tablewriter.DisplayWidth(s)
+	}
+	width := 0
+	for _, line := range strings.Split(s, "\n") {
+		if w := tablewriter.DisplayWidth(line); w > width {
+			width = w
+		}
+	}
+	return width
+}
+
+func (v *TableView) calculateColumnWidths(minWidth int, rows [][]string) {
 	if len(v.ColumnWidths) == 0 {
 		maxTableWidth := v.getWidth(TABLE_MAX_WIDTH)
 		v.ColumnWidths = make([]int, 0)
@@ -120,22 +147,43 @@ func (v *TableView) calculateColumnWidths(minWidth int, row []string) {
 		columns := []string{}
 
 		// only include columns if they fit in the view
-		for i, columnValue := range row {
+		for i := range v.Columns {
+			// use the widest value of the sampled rows, as the first row
+			// may not contain a value for every column
+			cellWidth := 0
+			hasValue := false
+			for _, row := range rows {
+				if i >= len(row) {
+					continue
+				}
+				if row[i] != "" {
+					hasValue = true
+				}
+				if w := cellDisplayWidth(row[i]); w > cellWidth {
+					cellWidth = w
+				}
+			}
+
 			curMinWidth = minWidth
-			if columnValue == "" && v.MinEmptyValueColumnWidth > 0 {
+			if !hasValue && v.MinEmptyValueColumnWidth > 0 {
 				curMinWidth = v.MinEmptyValueColumnWidth
+			}
+
+			// only pad value (not column widths)
+			paddedCellWidth := cellWidth + v.ColumnPadding
+			if v.MaxColumnWidth > 0 && paddedCellWidth > v.MaxColumnWidth {
+				paddedCellWidth = v.MaxColumnWidth
 			}
 
 			Logger.Printf("iColumn: name=%s, cellWidth=%d, min=%d, col=%d",
 				v.Columns[i],
-				tablewriter.DisplayWidth(columnValue)+v.ColumnPadding,
+				paddedCellWidth,
 				curMinWidth+v.ColumnPadding,
 				tablewriter.DisplayWidth(v.Columns[i]),
 			)
 
 			_, colWidth := minmax([]int{
-				// only pad value (not column widths)
-				tablewriter.DisplayWidth(columnValue) + v.ColumnPadding,
+				paddedCellWidth,
 				curMinWidth + v.ColumnPadding,
 				tablewriter.DisplayWidth(v.Columns[i]),
 			})
@@ -165,6 +213,67 @@ func (v *TableView) calculateColumnWidths(minWidth int, row []string) {
 	}
 }
 
+// SampleColumnWidths resolve the column widths and alignments from multiple
+// sampled rows, where each row is a json object or an array of objects.
+// It does nothing if the column widths have already been resolved
+func (v *TableView) SampleColumnWidths(jsonRows [][]byte) {
+	if len(v.ColumnWidths) != 0 {
+		return
+	}
+	samples := []gjson.Result{}
+	limit := v.sampleLimit()
+	for _, b := range jsonRows {
+		r := gjson.ParseBytes(b)
+		if r.IsArray() {
+			for _, item := range r.Array() {
+				if len(samples) >= limit {
+					break
+				}
+				samples = append(samples, item)
+			}
+		} else if r.IsObject() {
+			samples = append(samples, r)
+		}
+		if len(samples) >= limit {
+			break
+		}
+	}
+	v.primeFromSamples(samples)
+}
+
+// primeFromSamples resolve the column widths and alignments from sampled rows
+func (v *TableView) primeFromSamples(samples []gjson.Result) {
+	if len(samples) == 0 || (len(v.ColumnWidths) != 0 && v.ColumnAlignments != nil) {
+		return
+	}
+	rows := make([][]string, 0, len(samples))
+	alignments := make([][]int, 0, len(samples))
+	for _, sample := range samples {
+		row, rowAlignments := v.getRow(sample)
+		rows = append(rows, row)
+		alignments = append(alignments, rowAlignments)
+	}
+
+	if v.ColumnAlignments == nil {
+		// use the alignment of the first row which has a value for the column,
+		// so columns are still aligned correctly (e.g. numbers) even if the
+		// first row does not contain a value
+		merged := make([]int, len(v.Columns))
+		for i := range v.Columns {
+			merged[i] = tablewriter.ALIGN_LEFT
+			for ri, row := range rows {
+				if i < len(row) && row[i] != "" && i < len(alignments[ri]) {
+					merged[i] = alignments[ri][i]
+					break
+				}
+			}
+		}
+		v.ColumnAlignments = merged
+	}
+
+	v.calculateColumnWidths(v.MinColumnWidth, rows)
+}
+
 func (v *TableView) getHeaderRow() []string {
 	header := []string{}
 	for i, name := range v.Columns {
@@ -188,8 +297,9 @@ func (v *TableView) TransformData(j []byte, property string) [][]string {
 	}
 
 	if r.IsArray() {
-		if len(r.Array()) > 0 {
-			v.calculateColumnWidths(v.MinColumnWidth, v.getValue(r.Array()[0]))
+		if items := r.Array(); len(items) > 0 {
+			sampleCount := min(len(items), v.sampleLimit())
+			v.primeFromSamples(items[0:sampleCount])
 		}
 		r.ForEach(func(key, value gjson.Result) bool {
 			Logger.Printf("parsing row: columns: %v", v.Columns)
@@ -197,7 +307,7 @@ func (v *TableView) TransformData(j []byte, property string) [][]string {
 			return true
 		})
 	} else if r.IsObject() {
-		v.calculateColumnWidths(v.MinColumnWidth, v.getValue(r))
+		v.primeFromSamples([]gjson.Result{r})
 		Logger.Printf("parsing row: columns: %v", v.Columns)
 		data = append(data, v.getValue(r))
 	}

--- a/tests/manual/common/output/output_table.yaml
+++ b/tests/manual/common/output/output_table.yaml
@@ -6,7 +6,7 @@ tests:
         c8y util show --select name,subtype --output table
     config:
       env:
-        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 20
         C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
         C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
         C8Y_SETTINGS_VIEWS_ROWMODE: "wrap"
@@ -88,21 +88,21 @@ tests:
     exit-code: 0
     stdout:
       exactly: |
-        | value      |
-        |------------|
-        |        1 p |
-        |        1 n |
-        |   0.000001 |
-        |         10 |
-        |        110 |
-        |       3000 |
-        |      10000 |
-        |      50000 |
-        |    9.999 M |
-        |  123.456 M |
-        |    1.234 M |
-        |    2.038 P |
-        |  203.837 G |
+        | value         |
+        |---------------|
+        |           1 p |
+        |           1 n |
+        |      0.000001 |
+        |            10 |
+        |           110 |
+        |          3000 |
+        |         10000 |
+        |         50000 |
+        |       9.999 M |
+        |     123.456 M |
+        |       1.234 M |
+        |       2.038 P |
+        |     203.837 G |
 
   It can use no number formatter:
     config:
@@ -121,18 +121,91 @@ tests:
     exit-code: 0
     stdout:
       exactly: |
-        | value      |
+        | value         |
+        |---------------|
+        |         1e-12 |
+        |          1e-9 |
+        |      0.000001 |
+        |            10 |
+        |           110 |
+        |          3000 |
+        |         10000 |
+        |         50000 |
+        |       9999999 |
+        |     123456789 |
+        | 1234567.5012… |
+        | 203837347888… |
+        |  203837347888 |
+
+  It shows row data regardless what the first row contains:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+    command: |
+      printf '%s\n%s\n' '{"name":"device01"}' '{"name":"device02","c8y_Firmware":{"version":"1.0.0"}}' |
+        c8y util show --select "name,c8y_Firmware.version" -o table --noColor
+    exit-code: 0
+    stdout:
+      exactly: |
+        | name          | c8y_Firmware.version |
+        |---------------|----------------------|
+        | device01      |                      |
+        | device02      | 1.0.0                |
+
+  It shows rows when data is irregular and selector is not case sensitive:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+    command: |
+      printf '%s\n%s\n' '{"name":"device01"}' '{"name":"device02","c8y_Firmware":{"version":"1.0.0"}}' |
+        c8y util show --select "name,c8y_firmware.versio*" -o table --noColor
+    exit-code: 0
+    stdout:
+      exactly: |
+        | name          | c8y_Firmware.version |
+        |---------------|----------------------|
+        | device01      |                      |
+        | device02      | 1.0.0                |
+
+  It calculates the column widths from the sampled rows:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+    command: |
+      printf '%s\n%s\n' '{"name":"dev01"}' '{"name":"device-with-a-much-longer-name"}' |
+        c8y util show --select "name" -o table --noColor
+    exit-code: 0
+    stdout:
+      exactly: |
+        | name                                |
+        |-------------------------------------|
+        | dev01                               |
+        | device-with-a-much-longer-name      |
+
+  It can limit the column width calculation to the first row by setting the sample size:
+    config:
+      env:
+        C8Y_SETTINGS_VIEWS_SAMPLESIZE: 1
+        C8Y_SETTINGS_VIEWS_COLUMNMAXWIDTH: 80
+        C8Y_SETTINGS_VIEWS_COLUMNPADDING: 5
+        C8Y_SETTINGS_VIEWS_COLUMNMINWIDTH: 5
+        C8Y_SETTINGS_VIEWS_ROWMODE: truncate
+    command: |
+      printf '%s\n%s\n' '{"name":"dev01"}' '{"name":"device-with-a-much-longer-name"}' |
+        c8y util show --select "name" -o table --noColor
+    exit-code: 0
+    stdout:
+      exactly: |
+        | name       |
         |------------|
-        |      1e-12 |
-        |       1e-9 |
-        |   0.000001 |
-        |         10 |
-        |        110 |
-        |       3000 |
-        |      10000 |
-        |      50000 |
-        |    9999999 |
-        |  123456789 |
-        | 1234567.5… |
-        | 203837347… |
-        | 203837347… |
+        | dev01      |
+        | device-wi… |


### PR DESCRIPTION
Previously the table output resolved the columns and column widths from the first row only. If the first row didn't contain one of the selected fragments, then the column header fell back to the (lowercased) select pattern, and since the lookup per row is case sensitive, every following row showed an empty cell even when a value existed. The same problem also affected wildcard selectors, and column widths were sized to the first row's values which often led to unnecessary truncation.

Now the first few rows are sampled before the table is rendered, and the columns, widths and alignment are resolved across all of the sampled rows. Each select pattern keeps track of which concrete keys it resolved to, so a fragment that's missing from the first row still gets a proper column (with the real key casing) as long as it appears in one of the sampled rows.

**Example**

```sh
printf '%s\n%s\n' '{"name":"device01"}' '{"name":"device02","c8y_Firmware":{"version":"1.0.0"}}' |
  c8y util show --select "name,c8y_Firmware.version" -o table
```

Before (the version column was never filled, and the header was lowercased):

```
| name          | c8y_firmware.version |
|---------------|----------------------|
| device01      |                      |
| device02      |                      |
```

After:

```
| name          | c8y_Firmware.version |
|---------------|----------------------|
| device01      |                      |
| device02      | 1.0.0                |
```

**Settings**

The sampling can be controlled via two new settings, as the defaults might not suit everyone:

* `settings.views.sampleSize` (default: `5`) - number of rows sampled to resolve the columns and widths. Set it to `1` to get the previous first-row-only behaviour.
* `settings.views.sampleTimeout` (default: `500ms`) - how long to buffer rows whilst waiting for more samples, so streamed output (e.g. realtime subscriptions) is delayed by at most this amount. Set to `0` to disable the timeout entirely.

Buffered rows are always rendered when the command finishes, so short outputs don't wait for the timeout.

**Other related changes**

* `settings.views.columnMaxWidth` now properly caps the calculated column width (previously a long value in the first row could push the column beyond it)
* `settings.views.columnMinWidthEmptyValue` only applies when the column is empty in **all** sampled rows, otherwise the column is sized to the actual content
* Numeric columns are right-aligned even if the first row doesn't contain a value for that column