### PR TITLE
feat(event createBinary): add `--type` flag to allow setting the attachment's mime type

### DIFF
--- a/api/spec/json/events.json
+++ b/api/spec/json/events.json
@@ -542,9 +542,14 @@
             "command": "c8y events createBinary --id 12345 --file ./myfile.log"
           },
           {
-            "description": "Add a binary to an event using a custom name",
+            "description": "Add a binary to an event using a custom name and use an auto-detected mime-type",
             "skipTest": true,
-            "command": "c8y events createBinary --id 12345 --file ./myfile.log --name \"myfile-2022-03-31.log\"\n"
+            "command": "c8y events createBinary --id 12345 --file ./myfile.log --name \"myfile-2022-03-31.txt\"\n"
+          },
+          {
+            "description": "Add a binary to an event using a custom name and use an explicit mime-type",
+            "skipTest": true,
+            "command": "c8y events createBinary --id 12345 --file ./myfile.log --name \"example.bin\" --type \"application/octet-stream\"\n"
           }
         ]
       },
@@ -568,6 +573,11 @@
           "name": "name",
           "type": "string",
           "description": "Set the name of the binary file. This will be the name of the file when it is downloaded in the UI"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "description": "Set the MIME type of the binary file, e.g. text/plain. If left blank, the type will be detected from the file extension or its contents"
         }
       ]
     },

--- a/api/spec/yaml/events.yaml
+++ b/api/spec/yaml/events.yaml
@@ -412,10 +412,15 @@ commands:
         - description: Add a binary to an event
           command: c8y events createBinary --id 12345 --file ./myfile.log
         
-        - description: Add a binary to an event using a custom name
+        - description: Add a binary to an event using a custom name and use an auto-detected mime-type
           skipTest: true
           command: |
-            c8y events createBinary --id 12345 --file ./myfile.log --name "myfile-2022-03-31.log"
+            c8y events createBinary --id 12345 --file ./myfile.log --name "myfile-2022-03-31.txt"
+
+        - description: Add a binary to an event using a custom name and use an explicit mime-type
+          skipTest: true
+          command: |
+            c8y events createBinary --id 12345 --file ./myfile.log --name "example.bin" --type "application/octet-stream"
 
     pathParameters:
       - name: id
@@ -434,6 +439,9 @@ commands:
         type: string
         description: Set the name of the binary file. This will be the name of the file when it is downloaded in the UI
 
+      - name: type
+        type: string
+        description: Set the MIME type of the binary file, e.g. text/plain. If left blank, the type will be detected from the file extension or its contents
 
   - name: updateEventBinary
     description: Update event binary

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.5.0
-	github.com/reubenmiller/go-c8y v0.37.10
+	github.com/reubenmiller/go-c8y v0.37.11
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/reubenmiller/go-c8y v0.37.10 h1:a3w/HSsZZ5MUVeF2jGKVotBnVa95XWD00g7xk3aUyR8=
-github.com/reubenmiller/go-c8y v0.37.10/go.mod h1:omJlFF3uDmYwbhiBC5ll5mq44+Yk9jax+tDzkjNje/A=
+github.com/reubenmiller/go-c8y v0.37.11 h1:NHQbcfE4+qT9gx/KAApaHHjWJl41dvk6CTajtIS1UYs=
+github.com/reubenmiller/go-c8y v0.37.11/go.mod h1:omJlFF3uDmYwbhiBC5ll5mq44+Yk9jax+tDzkjNje/A=
 github.com/reubenmiller/go-c8y/v2 v2.0.0-20260318160755-635d890df069 h1:aXy+nj/MHQjF8WWiSohXakDDxhfBwvFP5UIHKls+Kfs=
 github.com/reubenmiller/go-c8y/v2 v2.0.0-20260318160755-635d890df069/go.mod h1:djqzpynYVs+Q+7azobc1mKEh0B1u2zSKCIY0ZB2zy4M=
 github.com/reubenmiller/gojsonq/v2 v2.0.0-20221119213524-0fd921ac20a3 h1:v8Q77ObTxkm0Wj9iAjcc0VMLxqEzKIdAnaTNPzSiw8Q=

--- a/pkg/cmd/events/createbinary/createBinary.auto.go
+++ b/pkg/cmd/events/createbinary/createBinary.auto.go
@@ -38,8 +38,11 @@ func NewCreateBinaryCmd(f *cmdutil.Factory) *CreateBinaryCmd {
 $ c8y events createBinary --id 12345 --file ./myfile.log
 Add a binary to an event
 
-$ c8y events createBinary --id 12345 --file ./myfile.log --name "myfile-2022-03-31.log"
-Add a binary to an event using a custom name
+$ c8y events createBinary --id 12345 --file ./myfile.log --name "myfile-2022-03-31.txt"
+Add a binary to an event using a custom name and use an auto-detected mime-type
+
+$ c8y events createBinary --id 12345 --file ./myfile.log --name "example.bin" --type "application/octet-stream"
+Add a binary to an event using a custom name and use an explicit mime-type
         `),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return f.CreateModeEnabled(cmd)
@@ -52,6 +55,7 @@ Add a binary to an event using a custom name
 	cmd.Flags().StringSlice("id", []string{""}, "Event id (required) (accepts pipeline)")
 	cmd.Flags().String("file", "", "File to be uploaded as a binary (required)")
 	cmd.Flags().String("name", "", "Set the name of the binary file. This will be the name of the file when it is downloaded in the UI")
+	cmd.Flags().String("type", "", "Set the MIME type of the binary file, e.g. text/plain. If left blank, the type will be detected from the file extension or its contents")
 
 	completion.WithOptions(
 		cmd,
@@ -144,6 +148,7 @@ func (n *CreateBinaryCmd) RunE(cmd *cobra.Command, args []string) error {
 		inputIterators,
 		flags.WithDataFlagValue(),
 		flags.WithStringValue("name", "name"),
+		flags.WithStringValue("type", "type"),
 		cmdutil.WithTemplateValue(n.factory),
 		flags.WithTemplateVariablesValue(),
 	)

--- a/pkg/flags/formdata.go
+++ b/pkg/flags/formdata.go
@@ -204,6 +204,7 @@ func WithFormDataFile(srcFile string, srcData string) []GetOption {
 	return []GetOption{
 		WithFileReader(srcFile, "file"),
 		WithStringFormValue("name", "filename"),
+		WithStringFormValue("type", "contentType"),
 	}
 }
 

--- a/tests/auto/events/tests/events_createBinary.yaml
+++ b/tests/auto/events/tests/events_createBinary.yaml
@@ -6,13 +6,24 @@ tests:
             json:
                 method: POST
                 path: /event/events/12345/binaries
-    events_createBinary_Add a binary to an event using a custom name:
+    events_createBinary_Add a binary to an event using a custom name and use an auto-detected mime-type:
         command: |
-            c8y events createBinary --id 12345 --file ./testdata/myfile.log --name "myfile-2022-03-31.log"
+            c8y events createBinary --id 12345 --file ./testdata/myfile.log --name "myfile-2022-03-31.txt"
         exit-code: 0
         skip: true
         stdout:
             json:
-                body.name: myfile-2022-03-31.log
+                body.name: myfile-2022-03-31.txt
+                method: POST
+                path: /event/events/12345/binaries
+    events_createBinary_Add a binary to an event using a custom name and use an explicit mime-type:
+        command: |
+            c8y events createBinary --id 12345 --file ./testdata/myfile.log --name "example.bin" --type "application/octet-stream"
+        exit-code: 0
+        skip: true
+        stdout:
+            json:
+                body.name: example.bin
+                body.type: application/octet-stream
                 method: POST
                 path: /event/events/12345/binaries

--- a/tests/manual/binaries/create/binaries_create.yaml
+++ b/tests/manual/binaries/create/binaries_create.yaml
@@ -17,7 +17,7 @@ tests:
       contains:
         - |
           Content-Disposition: form-data; name="file"; filename="data.csv"
-          Content-Type: application/octet-stream
+          Content-Type: text/csv
 
           index,name
           0,Peter
@@ -36,7 +36,7 @@ tests:
       contains:
         - |
           Content-Disposition: form-data; name="file"; filename="myCustomName.json"
-          Content-Type: application/octet-stream
+          Content-Type: application/json
 
           index,name
           0,Peter
@@ -55,7 +55,7 @@ tests:
       contains:
         - |
           Content-Disposition: form-data; name="file"; filename="override"
-          Content-Type: application/octet-stream
+          Content-Type: text/plain
 
           index,name
           0,Peter

--- a/tests/manual/common/flags/dry/golden.curl.binary.create.txt
+++ b/tests/manual/common/flags/dry/golden.curl.binary.create.txt
@@ -1,13 +1,13 @@
 ##### curl (shell)
 
 ```sh
-curl -X POST 'https://{host}/inventory/binaries' -H 'Accept: application/json' -H 'Authorization: Basic {base64 tenant/username:password}' -F 'file=@input01.txt;type=application/octet-stream' -F 'object={"name":"input01.txt","type":"text/plain; charset=utf-8"}'
+curl -X POST 'https://{host}/inventory/binaries' -H 'Accept: application/json' -H 'Authorization: Basic {base64 tenant/username:password}' -F 'file=@input01.txt;type=text/plain' -F 'object={"name":"input01.txt","type":"text/plain; charset=utf-8"}'
 ```
 
 ##### curl (PowerShell)
 
 ```powershell
-curl -X POST 'https://{host}/inventory/binaries' -H 'Accept: application/json' -H 'Authorization: Basic {base64 tenant/username:password}' -F 'file=@input01.txt;type=application/octet-stream' -F 'object={\"name\":\"input01.txt\",\"type\":\"text/plain; charset=utf-8\"}'
+curl -X POST 'https://{host}/inventory/binaries' -H 'Accept: application/json' -H 'Authorization: Basic {base64 tenant/username:password}' -F 'file=@input01.txt;type=text/plain' -F 'object={\"name\":\"input01.txt\",\"type\":\"text/plain; charset=utf-8\"}'
 ```
 
 ##### file: input01.txt

--- a/tests/manual/events/createBinary/events_createBinary.yaml
+++ b/tests/manual/events/createBinary/events_createBinary.yaml
@@ -17,7 +17,7 @@ tests:
       contains:
         - |
           Content-Disposition: form-data; name="file"; filename="config.ini"
-          Content-Type: application/octet-stream
+          Content-Type: text/plain
 
           [agent]
           disabled = False
@@ -30,7 +30,7 @@ tests:
       contains:
         - |
           Content-Disposition: form-data; name="file"; filename="myCustomName.json"
-          Content-Type: application/octet-stream
+          Content-Type: application/json
 
           [agent]
           disabled = False
@@ -38,3 +38,16 @@ tests:
   Creating and updating binaries are kept in their original form:
     command: ./manual/events/createBinary/tests.sh
     exit-code: 0
+  
+  It allows users to set the mime type:
+    command: |
+      c8y events createBinary --id 1234 --file manual/events/createBinary/config.ini --type foo/bar --dry --dryFormat markdown
+    exit-code: 0
+    stdout:
+      contains:
+        - |
+          Content-Disposition: form-data; name="file"; filename="config.ini"
+          Content-Type: foo/bar
+
+          [agent]
+          disabled = False

--- a/tests/manual/extensions/example/body_basic_tests.yaml
+++ b/tests/manual/extensions/example/body_basic_tests.yaml
@@ -260,7 +260,7 @@ tests:
     stdout:
       lines:
         8: 'Content-Disposition: form-data; name="file"; filename="file1.txt"'
-        9: "Content-Type: application/octet-stream"
+        9: "Content-Type: text/plain"
         10: ""
         11: one
         12: two
@@ -310,7 +310,7 @@ tests:
         6: ""
         7: r/^--[a-zA-Z0-9]+$
         8: 'Content-Disposition: form-data; name="file"; filename="file1.txt"'
-        9: "Content-Type: application/octet-stream"
+        9: "Content-Type: text/plain"
         10: ""
         11: one
         12: two

--- a/tools/PSc8y/Public/New-EventBinary.ps1
+++ b/tools/PSc8y/Public/New-EventBinary.ps1
@@ -37,7 +37,12 @@ Add a binary to an event
         # Set the name of the binary file. This will be the name of the file when it is downloaded in the UI
         [Parameter()]
         [string]
-        $Name
+        $Name,
+
+        # Set the MIME type of the binary file, e.g. text/plain. If left blank, the type will be detected from the file extension or its contents
+        [Parameter()]
+        [string]
+        $Type
     )
     DynamicParam {
         Get-ClientCommonParameters -Type "Create", "Template"


### PR DESCRIPTION
Allow users to set the mime type of the event binary instead of just setting it to `application/octet-stream` by default.

If the user doesn't provide a type, then the mime-type will be auto detected based on the extension or content type, but the user can specify a manual type which will be used instead.

**Example**

```sh
c8y binaries create --file config.ini --type "text/plain"
```